### PR TITLE
feat(ingestion): add portal scanning for Greenhouse, Lever, and Ashby

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,13 @@ INGESTION_SCHEDULE=0 */6 * * *
 ENABLED_JOB_SOURCES=remotive,remoteok,jobicy,himalayas,hn_hiring,weworkremotely,getonboard
 # Options: remotive,remoteok,jobicy,himalayas,hn_hiring,weworkremotely,getonboard,csv,json
 
+# === Portal Scanning ===
+PORTALS_CONFIG_PATH=ingestion/config/portals.yml
+PORTAL_SCAN_TIMEOUT=30
+GREENHOUSE_API_URL=https://boards-api.greenhouse.io/v1/boards
+LEVER_API_URL=https://api.lever.co/v0/postings
+ASHBY_API_URL=https://api.ashbyhq.com/posting-api/job-board
+
 # === LaTeX ===
 LATEX_COMPILER=xelatex
 # Options: xelatex | docker_xelatex

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ docker-compose.override.yml
 
 # Alembic
 alembic/versions/*.pyc
+.worktrees/

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "langchain-core>=0.3.0",
     "feedparser>=6.0.0",
     "beautifulsoup4>=4.12.0",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -73,6 +73,13 @@ class Settings(BaseSettings):
     supported_languages: list[str] = ["en", "es"]
     default_language: str = "en"
 
+    # Portal scanning
+    portals_config_path: str = "ingestion/config/portals.yml"
+    portal_scan_timeout: float = 30.0
+    greenhouse_api_url: str = "https://boards-api.greenhouse.io/v1/boards"
+    lever_api_url: str = "https://api.lever.co/v0/postings"
+    ashby_api_url: str = "https://api.ashbyhq.com/posting-api/job-board"
+
     # Matching weights
     weight_semantic: int = 30
     weight_skill_match: int = 40

--- a/backend/src/hiresense/ingestion/adapters/ashby_adapter.py
+++ b/backend/src/hiresense/ingestion/adapters/ashby_adapter.py
@@ -20,7 +20,7 @@ class AshbyAdapter:
 
     async def fetch_jobs(self, board_id: str, company_name: str) -> list[RawJobListing]:
         url = f"{self._base_url}/{board_id}"
-        response = await self._http.post(url)
+        response = await self._http.post(url, timeout=self._timeout)
         response.raise_for_status()
         data = response.json()
         return [

--- a/backend/src/hiresense/ingestion/adapters/ashby_adapter.py
+++ b/backend/src/hiresense/ingestion/adapters/ashby_adapter.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+
+class AshbyAdapter:
+    def __init__(self, http_client: Any, base_url: str, timeout: float) -> None:
+        self._http = http_client
+        self._base_url = base_url
+        self._timeout = timeout
+
+    def source_name(self) -> str:
+        return "ashby"
+
+    def source_type(self) -> SourceType:
+        return SourceType.API
+
+    async def fetch_jobs(self, board_id: str, company_name: str) -> list[RawJobListing]:
+        url = f"{self._base_url}/{board_id}"
+        response = await self._http.post(url)
+        response.raise_for_status()
+        data = response.json()
+        return [
+            RawJobListing(
+                source="ashby",
+                source_id=str(job["id"]),
+                raw_data={**job, "company": company_name},
+            )
+            for job in data.get("jobs", [])
+        ]

--- a/backend/src/hiresense/ingestion/adapters/greenhouse_adapter.py
+++ b/backend/src/hiresense/ingestion/adapters/greenhouse_adapter.py
@@ -20,7 +20,7 @@ class GreenhouseAdapter:
 
     async def fetch_jobs(self, board_id: str, company_name: str) -> list[RawJobListing]:
         url = f"{self._base_url}/{board_id}/jobs"
-        response = await self._http.get(url, params={"content": "true"})
+        response = await self._http.get(url, params={"content": "true"}, timeout=self._timeout)
         response.raise_for_status()
         data = response.json()
         return [

--- a/backend/src/hiresense/ingestion/adapters/greenhouse_adapter.py
+++ b/backend/src/hiresense/ingestion/adapters/greenhouse_adapter.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+
+class GreenhouseAdapter:
+    def __init__(self, http_client: Any, base_url: str, timeout: float) -> None:
+        self._http = http_client
+        self._base_url = base_url
+        self._timeout = timeout
+
+    def source_name(self) -> str:
+        return "greenhouse"
+
+    def source_type(self) -> SourceType:
+        return SourceType.API
+
+    async def fetch_jobs(self, board_id: str, company_name: str) -> list[RawJobListing]:
+        url = f"{self._base_url}/{board_id}/jobs"
+        response = await self._http.get(url, params={"content": "true"})
+        response.raise_for_status()
+        data = response.json()
+        return [
+            RawJobListing(
+                source="greenhouse",
+                source_id=str(job["id"]),
+                raw_data={**job, "company": company_name},
+            )
+            for job in data.get("jobs", [])
+        ]

--- a/backend/src/hiresense/ingestion/adapters/lever_adapter.py
+++ b/backend/src/hiresense/ingestion/adapters/lever_adapter.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+
+class LeverAdapter:
+    def __init__(self, http_client: Any, base_url: str, timeout: float) -> None:
+        self._http = http_client
+        self._base_url = base_url
+        self._timeout = timeout
+
+    def source_name(self) -> str:
+        return "lever"
+
+    def source_type(self) -> SourceType:
+        return SourceType.API
+
+    async def fetch_jobs(self, board_id: str, company_name: str) -> list[RawJobListing]:
+        url = f"{self._base_url}/{board_id}"
+        response = await self._http.get(url, params={"mode": "json"})
+        response.raise_for_status()
+        postings = response.json()
+        return [
+            RawJobListing(
+                source="lever",
+                source_id=str(posting["id"]),
+                raw_data={**posting, "company": company_name},
+            )
+            for posting in postings
+        ]

--- a/backend/src/hiresense/ingestion/adapters/lever_adapter.py
+++ b/backend/src/hiresense/ingestion/adapters/lever_adapter.py
@@ -20,7 +20,7 @@ class LeverAdapter:
 
     async def fetch_jobs(self, board_id: str, company_name: str) -> list[RawJobListing]:
         url = f"{self._base_url}/{board_id}"
-        response = await self._http.get(url, params={"mode": "json"})
+        response = await self._http.get(url, params={"mode": "json"}, timeout=self._timeout)
         response.raise_for_status()
         postings = response.json()
         return [

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -6,12 +6,22 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
+from hiresense.ingestion.domain.portal_scanner import PortalScanner, ScanFilters, ScanResult
 from hiresense.ingestion.domain.services import IngestionOrchestrator
 
 router = APIRouter(prefix="/ingestion", tags=["ingestion"])
 
 
 def get_ingestion_orchestrator() -> IngestionOrchestrator:
+    raise NotImplementedError("Must be overridden during app startup via dependency_overrides")
+
+
+def get_portal_scanner() -> PortalScanner:
+    raise NotImplementedError("Must be overridden during app startup via dependency_overrides")
+
+
+def get_portals_config() -> PortalsConfig:
     raise NotImplementedError("Must be overridden during app startup via dependency_overrides")
 
 
@@ -26,3 +36,18 @@ async def fetch_jobs(
 ) -> FetchResponse:
     jobs = await orchestrator.run()
     return FetchResponse(count=len(jobs), jobs=jobs)
+
+
+@router.post("/scan-portals", response_model=ScanResult)
+async def scan_portals(
+    filters: ScanFilters,
+    scanner: Annotated[PortalScanner, Depends(get_portal_scanner)],
+) -> ScanResult:
+    return await scanner.scan(filters)
+
+
+@router.get("/portals", response_model=list[PortalEntry])
+async def list_portals(
+    config: Annotated[PortalsConfig, Depends(get_portals_config)],
+) -> list[PortalEntry]:
+    return config.portals

--- a/backend/src/hiresense/ingestion/config/portals.yml
+++ b/backend/src/hiresense/ingestion/config/portals.yml
@@ -1,0 +1,65 @@
+portals:
+  # AI Research Labs
+  - name: Anthropic
+    platform: greenhouse
+    board_id: anthropic
+    categories: [ai-research]
+
+  - name: OpenAI
+    platform: greenhouse
+    board_id: openai
+    categories: [ai-research]
+
+  - name: Mistral
+    platform: greenhouse
+    board_id: mistralai
+    categories: [ai-research]
+
+  - name: Cohere
+    platform: greenhouse
+    board_id: cohere
+    categories: [ai-research]
+
+  - name: LangChain
+    platform: greenhouse
+    board_id: langchain
+    categories: [ai-research]
+
+  # Voice Technology
+  - name: ElevenLabs
+    platform: ashby
+    board_id: elevenlabs
+    categories: [voice-tech]
+
+  - name: Deepgram
+    platform: greenhouse
+    board_id: deepgram
+    categories: [voice-tech]
+
+  # Development Platforms
+  - name: Retool
+    platform: lever
+    board_id: retool
+    categories: [dev-platforms]
+
+  - name: Vercel
+    platform: greenhouse
+    board_id: vercel
+    categories: [dev-platforms]
+
+  - name: Temporal
+    platform: greenhouse
+    board_id: temporal
+    categories: [dev-platforms]
+
+  # LLM Operations
+  - name: Weights & Biases
+    platform: greenhouse
+    board_id: wandb
+    categories: [llm-ops]
+
+  # Workflow Automation
+  - name: n8n
+    platform: greenhouse
+    board_id: n8n
+    categories: [workflow-automation]

--- a/backend/src/hiresense/ingestion/domain/html_stripper.py
+++ b/backend/src/hiresense/ingestion/domain/html_stripper.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+
+def strip_html(html: str) -> str:
+    """Convert HTML to plain text, preserving paragraph breaks."""
+    if not html:
+        return ""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup.find_all(["p", "br", "div", "li"]):
+        tag.insert_before("\n")
+    text = soup.get_text()
+    lines = [line.strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)

--- a/backend/src/hiresense/ingestion/domain/models.py
+++ b/backend/src/hiresense/ingestion/domain/models.py
@@ -26,6 +26,7 @@ class NormalizedJob(BaseModel):
     language: str = "en"
     url: str
     posted_date: datetime | None = None
+    department: str | None = None
 
     def dedup_key(self) -> str:
         raw = f"{self.source}:{self.title.lower().strip()}:{self.company.lower().strip()}:{self.url}"

--- a/backend/src/hiresense/ingestion/domain/normalizers/ashby_normalizer.py
+++ b/backend/src/hiresense/ingestion/domain/normalizers/ashby_normalizer.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hiresense.ingestion.domain.html_stripper import strip_html
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+class AshbyNormalizer:
+    def normalize(self, raw: RawJobListing) -> dict[str, Any]:
+        d = raw.raw_data
+        return {
+            "title": d["title"],
+            "company": d["company"],
+            "description": strip_html(d["descriptionHtml"]),
+            "skills": [],
+            "location": d.get("location", ""),
+            "salary_range": None,
+            "url": d["jobUrl"],
+            "language": "en",
+            "posted_date": d.get("publishedAt"),
+            "department": d.get("departmentName"),
+        }

--- a/backend/src/hiresense/ingestion/domain/normalizers/greenhouse_normalizer.py
+++ b/backend/src/hiresense/ingestion/domain/normalizers/greenhouse_normalizer.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import Any
+
+from hiresense.ingestion.domain.html_stripper import strip_html
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+class GreenhouseNormalizer:
+    def normalize(self, raw: RawJobListing) -> dict[str, Any]:
+        d = raw.raw_data
+        location_obj = d.get("location")
+        location = location_obj["name"] if isinstance(location_obj, dict) else ""
+        departments = d.get("departments", [])
+        department = departments[0]["name"] if departments else None
+        return {
+            "title": d.get("title", ""),
+            "company": d.get("company", ""),
+            "description": strip_html(d.get("content", "")),
+            "skills": [],
+            "location": location,
+            "salary_range": None,
+            "url": d.get("absolute_url", ""),
+            "language": "en",
+            "posted_date": d.get("updated_at"),
+            "department": department,
+        }

--- a/backend/src/hiresense/ingestion/domain/normalizers/lever_normalizer.py
+++ b/backend/src/hiresense/ingestion/domain/normalizers/lever_normalizer.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from hiresense.ingestion.domain.html_stripper import strip_html
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+class LeverNormalizer:
+    def normalize(self, raw: RawJobListing) -> dict[str, Any]:
+        d = raw.raw_data
+        categories = d.get("categories") or {}
+        created_at_ms = d.get("createdAt")
+        if created_at_ms is not None:
+            posted_date = datetime.fromtimestamp(created_at_ms / 1000, tz=timezone.utc).isoformat()
+        else:
+            posted_date = None
+        return {
+            "title": d.get("text", ""),
+            "company": d.get("company", ""),
+            "description": strip_html(d.get("description", "")),
+            "skills": [],
+            "location": categories.get("location", ""),
+            "salary_range": None,
+            "url": d.get("hostedUrl", ""),
+            "language": "en",
+            "posted_date": posted_date,
+            "department": categories.get("team"),
+        }

--- a/backend/src/hiresense/ingestion/domain/portal_config.py
+++ b/backend/src/hiresense/ingestion/domain/portal_config.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel
+
+
+class PortalEntry(BaseModel):
+    name: str
+    platform: Literal["greenhouse", "lever", "ashby"]
+    board_id: str
+    categories: list[str] = []
+
+
+class PortalsConfig(BaseModel):
+    portals: list[PortalEntry]
+
+
+def load_portals_config(path: Path) -> PortalsConfig:
+    """Load and validate portals.yml from the given path."""
+    if not path.exists():
+        raise FileNotFoundError(f"Portals config not found: {path}")
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return PortalsConfig.model_validate(data)

--- a/backend/src/hiresense/ingestion/domain/portal_scanner.py
+++ b/backend/src/hiresense/ingestion/domain/portal_scanner.py
@@ -99,6 +99,11 @@ class PortalScanner:
                     source_type="api",
                     **normalized_data,
                 )
+                if filters.keyword:
+                    kw = filters.keyword.lower()
+                    if kw not in job.title.lower() and kw not in job.description.lower():
+                        continue
+
                 dedup_key = job.dedup_key()
                 if dedup_key not in seen_dedup_keys:
                     seen_dedup_keys.add(dedup_key)

--- a/backend/src/hiresense/ingestion/domain/portal_scanner.py
+++ b/backend/src/hiresense/ingestion/domain/portal_scanner.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from pydantic import BaseModel
+
+from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.ingestion.domain.normalizer import JobNormalizer
+from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
+from hiresense.kernel.contracts.jobs_ingested_event import JobsIngestedEvent
+
+logger = logging.getLogger(__name__)
+
+
+class ScanFilters(BaseModel):
+    categories: list[str] = []
+    companies: list[str] = []
+    keyword: str | None = None
+
+
+class ScanError(BaseModel):
+    portal: str
+    platform: str
+    error: str
+
+
+class ScanResult(BaseModel):
+    total_fetched: int
+    new: int
+    duplicates: int
+    jobs: list[NormalizedJob]
+    errors: list[ScanError]
+
+
+class PortalScanner:
+    def __init__(
+        self,
+        config: PortalsConfig,
+        adapters: dict[str, Any],
+        normalizers: dict[str, JobNormalizer],
+        event_bus: Any,
+    ) -> None:
+        self._config = config
+        self._adapters = adapters
+        self._normalizers = normalizers
+        self._event_bus = event_bus
+
+    def _filter_portals(self, filters: ScanFilters) -> list[PortalEntry]:
+        portals = self._config.portals
+
+        if filters.categories:
+            filter_set = set(filters.categories)
+            portals = [p for p in portals if filter_set & set(p.categories)]
+
+        if filters.companies:
+            company_set = set(filters.companies)
+            portals = [p for p in portals if p.name in company_set]
+
+        return portals
+
+    async def scan(self, filters: ScanFilters) -> ScanResult:
+        portals = self._filter_portals(filters)
+        seen_dedup_keys: set[str] = set()
+        new_jobs: list[NormalizedJob] = []
+        errors: list[ScanError] = []
+        total_fetched = 0
+
+        for portal in portals:
+            adapter = self._adapters.get(portal.platform)
+            normalizer = self._normalizers.get(portal.platform)
+
+            if adapter is None:
+                logger.warning("No adapter for platform: %s", portal.platform)
+                continue
+            if normalizer is None:
+                logger.warning("No normalizer for platform: %s", portal.platform)
+                continue
+
+            try:
+                raw_jobs = await adapter.fetch_jobs(portal.board_id, portal.name)
+            except Exception as exc:
+                errors.append(
+                    ScanError(
+                        portal=portal.name,
+                        platform=portal.platform,
+                        error=str(exc),
+                    )
+                )
+                continue
+
+            for raw in raw_jobs:
+                total_fetched += 1
+                normalized_data = normalizer.normalize(raw)
+                job = NormalizedJob(
+                    id=str(uuid.uuid4()),
+                    source=portal.platform,
+                    source_type="api",
+                    **normalized_data,
+                )
+                dedup_key = job.dedup_key()
+                if dedup_key not in seen_dedup_keys:
+                    seen_dedup_keys.add(dedup_key)
+                    new_jobs.append(job)
+
+        duplicates = total_fetched - len(new_jobs)
+
+        if new_jobs:
+            event = JobsIngestedEvent(
+                payload={
+                    "job_ids": [j.id for j in new_jobs],
+                    "source": "portal_scan",
+                },
+            )
+            await self._event_bus.publish(event)
+
+        return ScanResult(
+            total_fetched=total_fetched,
+            new=len(new_jobs),
+            duplicates=duplicates,
+            jobs=new_jobs,
+            errors=errors,
+        )

--- a/backend/src/hiresense/kernel/contracts/jobs_ingested_event.py
+++ b/backend/src/hiresense/kernel/contracts/jobs_ingested_event.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from hiresense.kernel.events import DomainEvent
+
+
+class JobsIngestedEvent(DomainEvent):
+    event_type: str = "jobs.ingested"
+    payload: dict  # keys: job_ids (list[str]), source (str)

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import httpx
 from fastapi import FastAPI
@@ -10,12 +11,20 @@ from hiresense.config import Settings
 from hiresense.identity.api.dependencies import get_auth_service
 from hiresense.identity.api.routes import router as auth_router
 from hiresense.identity.services import AuthService
-from hiresense.ingestion.api.routes import get_ingestion_orchestrator
-from hiresense.ingestion.api.routes import router as ingestion_router
-from hiresense.ingestion.adapters.remotive import RemotiveAdapter
-from hiresense.ingestion.adapters.remoteok import RemoteOKAdapter
+from hiresense.ingestion.adapters.ashby_adapter import AshbyAdapter
 from hiresense.ingestion.adapters.csv_import import CSVImportAdapter
+from hiresense.ingestion.adapters.greenhouse_adapter import GreenhouseAdapter
+from hiresense.ingestion.adapters.lever_adapter import LeverAdapter
+from hiresense.ingestion.adapters.remoteok import RemoteOKAdapter
+from hiresense.ingestion.adapters.remotive import RemotiveAdapter
+from hiresense.ingestion.api.routes import get_ingestion_orchestrator, get_portal_scanner, get_portals_config
+from hiresense.ingestion.api.routes import router as ingestion_router
 from hiresense.ingestion.domain.normalizer import CSVNormalizer, RemoteOKNormalizer, RemotiveNormalizer
+from hiresense.ingestion.domain.normalizers.ashby_normalizer import AshbyNormalizer
+from hiresense.ingestion.domain.normalizers.greenhouse_normalizer import GreenhouseNormalizer
+from hiresense.ingestion.domain.normalizers.lever_normalizer import LeverNormalizer
+from hiresense.ingestion.domain.portal_config import load_portals_config
+from hiresense.ingestion.domain.portal_scanner import PortalScanner
 from hiresense.ingestion.domain.services import IngestionOrchestrator
 from hiresense.matching.api.dependencies import get_matching_orchestrator
 from hiresense.matching.api.routes import router as matching_router
@@ -73,6 +82,44 @@ def create_app() -> FastAPI:
     )
     app.dependency_overrides[get_ingestion_orchestrator] = lambda: ingestion_orchestrator
     app.include_router(ingestion_router)
+
+    # --- Portal scanning ---
+    portals_config_path = Path(__file__).parent / settings.portals_config_path
+    portals_config = load_portals_config(portals_config_path)
+
+    portal_adapters = {
+        "greenhouse": GreenhouseAdapter(
+            http_client=http_client,
+            base_url=settings.greenhouse_api_url,
+            timeout=settings.portal_scan_timeout,
+        ),
+        "lever": LeverAdapter(
+            http_client=http_client,
+            base_url=settings.lever_api_url,
+            timeout=settings.portal_scan_timeout,
+        ),
+        "ashby": AshbyAdapter(
+            http_client=http_client,
+            base_url=settings.ashby_api_url,
+            timeout=settings.portal_scan_timeout,
+        ),
+    }
+
+    portal_normalizers = {
+        "greenhouse": GreenhouseNormalizer(),
+        "lever": LeverNormalizer(),
+        "ashby": AshbyNormalizer(),
+    }
+
+    portal_scanner = PortalScanner(
+        config=portals_config,
+        adapters=portal_adapters,
+        normalizers=portal_normalizers,
+        event_bus=event_bus,
+    )
+
+    app.dependency_overrides[get_portal_scanner] = lambda: portal_scanner
+    app.dependency_overrides[get_portals_config] = lambda: portals_config
 
     # --- Profile module ---
     latex_parser = LaTeXParser()

--- a/backend/tests/unit/ingestion/test_ashby.py
+++ b/backend/tests/unit/ingestion/test_ashby.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import pytest
+from hiresense.ingestion.adapters.ashby_adapter import AshbyAdapter
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeResponse:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+        self.status_code = 200
+
+    def json(self) -> dict:
+        return self._data
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class FakeHttpClient:
+    def __init__(self, response_data: dict) -> None:
+        self._response_data = response_data
+        self.last_url: str | None = None
+        self.last_kwargs: dict | None = None
+
+    async def post(self, url: str, **kwargs) -> FakeResponse:
+        self.last_url = url
+        self.last_kwargs = kwargs
+        return FakeResponse(self._response_data)
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_JOB = {
+    "id": "job-001",
+    "title": "AI Engineer",
+    "location": "Remote - US",
+    "descriptionHtml": "<p>Work on <b>voice synthesis</b></p>",
+    "jobUrl": "https://jobs.ashbyhq.com/elevenlabs/job-001",
+    "publishedAt": "2026-04-01T00:00:00.000Z",
+    "departmentName": "AI Team",
+}
+
+SAMPLE_RESPONSE = {"jobs": [SAMPLE_JOB]}
+
+
+# ---------------------------------------------------------------------------
+# Adapter tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ashby_fetches_jobs() -> None:
+    client = FakeHttpClient(SAMPLE_RESPONSE)
+    adapter = AshbyAdapter(
+        http_client=client,
+        base_url="https://api.ashbyhq.com/posting-api/job-board",
+        timeout=10.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="elevenlabs", company_name="ElevenLabs")
+    assert len(jobs) == 1
+    assert jobs[0].source == "ashby"
+    assert jobs[0].source_id == "job-001"
+    assert jobs[0].raw_data["title"] == "AI Engineer"
+    assert jobs[0].raw_data["company"] == "ElevenLabs"
+
+
+@pytest.mark.asyncio
+async def test_ashby_uses_post_method() -> None:
+    client = FakeHttpClient(SAMPLE_RESPONSE)
+    adapter = AshbyAdapter(
+        http_client=client,
+        base_url="https://api.ashbyhq.com/posting-api/job-board",
+        timeout=10.0,
+    )
+    await adapter.fetch_jobs(board_id="elevenlabs", company_name="ElevenLabs")
+    assert client.last_url == "https://api.ashbyhq.com/posting-api/job-board/elevenlabs"
+
+
+@pytest.mark.asyncio
+async def test_ashby_handles_empty_board() -> None:
+    client = FakeHttpClient({"jobs": []})
+    adapter = AshbyAdapter(
+        http_client=client,
+        base_url="https://api.ashbyhq.com/posting-api/job-board",
+        timeout=10.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="empty-co", company_name="Empty Co")
+    assert jobs == []
+
+
+def test_ashby_source_metadata() -> None:
+    adapter = AshbyAdapter(
+        http_client=None,
+        base_url="https://api.ashbyhq.com/posting-api/job-board",
+        timeout=10.0,
+    )
+    assert adapter.source_name() == "ashby"
+    assert adapter.source_type() == SourceType.API
+
+
+# ---------------------------------------------------------------------------
+# Normalizer tests
+# ---------------------------------------------------------------------------
+
+from hiresense.ingestion.domain.normalizers.ashby_normalizer import AshbyNormalizer  # noqa: E402
+
+
+def _make_raw(overrides: dict | None = None) -> RawJobListing:
+    data = {**SAMPLE_JOB, "company": "ElevenLabs"}
+    if overrides:
+        data.update(overrides)
+    return RawJobListing(source="ashby", source_id="job-001", raw_data=data)
+
+
+def test_ashby_normalizer_full_data() -> None:
+    normalizer = AshbyNormalizer()
+    result = normalizer.normalize(_make_raw())
+
+    assert result["title"] == "AI Engineer"
+    assert result["company"] == "ElevenLabs"
+    assert "voice synthesis" in result["description"]
+    assert "<p>" not in result["description"]
+    assert result["skills"] == []
+    assert result["location"] == "Remote - US"
+    assert result["salary_range"] is None
+    assert result["url"] == "https://jobs.ashbyhq.com/elevenlabs/job-001"
+    assert result["language"] == "en"
+    assert result["posted_date"] == "2026-04-01T00:00:00.000Z"
+    assert result["department"] == "AI Team"
+
+
+def test_ashby_normalizer_strips_html() -> None:
+    normalizer = AshbyNormalizer()
+    result = normalizer.normalize(_make_raw({"descriptionHtml": "<p>Line one</p><p>Line two</p>"}))
+    assert "<p>" not in result["description"]
+    assert "Line one" in result["description"]
+    assert "Line two" in result["description"]
+
+
+def test_ashby_normalizer_missing_location() -> None:
+    normalizer = AshbyNormalizer()
+    raw_data = {k: v for k, v in {**SAMPLE_JOB, "company": "ElevenLabs"}.items() if k != "location"}
+    raw = RawJobListing(source="ashby", source_id="job-001", raw_data=raw_data)
+    result = normalizer.normalize(raw)
+    assert result["location"] == ""
+
+
+def test_ashby_normalizer_missing_published_at() -> None:
+    normalizer = AshbyNormalizer()
+    raw_data = {k: v for k, v in {**SAMPLE_JOB, "company": "ElevenLabs"}.items() if k != "publishedAt"}
+    raw = RawJobListing(source="ashby", source_id="job-001", raw_data=raw_data)
+    result = normalizer.normalize(raw)
+    assert result["posted_date"] is None
+
+
+def test_ashby_normalizer_missing_department() -> None:
+    normalizer = AshbyNormalizer()
+    raw_data = {k: v for k, v in {**SAMPLE_JOB, "company": "ElevenLabs"}.items() if k != "departmentName"}
+    raw = RawJobListing(source="ashby", source_id="job-001", raw_data=raw_data)
+    result = normalizer.normalize(raw)
+    assert result["department"] is None

--- a/backend/tests/unit/ingestion/test_greenhouse.py
+++ b/backend/tests/unit/ingestion/test_greenhouse.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import pytest
+from hiresense.ingestion.adapters.greenhouse_adapter import GreenhouseAdapter
+from hiresense.ingestion.domain.normalizers.greenhouse_normalizer import GreenhouseNormalizer
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeResponse:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+        self.status_code = 200
+
+    def json(self) -> dict:
+        return self._data
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class FakeHttpClient:
+    def __init__(self, response_data: dict) -> None:
+        self._response_data = response_data
+        self.last_url: str | None = None
+        self.last_params: dict | None = None
+
+    async def get(self, url: str, **kwargs) -> FakeResponse:
+        self.last_url = url
+        self.last_params = kwargs.get("params")
+        return FakeResponse(self._response_data)
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_JOB = {
+    "id": 4001,
+    "title": "Senior Python Engineer",
+    "content": "<p>Build backend systems with FastAPI.</p>",
+    "absolute_url": "https://boards.greenhouse.io/acme/jobs/4001",
+    "location": {"name": "Remote — Americas"},
+    "departments": [{"id": 1, "name": "Engineering"}],
+    "updated_at": "2026-03-28T10:00:00.000Z",
+}
+
+SAMPLE_RESPONSE = {"jobs": [SAMPLE_JOB]}
+
+
+# ---------------------------------------------------------------------------
+# Adapter tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_greenhouse_fetches_jobs() -> None:
+    client = FakeHttpClient(SAMPLE_RESPONSE)
+    adapter = GreenhouseAdapter(
+        http_client=client,
+        base_url="https://boards-api.greenhouse.io/v1/boards",
+        timeout=10.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="acme", company_name="Acme Corp")
+    assert len(jobs) == 1
+    assert jobs[0].source == "greenhouse"
+    assert jobs[0].source_id == "4001"
+    assert jobs[0].raw_data["title"] == "Senior Python Engineer"
+    assert jobs[0].raw_data["company"] == "Acme Corp"
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_builds_correct_url() -> None:
+    client = FakeHttpClient(SAMPLE_RESPONSE)
+    adapter = GreenhouseAdapter(
+        http_client=client,
+        base_url="https://boards-api.greenhouse.io/v1/boards",
+        timeout=10.0,
+    )
+    await adapter.fetch_jobs(board_id="acme", company_name="Acme Corp")
+    assert client.last_url == "https://boards-api.greenhouse.io/v1/boards/acme/jobs"
+    assert client.last_params == {"content": "true"}
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_handles_empty_board() -> None:
+    client = FakeHttpClient({"jobs": []})
+    adapter = GreenhouseAdapter(
+        http_client=client,
+        base_url="https://boards-api.greenhouse.io/v1/boards",
+        timeout=10.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="empty-co", company_name="Empty Co")
+    assert jobs == []
+
+
+def test_greenhouse_source_metadata() -> None:
+    adapter = GreenhouseAdapter(
+        http_client=None,
+        base_url="https://boards-api.greenhouse.io/v1/boards",
+        timeout=10.0,
+    )
+    assert adapter.source_name() == "greenhouse"
+    assert adapter.source_type() == SourceType.API
+
+
+# ---------------------------------------------------------------------------
+# Normalizer tests
+# ---------------------------------------------------------------------------
+
+def _make_raw(overrides: dict | None = None) -> RawJobListing:
+    data = {**SAMPLE_JOB, "company": "Acme Corp"}
+    if overrides:
+        data.update(overrides)
+    return RawJobListing(source="greenhouse", source_id="4001", raw_data=data)
+
+
+def test_greenhouse_normalizer_full_data() -> None:
+    normalizer = GreenhouseNormalizer()
+    result = normalizer.normalize(_make_raw())
+
+    assert result["title"] == "Senior Python Engineer"
+    assert result["company"] == "Acme Corp"
+    assert "Build backend systems with FastAPI" in result["description"]
+    assert result["skills"] == []
+    assert result["location"] == "Remote — Americas"
+    assert result["salary_range"] is None
+    assert result["url"] == "https://boards.greenhouse.io/acme/jobs/4001"
+    assert result["language"] == "en"
+    assert result["posted_date"] == "2026-03-28T10:00:00.000Z"
+    assert result["department"] == "Engineering"
+
+
+def test_greenhouse_normalizer_missing_location() -> None:
+    normalizer = GreenhouseNormalizer()
+    result = normalizer.normalize(_make_raw({"location": None}))
+    assert result["location"] == ""
+
+
+def test_greenhouse_normalizer_missing_departments() -> None:
+    normalizer = GreenhouseNormalizer()
+    result = normalizer.normalize(_make_raw({"departments": []}))
+    assert result["department"] is None
+
+
+def test_greenhouse_normalizer_no_departments_key() -> None:
+    normalizer = GreenhouseNormalizer()
+    raw_data = {k: v for k, v in {**SAMPLE_JOB, "company": "Acme Corp"}.items() if k != "departments"}
+    raw = RawJobListing(source="greenhouse", source_id="4001", raw_data=raw_data)
+    result = normalizer.normalize(raw)
+    assert result["department"] is None
+
+
+def test_greenhouse_normalizer_strips_html() -> None:
+    normalizer = GreenhouseNormalizer()
+    result = normalizer.normalize(_make_raw({"content": "<p>Line one</p><p>Line two</p>"}))
+    assert "<p>" not in result["description"]
+    assert "Line one" in result["description"]
+    assert "Line two" in result["description"]

--- a/backend/tests/unit/ingestion/test_html_stripper.py
+++ b/backend/tests/unit/ingestion/test_html_stripper.py
@@ -1,0 +1,34 @@
+from hiresense.ingestion.domain.html_stripper import strip_html
+
+
+def test_strips_basic_tags() -> None:
+    html = "<p>Hello <b>world</b></p>"
+    assert strip_html(html) == "Hello world"
+
+
+def test_preserves_paragraph_breaks() -> None:
+    html = "<p>First paragraph</p><p>Second paragraph</p>"
+    result = strip_html(html)
+    assert "First paragraph" in result
+    assert "Second paragraph" in result
+    assert "\n" in result
+
+
+def test_handles_empty_string() -> None:
+    assert strip_html("") == ""
+
+
+def test_handles_plain_text() -> None:
+    assert strip_html("no html here") == "no html here"
+
+
+def test_strips_nested_tags() -> None:
+    html = "<div><ul><li>Item 1</li><li>Item 2</li></ul></div>"
+    result = strip_html(html)
+    assert "Item 1" in result
+    assert "Item 2" in result
+
+
+def test_decodes_html_entities() -> None:
+    html = "<p>Salary &gt; $100k &amp; benefits</p>"
+    assert strip_html(html) == "Salary > $100k & benefits"

--- a/backend/tests/unit/ingestion/test_lever.py
+++ b/backend/tests/unit/ingestion/test_lever.py
@@ -130,7 +130,7 @@ def test_lever_normalizer_full_data() -> None:
     assert result["salary_range"] is None
     assert result["url"] == "https://jobs.lever.co/retool/abc-123"
     assert result["language"] == "en"
-    assert result["posted_date"] == "2024-03-29T04:00:00+00:00"
+    assert result["posted_date"] == "2024-03-29T08:00:00+00:00"
     assert result["department"] == "Product"
 
 

--- a/backend/tests/unit/ingestion/test_lever.py
+++ b/backend/tests/unit/ingestion/test_lever.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import pytest
+from hiresense.ingestion.adapters.lever_adapter import LeverAdapter
+from hiresense.ingestion.domain.normalizers.lever_normalizer import LeverNormalizer
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class FakeResponse:
+    def __init__(self, data: list) -> None:
+        self._data = data
+        self.status_code = 200
+
+    def json(self) -> list:
+        return self._data
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class FakeHttpClient:
+    def __init__(self, response_data: list) -> None:
+        self._response_data = response_data
+        self.last_url: str | None = None
+        self.last_params: dict | None = None
+
+    async def get(self, url: str, **kwargs) -> FakeResponse:
+        self.last_url = url
+        self.last_params = kwargs.get("params")
+        return FakeResponse(self._response_data)
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_POSTING = {
+    "id": "abc-123",
+    "text": "Frontend Engineer",
+    "categories": {"location": "New York, NY", "team": "Product"},
+    "description": "<p>Build UIs with React</p>",
+    "hostedUrl": "https://jobs.lever.co/retool/abc-123",
+    "createdAt": 1711699200000,
+}
+
+SAMPLE_RESPONSE = [SAMPLE_POSTING]
+
+
+# ---------------------------------------------------------------------------
+# Adapter tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_lever_fetches_jobs() -> None:
+    client = FakeHttpClient(SAMPLE_RESPONSE)
+    adapter = LeverAdapter(
+        http_client=client,
+        base_url="https://api.lever.co/v0/postings",
+        timeout=10.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="retool", company_name="Retool")
+    assert len(jobs) == 1
+    assert jobs[0].source == "lever"
+    assert jobs[0].source_id == "abc-123"
+    assert jobs[0].raw_data["text"] == "Frontend Engineer"
+    assert jobs[0].raw_data["company"] == "Retool"
+
+
+@pytest.mark.asyncio
+async def test_lever_builds_correct_url() -> None:
+    client = FakeHttpClient(SAMPLE_RESPONSE)
+    adapter = LeverAdapter(
+        http_client=client,
+        base_url="https://api.lever.co/v0/postings",
+        timeout=10.0,
+    )
+    await adapter.fetch_jobs(board_id="retool", company_name="Retool")
+    assert client.last_url == "https://api.lever.co/v0/postings/retool"
+    assert client.last_params == {"mode": "json"}
+
+
+@pytest.mark.asyncio
+async def test_lever_handles_empty_board() -> None:
+    client = FakeHttpClient([])
+    adapter = LeverAdapter(
+        http_client=client,
+        base_url="https://api.lever.co/v0/postings",
+        timeout=10.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="empty-co", company_name="Empty Co")
+    assert jobs == []
+
+
+def test_lever_source_metadata() -> None:
+    adapter = LeverAdapter(
+        http_client=None,
+        base_url="https://api.lever.co/v0/postings",
+        timeout=10.0,
+    )
+    assert adapter.source_name() == "lever"
+    assert adapter.source_type() == SourceType.API
+
+
+# ---------------------------------------------------------------------------
+# Normalizer tests
+# ---------------------------------------------------------------------------
+
+def _make_raw(overrides: dict | None = None) -> RawJobListing:
+    data = {**SAMPLE_POSTING, "company": "Retool"}
+    if overrides:
+        data.update(overrides)
+    return RawJobListing(source="lever", source_id="abc-123", raw_data=data)
+
+
+def test_lever_normalizer_full_data() -> None:
+    normalizer = LeverNormalizer()
+    result = normalizer.normalize(_make_raw())
+
+    assert result["title"] == "Frontend Engineer"
+    assert result["company"] == "Retool"
+    assert "Build UIs with React" in result["description"]
+    assert "<p>" not in result["description"]
+    assert result["skills"] == []
+    assert result["location"] == "New York, NY"
+    assert result["salary_range"] is None
+    assert result["url"] == "https://jobs.lever.co/retool/abc-123"
+    assert result["language"] == "en"
+    assert result["posted_date"] == "2024-03-29T04:00:00+00:00"
+    assert result["department"] == "Product"
+
+
+def test_lever_normalizer_strips_html() -> None:
+    normalizer = LeverNormalizer()
+    result = normalizer.normalize(_make_raw({"description": "<p>Line one</p><p>Line two</p>"}))
+    assert "<p>" not in result["description"]
+    assert "Line one" in result["description"]
+    assert "Line two" in result["description"]
+
+
+def test_lever_normalizer_missing_categories() -> None:
+    normalizer = LeverNormalizer()
+    result = normalizer.normalize(_make_raw({"categories": {}}))
+    assert result["location"] == ""
+    assert result["department"] is None
+
+
+def test_lever_normalizer_no_categories_key() -> None:
+    normalizer = LeverNormalizer()
+    raw_data = {k: v for k, v in {**SAMPLE_POSTING, "company": "Retool"}.items() if k != "categories"}
+    raw = RawJobListing(source="lever", source_id="abc-123", raw_data=raw_data)
+    result = normalizer.normalize(raw)
+    assert result["location"] == ""
+    assert result["department"] is None
+
+
+def test_lever_normalizer_missing_created_at() -> None:
+    normalizer = LeverNormalizer()
+    result = normalizer.normalize(_make_raw({"createdAt": None}))
+    assert result["posted_date"] is None
+
+
+def test_lever_normalizer_no_created_at_key() -> None:
+    normalizer = LeverNormalizer()
+    raw_data = {k: v for k, v in {**SAMPLE_POSTING, "company": "Retool"}.items() if k != "createdAt"}
+    raw = RawJobListing(source="lever", source_id="abc-123", raw_data=raw_data)
+    result = normalizer.normalize(raw)
+    assert result["posted_date"] is None

--- a/backend/tests/unit/ingestion/test_portal_config.py
+++ b/backend/tests/unit/ingestion/test_portal_config.py
@@ -1,0 +1,86 @@
+import pytest
+from pathlib import Path
+from hiresense.ingestion.domain.portal_config import (
+    PortalEntry,
+    PortalsConfig,
+    load_portals_config,
+)
+
+
+def test_portal_entry_model() -> None:
+    entry = PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic")
+    assert entry.name == "Anthropic"
+    assert entry.platform == "greenhouse"
+    assert entry.board_id == "anthropic"
+    assert entry.categories == []
+
+
+def test_portal_entry_with_categories() -> None:
+    entry = PortalEntry(
+        name="Anthropic",
+        platform="greenhouse",
+        board_id="anthropic",
+        categories=["ai-research"],
+    )
+    assert entry.categories == ["ai-research"]
+
+
+def test_portal_entry_rejects_invalid_platform() -> None:
+    with pytest.raises(ValueError):
+        PortalEntry(name="Foo", platform="invalid", board_id="foo")
+
+
+def test_portals_config_model() -> None:
+    config = PortalsConfig(
+        portals=[
+            PortalEntry(name="A", platform="greenhouse", board_id="a"),
+            PortalEntry(name="B", platform="lever", board_id="b"),
+        ]
+    )
+    assert len(config.portals) == 2
+
+
+def test_load_portals_config(tmp_path: Path) -> None:
+    yml = tmp_path / "portals.yml"
+    yml.write_text(
+        "portals:\n"
+        "  - name: TestCo\n"
+        "    platform: ashby\n"
+        "    board_id: testco\n"
+        "    categories: [ai]\n"
+    )
+    config = load_portals_config(yml)
+    assert len(config.portals) == 1
+    assert config.portals[0].name == "TestCo"
+    assert config.portals[0].platform == "ashby"
+    assert config.portals[0].categories == ["ai"]
+
+
+def test_load_portals_config_file_not_found() -> None:
+    with pytest.raises(FileNotFoundError):
+        load_portals_config(Path("/nonexistent/portals.yml"))
+
+
+def test_filter_by_category() -> None:
+    config = PortalsConfig(
+        portals=[
+            PortalEntry(name="A", platform="greenhouse", board_id="a", categories=["ai"]),
+            PortalEntry(name="B", platform="lever", board_id="b", categories=["devtools"]),
+            PortalEntry(name="C", platform="ashby", board_id="c", categories=["ai", "devtools"]),
+        ]
+    )
+    filtered = [p for p in config.portals if "ai" in p.categories]
+    assert len(filtered) == 2
+    assert {p.name for p in filtered} == {"A", "C"}
+
+
+def test_filter_by_company() -> None:
+    config = PortalsConfig(
+        portals=[
+            PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic"),
+            PortalEntry(name="Retool", platform="lever", board_id="retool"),
+        ]
+    )
+    filtered = [p for p in config.portals if p.name in ["Anthropic"]]
+    assert len(filtered) == 1
+    assert filtered[0].board_id == "anthropic"

--- a/backend/tests/unit/ingestion/test_portal_scanner.py
+++ b/backend/tests/unit/ingestion/test_portal_scanner.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from hiresense.ingestion.domain.models import NormalizedJob, RawJobListing
+from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
+from hiresense.ingestion.domain.portal_scanner import (
+    PortalScanner,
+    ScanFilters,
+    ScanResult,
+)
+from hiresense.kernel.events import DomainEvent
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class FakeAdapter:
+    def __init__(self, jobs: list[RawJobListing] | None = None, *, raise_on_fetch: bool = False) -> None:
+        self._jobs = jobs or []
+        self._raise_on_fetch = raise_on_fetch
+        self.calls: list[tuple[str, str]] = []
+
+    async def fetch_jobs(self, board_id: str, company_name: str) -> list[RawJobListing]:
+        self.calls.append((board_id, company_name))
+        if self._raise_on_fetch:
+            raise RuntimeError("network error")
+        return self._jobs
+
+
+class FakeNormalizer:
+    def __init__(self, title: str = "Engineer", company: str = "Acme", url: str = "https://example.com/1") -> None:
+        self._title = title
+        self._company = company
+        self._url = url
+
+    def normalize(self, raw: RawJobListing) -> dict[str, Any]:
+        return {
+            "title": raw.raw_data.get("title", self._title),
+            "company": raw.raw_data.get("company", self._company),
+            "description": "Some description",
+            "skills": [],
+            "location": "Remote",
+            "salary_range": None,
+            "url": raw.raw_data.get("url", self._url),
+            "language": "en",
+            "posted_date": None,
+        }
+
+
+class FakeEventBus:
+    def __init__(self) -> None:
+        self.published: list[DomainEvent] = []
+
+    async def publish(self, event: DomainEvent) -> None:
+        self.published.append(event)
+
+
+def _make_raw(title: str = "Engineer", company: str = "Acme", url: str = "https://example.com/1") -> RawJobListing:
+    return RawJobListing(
+        source="test",
+        source_id="1",
+        raw_data={"title": title, "company": company, "url": url},
+    )
+
+
+def _make_config(*portals: PortalEntry) -> PortalsConfig:
+    return PortalsConfig(portals=list(portals))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_scan_all_portals() -> None:
+    """Two portals on different platforms — both get scanned and results merged."""
+    raw_gh = _make_raw("Backend Dev", "GreenCo", "https://gh.example.com/1")
+    raw_lv = _make_raw("Frontend Dev", "LeverCo", "https://lv.example.com/1")
+
+    adapter_gh = FakeAdapter([raw_gh])
+    adapter_lv = FakeAdapter([raw_lv])
+
+    config = _make_config(
+        PortalEntry(name="GreenCo", platform="greenhouse", board_id="greenco", categories=["engineering"]),
+        PortalEntry(name="LeverCo", platform="lever", board_id="leverco", categories=["engineering"]),
+    )
+    adapters = {"greenhouse": adapter_gh, "lever": adapter_lv}
+    normalizers = {"greenhouse": FakeNormalizer(), "lever": FakeNormalizer()}
+    bus = FakeEventBus()
+
+    scanner = PortalScanner(config=config, adapters=adapters, normalizers=normalizers, event_bus=bus)
+    result = await scanner.scan(ScanFilters())
+
+    assert result.total_fetched == 2
+    assert result.new == 2
+    assert result.duplicates == 0
+    assert len(result.jobs) == 2
+    assert result.errors == []
+    assert len(adapter_gh.calls) == 1
+    assert len(adapter_lv.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_filters_by_category() -> None:
+    """Only portals whose categories overlap with the filter are scanned."""
+    raw = _make_raw()
+    adapter_eng = FakeAdapter([raw])
+    adapter_design = FakeAdapter([raw])
+
+    config = _make_config(
+        PortalEntry(name="EngCo", platform="greenhouse", board_id="engco", categories=["engineering"]),
+        PortalEntry(name="DesignCo", platform="lever", board_id="designco", categories=["design"]),
+    )
+    adapters = {"greenhouse": adapter_eng, "lever": adapter_design}
+    normalizers = {"greenhouse": FakeNormalizer(), "lever": FakeNormalizer()}
+    bus = FakeEventBus()
+
+    scanner = PortalScanner(config=config, adapters=adapters, normalizers=normalizers, event_bus=bus)
+    result = await scanner.scan(ScanFilters(categories=["engineering"]))
+
+    assert result.new == 1
+    assert len(adapter_eng.calls) == 1
+    assert len(adapter_design.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_filters_by_company() -> None:
+    """Only portals whose name matches a company in the filter are scanned."""
+    raw = _make_raw()
+    adapter_a = FakeAdapter([raw])
+    adapter_b = FakeAdapter([raw])
+
+    config = _make_config(
+        PortalEntry(name="CompanyA", platform="greenhouse", board_id="ca", categories=[]),
+        PortalEntry(name="CompanyB", platform="lever", board_id="cb", categories=[]),
+    )
+    adapters = {"greenhouse": adapter_a, "lever": adapter_b}
+    normalizers = {"greenhouse": FakeNormalizer(), "lever": FakeNormalizer()}
+    bus = FakeEventBus()
+
+    scanner = PortalScanner(config=config, adapters=adapters, normalizers=normalizers, event_bus=bus)
+    result = await scanner.scan(ScanFilters(companies=["CompanyA"]))
+
+    assert result.new == 1
+    assert len(adapter_a.calls) == 1
+    assert len(adapter_b.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_deduplicates() -> None:
+    """The same raw job returned twice yields new=1, duplicates=1."""
+    raw = _make_raw("Engineer", "Acme", "https://example.com/1")
+    adapter = FakeAdapter([raw, raw])
+
+    config = _make_config(
+        PortalEntry(name="Acme", platform="greenhouse", board_id="acme", categories=[]),
+    )
+    adapters = {"greenhouse": adapter}
+    normalizers = {"greenhouse": FakeNormalizer("Engineer", "Acme", "https://example.com/1")}
+    bus = FakeEventBus()
+
+    scanner = PortalScanner(config=config, adapters=adapters, normalizers=normalizers, event_bus=bus)
+    result = await scanner.scan(ScanFilters())
+
+    assert result.total_fetched == 2
+    assert result.new == 1
+    assert result.duplicates == 1
+    assert len(result.jobs) == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_collects_errors() -> None:
+    """When an adapter raises, the error is collected and scanning continues."""
+    raw = _make_raw()
+    adapter_ok = FakeAdapter([raw])
+    adapter_bad = FakeAdapter(raise_on_fetch=True)
+
+    config = _make_config(
+        PortalEntry(name="GoodCo", platform="greenhouse", board_id="good", categories=[]),
+        PortalEntry(name="BadCo", platform="lever", board_id="bad", categories=[]),
+    )
+    adapters = {"greenhouse": adapter_ok, "lever": adapter_bad}
+    normalizers = {"greenhouse": FakeNormalizer(), "lever": FakeNormalizer()}
+    bus = FakeEventBus()
+
+    scanner = PortalScanner(config=config, adapters=adapters, normalizers=normalizers, event_bus=bus)
+    result = await scanner.scan(ScanFilters())
+
+    assert result.new == 1
+    assert len(result.errors) == 1
+    assert result.errors[0].portal == "BadCo"
+    assert result.errors[0].platform == "lever"
+    assert "network error" in result.errors[0].error
+
+
+@pytest.mark.asyncio
+async def test_scan_publishes_event_when_jobs_found() -> None:
+    """A JobsIngestedEvent is published when at least one new job is found."""
+    raw = _make_raw()
+    adapter = FakeAdapter([raw])
+
+    config = _make_config(
+        PortalEntry(name="SomeCo", platform="greenhouse", board_id="someco", categories=[]),
+    )
+    adapters = {"greenhouse": adapter}
+    normalizers = {"greenhouse": FakeNormalizer()}
+    bus = FakeEventBus()
+
+    scanner = PortalScanner(config=config, adapters=adapters, normalizers=normalizers, event_bus=bus)
+    result = await scanner.scan(ScanFilters())
+
+    assert result.new == 1
+    assert len(bus.published) == 1
+    event = bus.published[0]
+    assert event.event_type == "jobs.ingested"
+    assert event.payload["source"] == "portal_scan"
+    assert len(event.payload["job_ids"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_no_event_when_no_new_jobs() -> None:
+    """No event is published when no jobs are found."""
+    adapter = FakeAdapter([])  # returns nothing
+
+    config = _make_config(
+        PortalEntry(name="EmptyCo", platform="greenhouse", board_id="empty", categories=[]),
+    )
+    adapters = {"greenhouse": adapter}
+    normalizers = {"greenhouse": FakeNormalizer()}
+    bus = FakeEventBus()
+
+    scanner = PortalScanner(config=config, adapters=adapters, normalizers=normalizers, event_bus=bus)
+    result = await scanner.scan(ScanFilters())
+
+    assert result.new == 0
+    assert bus.published == []

--- a/backend/tests/unit/ingestion/test_portal_scanner.py
+++ b/backend/tests/unit/ingestion/test_portal_scanner.py
@@ -4,12 +4,11 @@ from typing import Any
 
 import pytest
 
-from hiresense.ingestion.domain.models import NormalizedJob, RawJobListing
+from hiresense.ingestion.domain.models import RawJobListing
 from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
 from hiresense.ingestion.domain.portal_scanner import (
     PortalScanner,
     ScanFilters,
-    ScanResult,
 )
 from hiresense.kernel.events import DomainEvent
 

--- a/backend/tests/unit/ingestion/test_portal_scanner.py
+++ b/backend/tests/unit/ingestion/test_portal_scanner.py
@@ -239,3 +239,25 @@ async def test_scan_no_event_when_no_new_jobs() -> None:
 
     assert result.new == 0
     assert bus.published == []
+
+
+@pytest.mark.asyncio
+async def test_scan_filters_by_keyword() -> None:
+    """Only jobs whose title or description match the keyword are included."""
+    raw_match = _make_raw("Backend Engineer", "Acme", "https://example.com/1")
+    raw_no_match = _make_raw("Designer", "Acme", "https://example.com/2")
+    adapter = FakeAdapter([raw_match, raw_no_match])
+
+    config = _make_config(
+        PortalEntry(name="Acme", platform="greenhouse", board_id="acme", categories=[]),
+    )
+    adapters = {"greenhouse": adapter}
+    normalizers = {"greenhouse": FakeNormalizer()}
+    bus = FakeEventBus()
+
+    scanner = PortalScanner(config=config, adapters=adapters, normalizers=normalizers, event_bus=bus)
+    result = await scanner.scan(ScanFilters(keyword="engineer"))
+
+    assert result.total_fetched == 2
+    assert result.new == 1
+    assert result.jobs[0].title == "Backend Engineer"

--- a/backend/tests/unit/ingestion/test_scan_routes.py
+++ b/backend/tests/unit/ingestion/test_scan_routes.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from hiresense.ingestion.api.routes import get_portal_scanner, get_portals_config, router
+from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
+from hiresense.ingestion.domain.portal_scanner import ScanError, ScanFilters, ScanResult
+
+_SAMPLE_JOB = NormalizedJob(
+    id="scan-1",
+    title="Backend Engineer",
+    company="Acme",
+    description="Build things",
+    skills=["python", "fastapi"],
+    location="Remote",
+    source="greenhouse",
+    source_type="api",
+    language="en",
+    url="https://boards.greenhouse.io/acme/jobs/1",
+)
+
+_SAMPLE_PORTALS_CONFIG = PortalsConfig(
+    portals=[
+        PortalEntry(
+            name="Acme",
+            platform="greenhouse",
+            board_id="acme",
+            categories=["engineering"],
+        ),
+        PortalEntry(
+            name="Beta Corp",
+            platform="lever",
+            board_id="betacorp",
+            categories=["product"],
+        ),
+    ]
+)
+
+
+class FakePortalScanner:
+    def __init__(self, result: ScanResult) -> None:
+        self._result = result
+        self.last_filters: ScanFilters | None = None
+
+    async def scan(self, filters: ScanFilters) -> ScanResult:
+        self.last_filters = filters
+        return self._result
+
+
+def _make_app(scanner: FakePortalScanner, config: PortalsConfig = _SAMPLE_PORTALS_CONFIG) -> FastAPI:
+    app = FastAPI()
+    app.dependency_overrides[get_portal_scanner] = lambda: scanner
+    app.dependency_overrides[get_portals_config] = lambda: config
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_scan_portals_returns_results() -> None:
+    result = ScanResult(
+        total_fetched=1,
+        new=1,
+        duplicates=0,
+        jobs=[_SAMPLE_JOB],
+        errors=[],
+    )
+    fake = FakePortalScanner(result)
+    app = _make_app(fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/ingestion/scan-portals", json={})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_fetched"] == 1
+    assert data["new"] == 1
+    assert data["duplicates"] == 0
+    assert len(data["jobs"]) == 1
+    assert data["jobs"][0]["title"] == "Backend Engineer"
+    assert data["errors"] == []
+
+
+@pytest.mark.asyncio
+async def test_scan_portals_passes_filters() -> None:
+    result = ScanResult(total_fetched=0, new=0, duplicates=0, jobs=[], errors=[])
+    fake = FakePortalScanner(result)
+    app = _make_app(fake)
+
+    payload = {
+        "categories": ["engineering"],
+        "companies": ["Acme"],
+        "keyword": "python",
+    }
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/ingestion/scan-portals", json=payload)
+
+    assert resp.status_code == 200
+    assert fake.last_filters is not None
+    assert fake.last_filters.categories == ["engineering"]
+    assert fake.last_filters.companies == ["Acme"]
+    assert fake.last_filters.keyword == "python"
+
+
+@pytest.mark.asyncio
+async def test_scan_portals_returns_errors() -> None:
+    error = ScanError(portal="Acme", platform="greenhouse", error="Connection timeout")
+    result = ScanResult(total_fetched=0, new=0, duplicates=0, jobs=[], errors=[error])
+    fake = FakePortalScanner(result)
+    app = _make_app(fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/ingestion/scan-portals", json={})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["portal"] == "Acme"
+    assert data["errors"][0]["platform"] == "greenhouse"
+    assert data["errors"][0]["error"] == "Connection timeout"
+
+
+@pytest.mark.asyncio
+async def test_get_portals_config() -> None:
+    result = ScanResult(total_fetched=0, new=0, duplicates=0, jobs=[], errors=[])
+    fake = FakePortalScanner(result)
+    app = _make_app(fake)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/ingestion/portals")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 2
+    names = {p["name"] for p in data}
+    assert names == {"Acme", "Beta Corp"}
+    assert data[0]["platform"] in {"greenhouse", "lever"}

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -641,6 +641,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
+    { name = "pyyaml" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -697,6 +698,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
     { name = "python-multipart", specifier = ">=0.0.12" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.35" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.0" },

--- a/docs/superpowers/plans/2026-04-06-portal-scanning.md
+++ b/docs/superpowers/plans/2026-04-06-portal-scanning.md
@@ -1,0 +1,2174 @@
+# Portal Scanning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Greenhouse, Lever, and Ashby ATS platform adapters to the ingestion module, with a YAML-based company registry and a new `POST /scan-portals` endpoint.
+
+**Architecture:** Extend the existing ingestion adapter/normalizer pattern. Each ATS platform gets its own adapter (fetches raw JSON from public APIs) and normalizer (maps to `NormalizedJobDTO`). A new `PortalScanner` service loads `portals.yml`, fans out to adapters, deduplicates, and returns results. The existing `IngestionOrchestrator` is not modified — portal scanning is a parallel entry point.
+
+**Tech Stack:** Python 3.12, FastAPI, httpx, Pydantic v2, PyYAML, BeautifulSoup4 (HTML stripping), pytest-asyncio
+
+---
+
+## File Map
+
+### New Files
+
+| File | Responsibility |
+|---|---|
+| `backend/src/hiresense/ingestion/config/portals.yml` | YAML company registry |
+| `backend/src/hiresense/ingestion/domain/portal_config.py` | Pydantic models for portal config + YAML loader |
+| `backend/src/hiresense/ingestion/domain/html_stripper.py` | Shared HTML-to-text utility |
+| `backend/src/hiresense/ingestion/adapters/greenhouse_adapter.py` | Greenhouse API adapter |
+| `backend/src/hiresense/ingestion/adapters/lever_adapter.py` | Lever API adapter |
+| `backend/src/hiresense/ingestion/adapters/ashby_adapter.py` | Ashby API adapter |
+| `backend/src/hiresense/ingestion/domain/normalizers/greenhouse_normalizer.py` | Greenhouse → NormalizedJob mapper |
+| `backend/src/hiresense/ingestion/domain/normalizers/lever_normalizer.py` | Lever → NormalizedJob mapper |
+| `backend/src/hiresense/ingestion/domain/normalizers/ashby_normalizer.py` | Ashby → NormalizedJob mapper |
+| `backend/src/hiresense/ingestion/domain/portal_scanner.py` | Portal scanning orchestrator |
+| `backend/tests/unit/ingestion/test_html_stripper.py` | Tests for HTML stripper |
+| `backend/tests/unit/ingestion/test_portal_config.py` | Tests for YAML config loading |
+| `backend/tests/unit/ingestion/test_greenhouse.py` | Tests for Greenhouse adapter + normalizer |
+| `backend/tests/unit/ingestion/test_lever.py` | Tests for Lever adapter + normalizer |
+| `backend/tests/unit/ingestion/test_ashby.py` | Tests for Ashby adapter + normalizer |
+| `backend/tests/unit/ingestion/test_portal_scanner.py` | Tests for portal scanner orchestrator |
+| `backend/tests/unit/ingestion/test_scan_routes.py` | Tests for scan-portals API endpoint |
+| `frontend/src/app/core/models/scan-portals-request.model.ts` | Request model |
+| `frontend/src/app/core/models/scan-result.model.ts` | Response model |
+| `frontend/src/app/core/models/portal-entry.model.ts` | Portal config model |
+
+### Modified Files
+
+| File | Change |
+|---|---|
+| `backend/src/hiresense/config.py` | Add portal scanning env vars |
+| `backend/src/hiresense/ingestion/api/routes.py` | Add `POST /scan-portals` and `GET /portals` endpoints |
+| `backend/src/hiresense/main.py` | Wire `PortalScanner` and register new route dependencies |
+| `.env.example` | Add portal scanning env var documentation |
+| `frontend/src/app/pages/ingestion/ingestion.component.ts` | Add scan portals UI |
+| `frontend/src/app/pages/ingestion/ingestion.component.html` | Add scan portals template |
+
+---
+
+## Task 1: Add PyYAML dependency
+
+**Files:**
+- Modify: `backend/pyproject.toml`
+
+- [ ] **Step 1: Add pyyaml to dependencies**
+
+In `backend/pyproject.toml`, add `"pyyaml>=6.0"` to the `dependencies` list:
+
+```toml
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
+    "pydantic>=2.9.0",
+    "pydantic-settings>=2.5.0",
+    "httpx>=0.27.0",
+    "feedparser>=6.0.0",
+    "beautifulsoup4>=4.12.0",
+    "pyyaml>=6.0",
+]
+```
+
+- [ ] **Step 2: Install dependencies**
+
+Run: `cd backend && uv sync`
+Expected: Clean install with pyyaml resolved
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/pyproject.toml backend/uv.lock
+git commit -m "build(backend): add pyyaml dependency for portal config"
+```
+
+---
+
+## Task 2: Add portal scanning config to Settings
+
+**Files:**
+- Modify: `backend/src/hiresense/config.py`
+- Modify: `.env.example`
+
+- [ ] **Step 1: Add portal config fields to Settings**
+
+Add these fields to the `Settings` class in `backend/src/hiresense/config.py`, after the existing ingestion settings:
+
+```python
+    # Portal scanning
+    portals_config_path: str = "ingestion/config/portals.yml"
+    portal_scan_timeout: float = 30.0
+    greenhouse_api_url: str = "https://boards-api.greenhouse.io/v1/boards"
+    lever_api_url: str = "https://api.lever.co/v0/postings"
+    ashby_api_url: str = "https://api.ashbyhq.com/posting-api/job-board"
+```
+
+- [ ] **Step 2: Add env vars to .env.example**
+
+Append to `.env.example`:
+
+```env
+# === Portal Scanning ===
+PORTALS_CONFIG_PATH=ingestion/config/portals.yml
+PORTAL_SCAN_TIMEOUT=30
+GREENHOUSE_API_URL=https://boards-api.greenhouse.io/v1/boards
+LEVER_API_URL=https://api.lever.co/v0/postings
+ASHBY_API_URL=https://api.ashbyhq.com/posting-api/job-board
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add backend/src/hiresense/config.py .env.example
+git commit -m "feat(config): add portal scanning environment variables"
+```
+
+---
+
+## Task 3: Create HTML stripper utility
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/domain/html_stripper.py`
+- Create: `backend/tests/unit/ingestion/test_html_stripper.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/ingestion/test_html_stripper.py`:
+
+```python
+from hiresense.ingestion.domain.html_stripper import strip_html
+
+
+def test_strips_basic_tags() -> None:
+    html = "<p>Hello <b>world</b></p>"
+    assert strip_html(html) == "Hello world"
+
+
+def test_preserves_paragraph_breaks() -> None:
+    html = "<p>First paragraph</p><p>Second paragraph</p>"
+    result = strip_html(html)
+    assert "First paragraph" in result
+    assert "Second paragraph" in result
+    assert "\n" in result
+
+
+def test_handles_empty_string() -> None:
+    assert strip_html("") == ""
+
+
+def test_handles_plain_text() -> None:
+    assert strip_html("no html here") == "no html here"
+
+
+def test_strips_nested_tags() -> None:
+    html = "<div><ul><li>Item 1</li><li>Item 2</li></ul></div>"
+    result = strip_html(html)
+    assert "Item 1" in result
+    assert "Item 2" in result
+
+
+def test_decodes_html_entities() -> None:
+    html = "<p>Salary &gt; $100k &amp; benefits</p>"
+    assert strip_html(html) == "Salary > $100k & benefits"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_html_stripper.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'hiresense.ingestion.domain.html_stripper'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `backend/src/hiresense/ingestion/domain/html_stripper.py`:
+
+```python
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+
+def strip_html(html: str) -> str:
+    """Convert HTML to plain text, preserving paragraph breaks."""
+    if not html:
+        return ""
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup.find_all(["p", "br", "div", "li"]):
+        tag.insert_before("\n")
+    text = soup.get_text()
+    lines = [line.strip() for line in text.splitlines()]
+    return "\n".join(line for line in lines if line)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_html_stripper.py -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/domain/html_stripper.py backend/tests/unit/ingestion/test_html_stripper.py
+git commit -m "feat(ingestion): add HTML stripper utility for portal normalizers"
+```
+
+---
+
+## Task 4: Create portal config model and YAML loader
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/domain/portal_config.py`
+- Create: `backend/src/hiresense/ingestion/config/portals.yml`
+- Create: `backend/tests/unit/ingestion/test_portal_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/ingestion/test_portal_config.py`:
+
+```python
+import pytest
+from pathlib import Path
+from hiresense.ingestion.domain.portal_config import (
+    PortalEntry,
+    PortalsConfig,
+    load_portals_config,
+)
+
+
+def test_portal_entry_model() -> None:
+    entry = PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic")
+    assert entry.name == "Anthropic"
+    assert entry.platform == "greenhouse"
+    assert entry.board_id == "anthropic"
+    assert entry.categories == []
+
+
+def test_portal_entry_with_categories() -> None:
+    entry = PortalEntry(
+        name="Anthropic",
+        platform="greenhouse",
+        board_id="anthropic",
+        categories=["ai-research"],
+    )
+    assert entry.categories == ["ai-research"]
+
+
+def test_portal_entry_rejects_invalid_platform() -> None:
+    with pytest.raises(ValueError):
+        PortalEntry(name="Foo", platform="invalid", board_id="foo")
+
+
+def test_portals_config_model() -> None:
+    config = PortalsConfig(
+        portals=[
+            PortalEntry(name="A", platform="greenhouse", board_id="a"),
+            PortalEntry(name="B", platform="lever", board_id="b"),
+        ]
+    )
+    assert len(config.portals) == 2
+
+
+def test_load_portals_config(tmp_path: Path) -> None:
+    yml = tmp_path / "portals.yml"
+    yml.write_text(
+        "portals:\n"
+        "  - name: TestCo\n"
+        "    platform: ashby\n"
+        "    board_id: testco\n"
+        "    categories: [ai]\n"
+    )
+    config = load_portals_config(yml)
+    assert len(config.portals) == 1
+    assert config.portals[0].name == "TestCo"
+    assert config.portals[0].platform == "ashby"
+    assert config.portals[0].categories == ["ai"]
+
+
+def test_load_portals_config_file_not_found() -> None:
+    with pytest.raises(FileNotFoundError):
+        load_portals_config(Path("/nonexistent/portals.yml"))
+
+
+def test_filter_by_category() -> None:
+    config = PortalsConfig(
+        portals=[
+            PortalEntry(name="A", platform="greenhouse", board_id="a", categories=["ai"]),
+            PortalEntry(name="B", platform="lever", board_id="b", categories=["devtools"]),
+            PortalEntry(name="C", platform="ashby", board_id="c", categories=["ai", "devtools"]),
+        ]
+    )
+    filtered = [p for p in config.portals if "ai" in p.categories]
+    assert len(filtered) == 2
+    assert {p.name for p in filtered} == {"A", "C"}
+
+
+def test_filter_by_company() -> None:
+    config = PortalsConfig(
+        portals=[
+            PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic"),
+            PortalEntry(name="Retool", platform="lever", board_id="retool"),
+        ]
+    )
+    filtered = [p for p in config.portals if p.name in ["Anthropic"]]
+    assert len(filtered) == 1
+    assert filtered[0].board_id == "anthropic"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_portal_config.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+Create `backend/src/hiresense/ingestion/domain/portal_config.py`:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel
+
+
+class PortalEntry(BaseModel):
+    name: str
+    platform: Literal["greenhouse", "lever", "ashby"]
+    board_id: str
+    categories: list[str] = []
+
+
+class PortalsConfig(BaseModel):
+    portals: list[PortalEntry]
+
+
+def load_portals_config(path: Path) -> PortalsConfig:
+    """Load and validate portals.yml from the given path."""
+    if not path.exists():
+        raise FileNotFoundError(f"Portals config not found: {path}")
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    return PortalsConfig.model_validate(data)
+```
+
+- [ ] **Step 4: Create the default portals.yml**
+
+Create `backend/src/hiresense/ingestion/config/portals.yml`:
+
+```yaml
+portals:
+  # AI Research Labs
+  - name: Anthropic
+    platform: greenhouse
+    board_id: anthropic
+    categories: [ai-research]
+
+  - name: OpenAI
+    platform: greenhouse
+    board_id: openai
+    categories: [ai-research]
+
+  - name: Mistral
+    platform: greenhouse
+    board_id: mistralai
+    categories: [ai-research]
+
+  - name: Cohere
+    platform: greenhouse
+    board_id: cohere
+    categories: [ai-research]
+
+  - name: LangChain
+    platform: greenhouse
+    board_id: langchain
+    categories: [ai-research]
+
+  # Voice Technology
+  - name: ElevenLabs
+    platform: ashby
+    board_id: elevenlabs
+    categories: [voice-tech]
+
+  - name: Deepgram
+    platform: greenhouse
+    board_id: deepgram
+    categories: [voice-tech]
+
+  # Development Platforms
+  - name: Retool
+    platform: lever
+    board_id: retool
+    categories: [dev-platforms]
+
+  - name: Vercel
+    platform: greenhouse
+    board_id: vercel
+    categories: [dev-platforms]
+
+  - name: Temporal
+    platform: greenhouse
+    board_id: temporal
+    categories: [dev-platforms]
+
+  # LLM Operations
+  - name: Weights & Biases
+    platform: greenhouse
+    board_id: wandb
+    categories: [llm-ops]
+
+  # Workflow Automation
+  - name: n8n
+    platform: greenhouse
+    board_id: n8n
+    categories: [workflow-automation]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_portal_config.py -v`
+Expected: All 8 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/domain/portal_config.py backend/src/hiresense/ingestion/config/portals.yml backend/tests/unit/ingestion/test_portal_config.py
+git commit -m "feat(ingestion): add portal config model and YAML loader with default company list"
+```
+
+---
+
+## Task 5: Greenhouse adapter
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/adapters/greenhouse_adapter.py`
+- Create: `backend/tests/unit/ingestion/test_greenhouse.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/ingestion/test_greenhouse.py`:
+
+```python
+import pytest
+from hiresense.ingestion.adapters.greenhouse_adapter import GreenhouseAdapter
+from hiresense.kernel.value_objects import SourceType
+
+
+class FakeResponse:
+    def __init__(self, data: list | dict, status_code: int = 200) -> None:
+        self._data = data
+        self.status_code = status_code
+
+    def json(self) -> list | dict:
+        return self._data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+class FakeHttpClient:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self._responses = list(responses)
+        self.requests: list[tuple[str, dict]] = []
+
+    async def get(self, url: str, **kwargs) -> FakeResponse:
+        self.requests.append((url, kwargs))
+        return self._responses.pop(0)
+
+
+SAMPLE_GREENHOUSE_JOBS = [
+    {
+        "id": 101,
+        "title": "Backend Engineer",
+        "location": {"name": "San Francisco, CA"},
+        "content": "<p>Build <b>APIs</b> with Python</p>",
+        "absolute_url": "https://boards.greenhouse.io/anthropic/jobs/101",
+        "updated_at": "2026-04-01T12:00:00Z",
+        "departments": [{"name": "Engineering"}],
+    },
+    {
+        "id": 102,
+        "title": "ML Researcher",
+        "location": {"name": "Remote"},
+        "content": "<p>Research LLMs</p>",
+        "absolute_url": "https://boards.greenhouse.io/anthropic/jobs/102",
+        "updated_at": "2026-03-28T12:00:00Z",
+        "departments": [{"name": "Research"}],
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_fetches_jobs() -> None:
+    client = FakeHttpClient([FakeResponse(SAMPLE_GREENHOUSE_JOBS)])
+    adapter = GreenhouseAdapter(
+        http_client=client,
+        base_url="https://boards-api.greenhouse.io/v1/boards",
+        timeout=30.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="anthropic", company_name="Anthropic")
+    assert len(jobs) == 2
+    assert jobs[0].source == "greenhouse"
+    assert jobs[0].source_id == "101"
+    assert jobs[0].raw_data["title"] == "Backend Engineer"
+    assert jobs[0].raw_data["company"] == "Anthropic"
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_builds_correct_url() -> None:
+    client = FakeHttpClient([FakeResponse([])])
+    adapter = GreenhouseAdapter(
+        http_client=client,
+        base_url="https://boards-api.greenhouse.io/v1/boards",
+        timeout=30.0,
+    )
+    await adapter.fetch_jobs(board_id="anthropic", company_name="Anthropic")
+    url, kwargs = client.requests[0]
+    assert url == "https://boards-api.greenhouse.io/v1/boards/anthropic/jobs"
+    assert kwargs["params"]["content"] == "true"
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_empty_board() -> None:
+    client = FakeHttpClient([FakeResponse([])])
+    adapter = GreenhouseAdapter(
+        http_client=client,
+        base_url="https://boards-api.greenhouse.io/v1/boards",
+        timeout=30.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="empty", company_name="Empty")
+    assert jobs == []
+
+
+def test_greenhouse_source_metadata() -> None:
+    adapter = GreenhouseAdapter(http_client=None, base_url="", timeout=30.0)
+    assert adapter.source_name() == "greenhouse"
+    assert adapter.source_type() == SourceType.API
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_greenhouse.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+Create `backend/src/hiresense/ingestion/adapters/greenhouse_adapter.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+logger = logging.getLogger(__name__)
+
+
+class GreenhouseAdapter:
+    def __init__(self, http_client: Any, base_url: str, timeout: float) -> None:
+        self._http = http_client
+        self._base_url = base_url
+        self._timeout = timeout
+
+    def source_name(self) -> str:
+        return "greenhouse"
+
+    def source_type(self) -> SourceType:
+        return SourceType.API
+
+    async def fetch_jobs(
+        self, board_id: str, company_name: str
+    ) -> list[RawJobListing]:
+        url = f"{self._base_url}/{board_id}/jobs"
+        params = {"content": "true"}
+        response = await self._http.get(
+            url, params=params, timeout=self._timeout
+        )
+        response.raise_for_status()
+        data = response.json()
+        jobs = data if isinstance(data, list) else data.get("jobs", [])
+        return [
+            RawJobListing(
+                source="greenhouse",
+                source_id=str(job["id"]),
+                raw_data={**job, "company": company_name},
+            )
+            for job in jobs
+        ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_greenhouse.py -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/adapters/greenhouse_adapter.py backend/tests/unit/ingestion/test_greenhouse.py
+git commit -m "feat(ingestion): add Greenhouse ATS adapter"
+```
+
+---
+
+## Task 6: Greenhouse normalizer
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/domain/normalizers/greenhouse_normalizer.py`
+- Modify: `backend/tests/unit/ingestion/test_greenhouse.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/ingestion/test_greenhouse.py`:
+
+```python
+from hiresense.ingestion.domain.normalizers.greenhouse_normalizer import GreenhouseNormalizer
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+def test_greenhouse_normalizer() -> None:
+    raw = RawJobListing(
+        source="greenhouse",
+        source_id="101",
+        raw_data={
+            "title": "Backend Engineer",
+            "company": "Anthropic",
+            "location": {"name": "San Francisco, CA"},
+            "content": "<p>Build <b>APIs</b> with Python</p>",
+            "absolute_url": "https://boards.greenhouse.io/anthropic/jobs/101",
+            "updated_at": "2026-04-01T12:00:00Z",
+            "departments": [{"name": "Engineering"}],
+        },
+    )
+    normalizer = GreenhouseNormalizer()
+    result = normalizer.normalize(raw)
+    assert result["title"] == "Backend Engineer"
+    assert result["company"] == "Anthropic"
+    assert result["url"] == "https://boards.greenhouse.io/anthropic/jobs/101"
+    assert result["location"] == "San Francisco, CA"
+    assert "<p>" not in result["description"]
+    assert "Build" in result["description"]
+    assert "APIs" in result["description"]
+
+
+def test_greenhouse_normalizer_missing_fields() -> None:
+    raw = RawJobListing(
+        source="greenhouse",
+        source_id="200",
+        raw_data={
+            "title": "SWE",
+            "company": "X",
+            "content": "",
+            "absolute_url": "https://example.com/200",
+        },
+    )
+    normalizer = GreenhouseNormalizer()
+    result = normalizer.normalize(raw)
+    assert result["title"] == "SWE"
+    assert result["location"] == ""
+    assert result["description"] == ""
+    assert result["department"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_greenhouse.py::test_greenhouse_normalizer -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+Create `backend/src/hiresense/ingestion/domain/normalizers/greenhouse_normalizer.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from hiresense.ingestion.domain.html_stripper import strip_html
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+class GreenhouseNormalizer:
+    def normalize(self, raw: RawJobListing) -> dict[str, Any]:
+        d = raw.raw_data
+        location_obj = d.get("location")
+        location = location_obj.get("name", "") if isinstance(location_obj, dict) else ""
+        departments = d.get("departments", [])
+        department = departments[0]["name"] if departments else None
+
+        return {
+            "title": d.get("title", ""),
+            "company": d.get("company", ""),
+            "description": strip_html(d.get("content", "")),
+            "skills": [],
+            "location": location,
+            "salary_range": None,
+            "url": d.get("absolute_url", ""),
+            "language": "en",
+            "posted_date": d.get("updated_at"),
+            "department": department,
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_greenhouse.py -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/domain/normalizers/greenhouse_normalizer.py backend/tests/unit/ingestion/test_greenhouse.py
+git commit -m "feat(ingestion): add Greenhouse normalizer"
+```
+
+---
+
+## Task 7: Lever adapter
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/adapters/lever_adapter.py`
+- Create: `backend/tests/unit/ingestion/test_lever.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/ingestion/test_lever.py`:
+
+```python
+import pytest
+from hiresense.ingestion.adapters.lever_adapter import LeverAdapter
+from hiresense.kernel.value_objects import SourceType
+
+
+class FakeResponse:
+    def __init__(self, data: list | dict, status_code: int = 200) -> None:
+        self._data = data
+        self.status_code = status_code
+
+    def json(self) -> list | dict:
+        return self._data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+class FakeHttpClient:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self._responses = list(responses)
+        self.requests: list[tuple[str, dict]] = []
+
+    async def get(self, url: str, **kwargs) -> FakeResponse:
+        self.requests.append((url, kwargs))
+        return self._responses.pop(0)
+
+
+SAMPLE_LEVER_POSTINGS = [
+    {
+        "id": "abc-123",
+        "text": "Frontend Engineer",
+        "categories": {
+            "location": "New York, NY",
+            "team": "Product",
+        },
+        "description": "<p>Build UIs with React</p>",
+        "hostedUrl": "https://jobs.lever.co/retool/abc-123",
+        "createdAt": 1711699200000,
+    },
+]
+
+
+@pytest.mark.asyncio
+async def test_lever_fetches_jobs() -> None:
+    client = FakeHttpClient([FakeResponse(SAMPLE_LEVER_POSTINGS)])
+    adapter = LeverAdapter(
+        http_client=client,
+        base_url="https://api.lever.co/v0/postings",
+        timeout=30.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="retool", company_name="Retool")
+    assert len(jobs) == 1
+    assert jobs[0].source == "lever"
+    assert jobs[0].source_id == "abc-123"
+    assert jobs[0].raw_data["text"] == "Frontend Engineer"
+    assert jobs[0].raw_data["company"] == "Retool"
+
+
+@pytest.mark.asyncio
+async def test_lever_builds_correct_url() -> None:
+    client = FakeHttpClient([FakeResponse([])])
+    adapter = LeverAdapter(
+        http_client=client,
+        base_url="https://api.lever.co/v0/postings",
+        timeout=30.0,
+    )
+    await adapter.fetch_jobs(board_id="retool", company_name="Retool")
+    url, kwargs = client.requests[0]
+    assert url == "https://api.lever.co/v0/postings/retool"
+    assert kwargs["params"]["mode"] == "json"
+
+
+@pytest.mark.asyncio
+async def test_lever_empty_board() -> None:
+    client = FakeHttpClient([FakeResponse([])])
+    adapter = LeverAdapter(
+        http_client=client,
+        base_url="https://api.lever.co/v0/postings",
+        timeout=30.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="empty", company_name="Empty")
+    assert jobs == []
+
+
+def test_lever_source_metadata() -> None:
+    adapter = LeverAdapter(http_client=None, base_url="", timeout=30.0)
+    assert adapter.source_name() == "lever"
+    assert adapter.source_type() == SourceType.API
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_lever.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+Create `backend/src/hiresense/ingestion/adapters/lever_adapter.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+logger = logging.getLogger(__name__)
+
+
+class LeverAdapter:
+    def __init__(self, http_client: Any, base_url: str, timeout: float) -> None:
+        self._http = http_client
+        self._base_url = base_url
+        self._timeout = timeout
+
+    def source_name(self) -> str:
+        return "lever"
+
+    def source_type(self) -> SourceType:
+        return SourceType.API
+
+    async def fetch_jobs(
+        self, board_id: str, company_name: str
+    ) -> list[RawJobListing]:
+        url = f"{self._base_url}/{board_id}"
+        params = {"mode": "json"}
+        response = await self._http.get(
+            url, params=params, timeout=self._timeout
+        )
+        response.raise_for_status()
+        data = response.json()
+        postings = data if isinstance(data, list) else []
+        return [
+            RawJobListing(
+                source="lever",
+                source_id=str(posting.get("id", "")),
+                raw_data={**posting, "company": company_name},
+            )
+            for posting in postings
+        ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_lever.py -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/adapters/lever_adapter.py backend/tests/unit/ingestion/test_lever.py
+git commit -m "feat(ingestion): add Lever ATS adapter"
+```
+
+---
+
+## Task 8: Lever normalizer
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/domain/normalizers/lever_normalizer.py`
+- Modify: `backend/tests/unit/ingestion/test_lever.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/ingestion/test_lever.py`:
+
+```python
+from hiresense.ingestion.domain.normalizers.lever_normalizer import LeverNormalizer
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+def test_lever_normalizer() -> None:
+    raw = RawJobListing(
+        source="lever",
+        source_id="abc-123",
+        raw_data={
+            "text": "Frontend Engineer",
+            "company": "Retool",
+            "categories": {
+                "location": "New York, NY",
+                "team": "Product",
+            },
+            "description": "<p>Build UIs with <b>React</b></p>",
+            "hostedUrl": "https://jobs.lever.co/retool/abc-123",
+            "createdAt": 1711699200000,
+        },
+    )
+    normalizer = LeverNormalizer()
+    result = normalizer.normalize(raw)
+    assert result["title"] == "Frontend Engineer"
+    assert result["company"] == "Retool"
+    assert result["url"] == "https://jobs.lever.co/retool/abc-123"
+    assert result["location"] == "New York, NY"
+    assert result["department"] == "Product"
+    assert "<p>" not in result["description"]
+    assert "Build UIs" in result["description"]
+
+
+def test_lever_normalizer_missing_categories() -> None:
+    raw = RawJobListing(
+        source="lever",
+        source_id="xyz",
+        raw_data={
+            "text": "SWE",
+            "company": "X",
+            "description": "",
+            "hostedUrl": "https://example.com/xyz",
+        },
+    )
+    normalizer = LeverNormalizer()
+    result = normalizer.normalize(raw)
+    assert result["title"] == "SWE"
+    assert result["location"] == ""
+    assert result["department"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_lever.py::test_lever_normalizer -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+Create `backend/src/hiresense/ingestion/domain/normalizers/lever_normalizer.py`:
+
+```python
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from hiresense.ingestion.domain.html_stripper import strip_html
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+class LeverNormalizer:
+    def normalize(self, raw: RawJobListing) -> dict[str, Any]:
+        d = raw.raw_data
+        categories = d.get("categories") or {}
+        created_ms = d.get("createdAt")
+        posted_date = (
+            datetime.fromtimestamp(created_ms / 1000, tz=timezone.utc).isoformat()
+            if created_ms
+            else None
+        )
+
+        return {
+            "title": d.get("text", ""),
+            "company": d.get("company", ""),
+            "description": strip_html(d.get("description", "")),
+            "skills": [],
+            "location": categories.get("location", ""),
+            "salary_range": None,
+            "url": d.get("hostedUrl", ""),
+            "language": "en",
+            "posted_date": posted_date,
+            "department": categories.get("team"),
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_lever.py -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/domain/normalizers/lever_normalizer.py backend/tests/unit/ingestion/test_lever.py
+git commit -m "feat(ingestion): add Lever normalizer"
+```
+
+---
+
+## Task 9: Ashby adapter
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/adapters/ashby_adapter.py`
+- Create: `backend/tests/unit/ingestion/test_ashby.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/ingestion/test_ashby.py`:
+
+```python
+import pytest
+from hiresense.ingestion.adapters.ashby_adapter import AshbyAdapter
+from hiresense.kernel.value_objects import SourceType
+
+
+class FakeResponse:
+    def __init__(self, data: dict, status_code: int = 200) -> None:
+        self._data = data
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return self._data
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise Exception(f"HTTP {self.status_code}")
+
+
+class FakeHttpClient:
+    def __init__(self, responses: list[FakeResponse]) -> None:
+        self._responses = list(responses)
+        self.requests: list[tuple[str, dict]] = []
+
+    async def post(self, url: str, **kwargs) -> FakeResponse:
+        self.requests.append((url, kwargs))
+        return self._responses.pop(0)
+
+
+SAMPLE_ASHBY_RESPONSE = {
+    "jobs": [
+        {
+            "id": "job-001",
+            "title": "AI Engineer",
+            "location": "Remote - US",
+            "descriptionHtml": "<p>Work on <b>voice synthesis</b></p>",
+            "jobUrl": "https://jobs.ashbyhq.com/elevenlabs/job-001",
+            "publishedAt": "2026-04-01T00:00:00.000Z",
+            "departmentName": "AI Team",
+        },
+    ]
+}
+
+
+@pytest.mark.asyncio
+async def test_ashby_fetches_jobs() -> None:
+    client = FakeHttpClient([FakeResponse(SAMPLE_ASHBY_RESPONSE)])
+    adapter = AshbyAdapter(
+        http_client=client,
+        base_url="https://api.ashbyhq.com/posting-api/job-board",
+        timeout=30.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="elevenlabs", company_name="ElevenLabs")
+    assert len(jobs) == 1
+    assert jobs[0].source == "ashby"
+    assert jobs[0].source_id == "job-001"
+    assert jobs[0].raw_data["title"] == "AI Engineer"
+    assert jobs[0].raw_data["company"] == "ElevenLabs"
+
+
+@pytest.mark.asyncio
+async def test_ashby_builds_correct_url() -> None:
+    client = FakeHttpClient([FakeResponse({"jobs": []})])
+    adapter = AshbyAdapter(
+        http_client=client,
+        base_url="https://api.ashbyhq.com/posting-api/job-board",
+        timeout=30.0,
+    )
+    await adapter.fetch_jobs(board_id="elevenlabs", company_name="ElevenLabs")
+    url, _ = client.requests[0]
+    assert url == "https://api.ashbyhq.com/posting-api/job-board/elevenlabs"
+
+
+@pytest.mark.asyncio
+async def test_ashby_empty_board() -> None:
+    client = FakeHttpClient([FakeResponse({"jobs": []})])
+    adapter = AshbyAdapter(
+        http_client=client,
+        base_url="https://api.ashbyhq.com/posting-api/job-board",
+        timeout=30.0,
+    )
+    jobs = await adapter.fetch_jobs(board_id="empty", company_name="Empty")
+    assert jobs == []
+
+
+def test_ashby_source_metadata() -> None:
+    adapter = AshbyAdapter(http_client=None, base_url="", timeout=30.0)
+    assert adapter.source_name() == "ashby"
+    assert adapter.source_type() == SourceType.API
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_ashby.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+Create `backend/src/hiresense/ingestion/adapters/ashby_adapter.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.kernel.value_objects import SourceType
+
+logger = logging.getLogger(__name__)
+
+
+class AshbyAdapter:
+    def __init__(self, http_client: Any, base_url: str, timeout: float) -> None:
+        self._http = http_client
+        self._base_url = base_url
+        self._timeout = timeout
+
+    def source_name(self) -> str:
+        return "ashby"
+
+    def source_type(self) -> SourceType:
+        return SourceType.API
+
+    async def fetch_jobs(
+        self, board_id: str, company_name: str
+    ) -> list[RawJobListing]:
+        url = f"{self._base_url}/{board_id}"
+        response = await self._http.post(url, timeout=self._timeout)
+        response.raise_for_status()
+        data = response.json()
+        jobs = data.get("jobs", [])
+        return [
+            RawJobListing(
+                source="ashby",
+                source_id=str(job.get("id", "")),
+                raw_data={**job, "company": company_name},
+            )
+            for job in jobs
+        ]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_ashby.py -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/adapters/ashby_adapter.py backend/tests/unit/ingestion/test_ashby.py
+git commit -m "feat(ingestion): add Ashby ATS adapter"
+```
+
+---
+
+## Task 10: Ashby normalizer
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/domain/normalizers/ashby_normalizer.py`
+- Modify: `backend/tests/unit/ingestion/test_ashby.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `backend/tests/unit/ingestion/test_ashby.py`:
+
+```python
+from hiresense.ingestion.domain.normalizers.ashby_normalizer import AshbyNormalizer
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+def test_ashby_normalizer() -> None:
+    raw = RawJobListing(
+        source="ashby",
+        source_id="job-001",
+        raw_data={
+            "title": "AI Engineer",
+            "company": "ElevenLabs",
+            "location": "Remote - US",
+            "descriptionHtml": "<p>Work on <b>voice synthesis</b></p>",
+            "jobUrl": "https://jobs.ashbyhq.com/elevenlabs/job-001",
+            "publishedAt": "2026-04-01T00:00:00.000Z",
+            "departmentName": "AI Team",
+        },
+    )
+    normalizer = AshbyNormalizer()
+    result = normalizer.normalize(raw)
+    assert result["title"] == "AI Engineer"
+    assert result["company"] == "ElevenLabs"
+    assert result["url"] == "https://jobs.ashbyhq.com/elevenlabs/job-001"
+    assert result["location"] == "Remote - US"
+    assert result["department"] == "AI Team"
+    assert "<p>" not in result["description"]
+    assert "voice synthesis" in result["description"]
+
+
+def test_ashby_normalizer_missing_fields() -> None:
+    raw = RawJobListing(
+        source="ashby",
+        source_id="x",
+        raw_data={
+            "title": "SWE",
+            "company": "X",
+            "descriptionHtml": "",
+            "jobUrl": "https://example.com/x",
+        },
+    )
+    normalizer = AshbyNormalizer()
+    result = normalizer.normalize(raw)
+    assert result["title"] == "SWE"
+    assert result["location"] == ""
+    assert result["department"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_ashby.py::test_ashby_normalizer -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+Create `backend/src/hiresense/ingestion/domain/normalizers/ashby_normalizer.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from hiresense.ingestion.domain.html_stripper import strip_html
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+class AshbyNormalizer:
+    def normalize(self, raw: RawJobListing) -> dict[str, Any]:
+        d = raw.raw_data
+
+        return {
+            "title": d.get("title", ""),
+            "company": d.get("company", ""),
+            "description": strip_html(d.get("descriptionHtml", "")),
+            "skills": [],
+            "location": d.get("location", ""),
+            "salary_range": None,
+            "url": d.get("jobUrl", ""),
+            "language": "en",
+            "posted_date": d.get("publishedAt"),
+            "department": d.get("departmentName"),
+        }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_ashby.py -v`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/domain/normalizers/ashby_normalizer.py backend/tests/unit/ingestion/test_ashby.py
+git commit -m "feat(ingestion): add Ashby normalizer"
+```
+
+---
+
+## Task 11: Portal scanner service
+
+**Files:**
+- Create: `backend/src/hiresense/ingestion/domain/portal_scanner.py`
+- Create: `backend/tests/unit/ingestion/test_portal_scanner.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/ingestion/test_portal_scanner.py`:
+
+```python
+import pytest
+from hiresense.ingestion.domain.portal_scanner import PortalScanner, ScanFilters, ScanResult
+from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
+from hiresense.ingestion.domain.models import RawJobListing
+
+
+class FakeAdapter:
+    def __init__(self, jobs: list[RawJobListing] | Exception) -> None:
+        self._jobs = jobs
+        self.calls: list[tuple[str, str]] = []
+
+    async def fetch_jobs(self, board_id: str, company_name: str) -> list[RawJobListing]:
+        self.calls.append((board_id, company_name))
+        if isinstance(self._jobs, Exception):
+            raise self._jobs
+        return self._jobs
+
+
+class FakeNormalizer:
+    def normalize(self, raw: RawJobListing) -> dict:
+        return {
+            "title": raw.raw_data.get("title", ""),
+            "company": raw.raw_data.get("company", ""),
+            "description": raw.raw_data.get("description", ""),
+            "skills": [],
+            "location": "",
+            "salary_range": None,
+            "url": raw.raw_data.get("url", f"https://example.com/{raw.source_id}"),
+            "language": "en",
+        }
+
+
+class FakeEventBus:
+    def __init__(self) -> None:
+        self.events: list = []
+
+    async def publish(self, event) -> None:
+        self.events.append(event)
+
+
+def _make_config(portals: list[PortalEntry]) -> PortalsConfig:
+    return PortalsConfig(portals=portals)
+
+
+def _make_raw(source: str, source_id: str, title: str, company: str, url: str) -> RawJobListing:
+    return RawJobListing(
+        source=source,
+        source_id=source_id,
+        raw_data={"title": title, "company": company, "url": url},
+    )
+
+
+@pytest.mark.asyncio
+async def test_scan_all_portals() -> None:
+    gh_jobs = [_make_raw("greenhouse", "1", "SWE", "Anthropic", "https://gh.io/1")]
+    lever_jobs = [_make_raw("lever", "2", "FE", "Retool", "https://lever.co/2")]
+
+    gh_adapter = FakeAdapter(gh_jobs)
+    lever_adapter = FakeAdapter(lever_jobs)
+
+    config = _make_config([
+        PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic"),
+        PortalEntry(name="Retool", platform="lever", board_id="retool"),
+    ])
+
+    scanner = PortalScanner(
+        config=config,
+        adapters={"greenhouse": gh_adapter, "lever": lever_adapter},
+        normalizers={"greenhouse": FakeNormalizer(), "lever": FakeNormalizer()},
+        event_bus=FakeEventBus(),
+    )
+
+    result = await scanner.scan(ScanFilters())
+    assert result.total_fetched == 2
+    assert result.new == 2
+    assert result.duplicates == 0
+    assert len(result.jobs) == 2
+    assert len(result.errors) == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_filters_by_category() -> None:
+    gh_adapter = FakeAdapter([_make_raw("greenhouse", "1", "SWE", "Anthropic", "https://gh.io/1")])
+    lever_adapter = FakeAdapter([_make_raw("lever", "2", "FE", "Retool", "https://lever.co/2")])
+
+    config = _make_config([
+        PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic", categories=["ai"]),
+        PortalEntry(name="Retool", platform="lever", board_id="retool", categories=["devtools"]),
+    ])
+
+    scanner = PortalScanner(
+        config=config,
+        adapters={"greenhouse": gh_adapter, "lever": lever_adapter},
+        normalizers={"greenhouse": FakeNormalizer(), "lever": FakeNormalizer()},
+        event_bus=FakeEventBus(),
+    )
+
+    result = await scanner.scan(ScanFilters(categories=["ai"]))
+    assert result.total_fetched == 1
+    assert result.jobs[0].title == "SWE"
+    assert len(lever_adapter.calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_scan_filters_by_company() -> None:
+    gh_adapter = FakeAdapter([_make_raw("greenhouse", "1", "SWE", "Anthropic", "https://gh.io/1")])
+
+    config = _make_config([
+        PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic"),
+        PortalEntry(name="OpenAI", platform="greenhouse", board_id="openai"),
+    ])
+
+    scanner = PortalScanner(
+        config=config,
+        adapters={"greenhouse": gh_adapter},
+        normalizers={"greenhouse": FakeNormalizer()},
+        event_bus=FakeEventBus(),
+    )
+
+    result = await scanner.scan(ScanFilters(companies=["Anthropic"]))
+    assert result.total_fetched == 1
+    assert len(gh_adapter.calls) == 1
+    assert gh_adapter.calls[0] == ("anthropic", "Anthropic")
+
+
+@pytest.mark.asyncio
+async def test_scan_deduplicates() -> None:
+    same_job = _make_raw("greenhouse", "1", "SWE", "Anthropic", "https://gh.io/1")
+    gh_adapter = FakeAdapter([same_job, same_job])
+
+    config = _make_config([
+        PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic"),
+    ])
+
+    scanner = PortalScanner(
+        config=config,
+        adapters={"greenhouse": gh_adapter},
+        normalizers={"greenhouse": FakeNormalizer()},
+        event_bus=FakeEventBus(),
+    )
+
+    result = await scanner.scan(ScanFilters())
+    assert result.total_fetched == 2
+    assert result.new == 1
+    assert result.duplicates == 1
+
+
+@pytest.mark.asyncio
+async def test_scan_collects_errors() -> None:
+    gh_adapter = FakeAdapter(TimeoutError("timed out"))
+
+    config = _make_config([
+        PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic"),
+    ])
+
+    scanner = PortalScanner(
+        config=config,
+        adapters={"greenhouse": gh_adapter},
+        normalizers={"greenhouse": FakeNormalizer()},
+        event_bus=FakeEventBus(),
+    )
+
+    result = await scanner.scan(ScanFilters())
+    assert result.total_fetched == 0
+    assert len(result.errors) == 1
+    assert result.errors[0].portal == "Anthropic"
+    assert result.errors[0].platform == "greenhouse"
+    assert "timed out" in result.errors[0].error
+
+
+@pytest.mark.asyncio
+async def test_scan_publishes_event_when_jobs_found() -> None:
+    gh_adapter = FakeAdapter([_make_raw("greenhouse", "1", "SWE", "Anthropic", "https://gh.io/1")])
+    event_bus = FakeEventBus()
+
+    config = _make_config([
+        PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic"),
+    ])
+
+    scanner = PortalScanner(
+        config=config,
+        adapters={"greenhouse": gh_adapter},
+        normalizers={"greenhouse": FakeNormalizer()},
+        event_bus=event_bus,
+    )
+
+    await scanner.scan(ScanFilters())
+    assert len(event_bus.events) == 1
+    assert event_bus.events[0].event_type == "jobs.ingested"
+
+
+@pytest.mark.asyncio
+async def test_scan_no_event_when_no_new_jobs() -> None:
+    gh_adapter = FakeAdapter([])
+    event_bus = FakeEventBus()
+
+    config = _make_config([
+        PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic"),
+    ])
+
+    scanner = PortalScanner(
+        config=config,
+        adapters={"greenhouse": gh_adapter},
+        normalizers={"greenhouse": FakeNormalizer()},
+        event_bus=event_bus,
+    )
+
+    await scanner.scan(ScanFilters())
+    assert len(event_bus.events) == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_portal_scanner.py -v`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Write implementation**
+
+Create `backend/src/hiresense/ingestion/domain/portal_scanner.py`:
+
+```python
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from pydantic import BaseModel
+
+from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.ingestion.domain.normalizers.job_normalizer import JobNormalizer
+from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
+from hiresense.kernel.contracts.jobs_ingested_event import JobsIngestedEvent
+
+logger = logging.getLogger(__name__)
+
+
+class ScanFilters(BaseModel):
+    categories: list[str] = []
+    companies: list[str] = []
+    keyword: str | None = None
+
+
+class ScanError(BaseModel):
+    portal: str
+    platform: str
+    error: str
+
+
+class ScanResult(BaseModel):
+    total_fetched: int
+    new: int
+    duplicates: int
+    jobs: list[NormalizedJob]
+    errors: list[ScanError]
+
+
+class PortalScanner:
+    def __init__(
+        self,
+        config: PortalsConfig,
+        adapters: dict[str, Any],
+        normalizers: dict[str, JobNormalizer],
+        event_bus: Any,
+    ) -> None:
+        self._config = config
+        self._adapters = adapters
+        self._normalizers = normalizers
+        self._event_bus = event_bus
+
+    def _filter_portals(self, filters: ScanFilters) -> list[PortalEntry]:
+        portals = self._config.portals
+        if filters.categories:
+            portals = [
+                p for p in portals
+                if any(c in p.categories for c in filters.categories)
+            ]
+        if filters.companies:
+            portals = [p for p in portals if p.name in filters.companies]
+        return portals
+
+    async def scan(self, filters: ScanFilters) -> ScanResult:
+        portals = self._filter_portals(filters)
+        all_jobs: list[NormalizedJob] = []
+        errors: list[ScanError] = []
+        total_fetched = 0
+        seen_dedup_keys: set[str] = set()
+
+        for portal in portals:
+            adapter = self._adapters.get(portal.platform)
+            normalizer = self._normalizers.get(portal.platform)
+            if adapter is None or normalizer is None:
+                logger.warning("No adapter/normalizer for platform: %s", portal.platform)
+                continue
+
+            try:
+                raw_jobs = await adapter.fetch_jobs(
+                    board_id=portal.board_id,
+                    company_name=portal.name,
+                )
+            except Exception as exc:
+                logger.exception("Failed to scan portal %s", portal.name)
+                errors.append(ScanError(
+                    portal=portal.name,
+                    platform=portal.platform,
+                    error=str(exc),
+                ))
+                continue
+
+            total_fetched += len(raw_jobs)
+
+            for raw in raw_jobs:
+                normalized_data = normalizer.normalize(raw)
+                job = NormalizedJob(
+                    id=str(uuid.uuid4()),
+                    source=portal.platform,
+                    source_type="api",
+                    **normalized_data,
+                )
+                dedup = job.dedup_key()
+                if dedup not in seen_dedup_keys:
+                    seen_dedup_keys.add(dedup)
+                    all_jobs.append(job)
+
+        duplicates = total_fetched - len(all_jobs)
+
+        if all_jobs:
+            event = JobsIngestedEvent(
+                payload={
+                    "job_ids": [j.id for j in all_jobs],
+                    "source": "portal_scan",
+                },
+            )
+            await self._event_bus.publish(event)
+
+        return ScanResult(
+            total_fetched=total_fetched,
+            new=len(all_jobs),
+            duplicates=duplicates,
+            jobs=all_jobs,
+            errors=errors,
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_portal_scanner.py -v`
+Expected: All 7 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/domain/portal_scanner.py backend/tests/unit/ingestion/test_portal_scanner.py
+git commit -m "feat(ingestion): add portal scanner orchestrator with filtering, dedup, and error collection"
+```
+
+---
+
+## Task 12: API routes for portal scanning
+
+**Files:**
+- Modify: `backend/src/hiresense/ingestion/api/routes.py`
+- Create: `backend/tests/unit/ingestion/test_scan_routes.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `backend/tests/unit/ingestion/test_scan_routes.py`:
+
+```python
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from hiresense.ingestion.api.routes import router, get_portal_scanner, get_portals_config
+from hiresense.ingestion.domain.portal_scanner import PortalScanner, ScanFilters, ScanResult, ScanError
+from hiresense.ingestion.domain.portal_config import PortalsConfig, PortalEntry
+from hiresense.ingestion.domain.models import NormalizedJob
+
+
+def _make_app(scanner: PortalScanner, config: PortalsConfig) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_portal_scanner] = lambda: scanner
+    app.dependency_overrides[get_portals_config] = lambda: config
+    return app
+
+
+class FakePortalScanner:
+    def __init__(self, result: ScanResult) -> None:
+        self._result = result
+        self.last_filters: ScanFilters | None = None
+
+    async def scan(self, filters: ScanFilters) -> ScanResult:
+        self.last_filters = filters
+        return self._result
+
+
+SAMPLE_JOB = NormalizedJob(
+    id="abc",
+    title="SWE",
+    company="Anthropic",
+    description="Build stuff",
+    skills=[],
+    location="Remote",
+    source="greenhouse",
+    source_type="api",
+    url="https://example.com/abc",
+)
+
+
+def test_scan_portals_returns_results() -> None:
+    result = ScanResult(total_fetched=1, new=1, duplicates=0, jobs=[SAMPLE_JOB], errors=[])
+    scanner = FakePortalScanner(result)
+    config = PortalsConfig(portals=[])
+
+    app = _make_app(scanner, config)
+    client = TestClient(app)
+
+    response = client.post("/ingestion/scan-portals", json={})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_fetched"] == 1
+    assert data["new"] == 1
+    assert len(data["jobs"]) == 1
+    assert data["jobs"][0]["title"] == "SWE"
+
+
+def test_scan_portals_passes_filters() -> None:
+    result = ScanResult(total_fetched=0, new=0, duplicates=0, jobs=[], errors=[])
+    scanner = FakePortalScanner(result)
+    config = PortalsConfig(portals=[])
+
+    app = _make_app(scanner, config)
+    client = TestClient(app)
+
+    client.post("/ingestion/scan-portals", json={
+        "categories": ["ai-research"],
+        "companies": ["Anthropic"],
+        "keyword": "python",
+    })
+    assert scanner.last_filters.categories == ["ai-research"]
+    assert scanner.last_filters.companies == ["Anthropic"]
+    assert scanner.last_filters.keyword == "python"
+
+
+def test_scan_portals_returns_errors() -> None:
+    result = ScanResult(
+        total_fetched=0,
+        new=0,
+        duplicates=0,
+        jobs=[],
+        errors=[ScanError(portal="X", platform="greenhouse", error="timeout")],
+    )
+    scanner = FakePortalScanner(result)
+    config = PortalsConfig(portals=[])
+
+    app = _make_app(scanner, config)
+    client = TestClient(app)
+
+    response = client.post("/ingestion/scan-portals", json={})
+    data = response.json()
+    assert len(data["errors"]) == 1
+    assert data["errors"][0]["portal"] == "X"
+
+
+def test_get_portals_config() -> None:
+    config = PortalsConfig(portals=[
+        PortalEntry(name="Anthropic", platform="greenhouse", board_id="anthropic", categories=["ai"]),
+    ])
+    scanner = FakePortalScanner(ScanResult(total_fetched=0, new=0, duplicates=0, jobs=[], errors=[]))
+
+    app = _make_app(scanner, config)
+    client = TestClient(app)
+
+    response = client.get("/ingestion/portals")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["name"] == "Anthropic"
+    assert data[0]["categories"] == ["ai"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_scan_routes.py -v`
+Expected: FAIL — `ImportError` (get_portal_scanner not defined yet)
+
+- [ ] **Step 3: Add new endpoints to routes.py**
+
+Add the following to `backend/src/hiresense/ingestion/api/routes.py`:
+
+```python
+from hiresense.ingestion.domain.portal_scanner import PortalScanner, ScanFilters, ScanResult
+from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
+
+
+def get_portal_scanner() -> PortalScanner:
+    raise NotImplementedError("Must be overridden during app startup via dependency_overrides")
+
+
+def get_portals_config() -> PortalsConfig:
+    raise NotImplementedError("Must be overridden during app startup via dependency_overrides")
+
+
+@router.post("/scan-portals", response_model=ScanResult)
+async def scan_portals(
+    filters: ScanFilters,
+    scanner: Annotated[PortalScanner, Depends(get_portal_scanner)],
+) -> ScanResult:
+    return await scanner.scan(filters)
+
+
+@router.get("/portals", response_model=list[PortalEntry])
+async def list_portals(
+    config: Annotated[PortalsConfig, Depends(get_portals_config)],
+) -> list[PortalEntry]:
+    return config.portals
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/test_scan_routes.py -v`
+Expected: All 4 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/api/routes.py backend/tests/unit/ingestion/test_scan_routes.py
+git commit -m "feat(ingestion): add POST /scan-portals and GET /portals API endpoints"
+```
+
+---
+
+## Task 13: Wire portal scanner into app factory
+
+**Files:**
+- Modify: `backend/src/hiresense/main.py`
+
+- [ ] **Step 1: Add imports**
+
+Add these imports to `backend/src/hiresense/main.py`:
+
+```python
+from pathlib import Path
+from hiresense.ingestion.adapters.greenhouse_adapter import GreenhouseAdapter
+from hiresense.ingestion.adapters.lever_adapter import LeverAdapter
+from hiresense.ingestion.adapters.ashby_adapter import AshbyAdapter
+from hiresense.ingestion.domain.normalizers.greenhouse_normalizer import GreenhouseNormalizer
+from hiresense.ingestion.domain.normalizers.lever_normalizer import LeverNormalizer
+from hiresense.ingestion.domain.normalizers.ashby_normalizer import AshbyNormalizer
+from hiresense.ingestion.domain.portal_config import load_portals_config
+from hiresense.ingestion.domain.portal_scanner import PortalScanner
+from hiresense.ingestion.api.routes import get_portal_scanner, get_portals_config
+```
+
+- [ ] **Step 2: Wire portal scanner after existing ingestion setup**
+
+Add this block after the existing ingestion orchestrator wiring in `create_app()`:
+
+```python
+    # --- Portal scanning ---
+    portals_config_path = Path(__file__).parent / settings.portals_config_path
+    portals_config = load_portals_config(portals_config_path)
+
+    portal_adapters = {
+        "greenhouse": GreenhouseAdapter(
+            http_client=http_client,
+            base_url=settings.greenhouse_api_url,
+            timeout=settings.portal_scan_timeout,
+        ),
+        "lever": LeverAdapter(
+            http_client=http_client,
+            base_url=settings.lever_api_url,
+            timeout=settings.portal_scan_timeout,
+        ),
+        "ashby": AshbyAdapter(
+            http_client=http_client,
+            base_url=settings.ashby_api_url,
+            timeout=settings.portal_scan_timeout,
+        ),
+    }
+
+    portal_normalizers = {
+        "greenhouse": GreenhouseNormalizer(),
+        "lever": LeverNormalizer(),
+        "ashby": AshbyNormalizer(),
+    }
+
+    portal_scanner = PortalScanner(
+        config=portals_config,
+        adapters=portal_adapters,
+        normalizers=portal_normalizers,
+        event_bus=event_bus,
+    )
+
+    app.dependency_overrides[get_portal_scanner] = lambda: portal_scanner
+    app.dependency_overrides[get_portals_config] = lambda: portals_config
+```
+
+- [ ] **Step 3: Run all ingestion tests to verify nothing broke**
+
+Run: `cd backend && uv run pytest tests/unit/ingestion/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/src/hiresense/main.py
+git commit -m "feat(app): wire portal scanner with Greenhouse, Lever, and Ashby adapters"
+```
+
+---
+
+## Task 14: Frontend models for portal scanning
+
+**Files:**
+- Create: `frontend/src/app/core/models/portal-entry.model.ts`
+- Create: `frontend/src/app/core/models/scan-portals-request.model.ts`
+- Create: `frontend/src/app/core/models/scan-result.model.ts`
+
+- [ ] **Step 1: Create PortalEntry model**
+
+Create `frontend/src/app/core/models/portal-entry.model.ts`:
+
+```typescript
+export interface PortalEntry {
+  name: string;
+  platform: 'greenhouse' | 'lever' | 'ashby';
+  board_id: string;
+  categories: string[];
+}
+```
+
+- [ ] **Step 2: Create ScanPortalsRequest model**
+
+Create `frontend/src/app/core/models/scan-portals-request.model.ts`:
+
+```typescript
+export interface ScanPortalsRequest {
+  categories?: string[];
+  companies?: string[];
+  keyword?: string;
+}
+```
+
+- [ ] **Step 3: Create ScanResult model**
+
+Create `frontend/src/app/core/models/scan-result.model.ts`:
+
+```typescript
+import { NormalizedJob } from './normalized-job.model';
+
+export interface ScanError {
+  portal: string;
+  platform: string;
+  error: string;
+}
+
+export interface ScanResult {
+  total_fetched: number;
+  new: number;
+  duplicates: number;
+  jobs: NormalizedJob[];
+  errors: ScanError[];
+}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/core/models/portal-entry.model.ts frontend/src/app/core/models/scan-portals-request.model.ts frontend/src/app/core/models/scan-result.model.ts
+git commit -m "feat(frontend): add portal scanning TypeScript models"
+```
+
+---
+
+## Task 15: Frontend ingestion page — scan portals UI
+
+**Files:**
+- Modify: `frontend/src/app/pages/ingestion/ingestion.component.ts`
+- Modify: `frontend/src/app/pages/ingestion/ingestion.component.html`
+
+- [ ] **Step 1: Add scan state and methods to component**
+
+Add these imports and properties to `frontend/src/app/pages/ingestion/ingestion.component.ts`:
+
+```typescript
+import { PortalEntry } from '../../core/models/portal-entry.model';
+import { ScanPortalsRequest } from '../../core/models/scan-portals-request.model';
+import { ScanResult, ScanError } from '../../core/models/scan-result.model';
+```
+
+Add these signals and methods to the component class:
+
+```typescript
+  // Portal scanning state
+  portals = signal<PortalEntry[]>([]);
+  availableCategories = signal<string[]>([]);
+  selectedCategories = signal<string[]>([]);
+  selectedCompanies = signal<string[]>([]);
+  scanKeyword = signal('');
+  scanning = signal(false);
+  scanSummary = signal('');
+  scanErrors = signal<ScanError[]>([]);
+  showFilters = signal(false);
+
+  ngOnInit(): void {
+    this.loadPortals();
+  }
+
+  loadPortals(): void {
+    this.http.get<PortalEntry[]>(`${environment.apiUrl}/ingestion/portals`).subscribe({
+      next: (portals) => {
+        this.portals.set(portals);
+        const categories = [...new Set(portals.flatMap(p => p.categories))].sort();
+        this.availableCategories.set(categories);
+      },
+    });
+  }
+
+  scanPortals(): void {
+    this.scanning.set(true);
+    this.scanSummary.set('');
+    this.scanErrors.set([]);
+
+    const request: ScanPortalsRequest = {};
+    if (this.selectedCategories().length) request.categories = this.selectedCategories();
+    if (this.selectedCompanies().length) request.companies = this.selectedCompanies();
+    if (this.scanKeyword()) request.keyword = this.scanKeyword();
+
+    this.http.post<ScanResult>(`${environment.apiUrl}/ingestion/scan-portals`, request).subscribe({
+      next: (result) => {
+        this.jobs.update(existing => [...existing, ...result.jobs]);
+        this.scanSummary.set(
+          `Found ${result.new} new jobs (${result.duplicates} duplicates).` +
+          (result.errors.length ? ` ${result.errors.length} portal(s) failed.` : '')
+        );
+        this.scanErrors.set(result.errors);
+        this.scanning.set(false);
+      },
+      error: (err) => {
+        this.error.set(err.error?.detail || 'Failed to scan portals');
+        this.scanning.set(false);
+      },
+    });
+  }
+
+  toggleFilters(): void {
+    this.showFilters.update(v => !v);
+  }
+```
+
+- [ ] **Step 2: Add scan portals template section**
+
+Add the following to `frontend/src/app/pages/ingestion/ingestion.component.html`, after the existing fetch jobs button section:
+
+```html
+<!-- Portal Scanning Section -->
+<section class="scan-section">
+  <div class="scan-header">
+    <button (click)="scanPortals()" [disabled]="scanning()">
+      {{ scanning() ? 'Scanning...' : 'Scan Portals' }}
+    </button>
+    <button (click)="toggleFilters()" class="filter-toggle">
+      {{ showFilters() ? 'Hide Filters' : 'Show Filters' }}
+    </button>
+  </div>
+
+  @if (showFilters()) {
+    <div class="scan-filters">
+      <div class="filter-group">
+        <label>Categories</label>
+        <select multiple (change)="onCategoryChange($event)">
+          @for (cat of availableCategories(); track cat) {
+            <option [value]="cat">{{ cat }}</option>
+          }
+        </select>
+      </div>
+      <div class="filter-group">
+        <label>Companies</label>
+        <select multiple (change)="onCompanyChange($event)">
+          @for (portal of portals(); track portal.board_id) {
+            <option [value]="portal.name">{{ portal.name }}</option>
+          }
+        </select>
+      </div>
+      <div class="filter-group">
+        <label>Keyword</label>
+        <input type="text" [value]="scanKeyword()" (input)="onKeywordInput($event)" placeholder="e.g. engineer" />
+      </div>
+    </div>
+  }
+
+  @if (scanSummary()) {
+    <div class="scan-summary">{{ scanSummary() }}</div>
+  }
+
+  @if (scanErrors().length) {
+    <details class="scan-errors">
+      <summary>{{ scanErrors().length }} portal(s) failed</summary>
+      <ul>
+        @for (err of scanErrors(); track err.portal) {
+          <li><strong>{{ err.portal }}</strong> ({{ err.platform }}): {{ err.error }}</li>
+        }
+      </ul>
+    </details>
+  }
+</section>
+```
+
+- [ ] **Step 3: Add helper methods for template bindings**
+
+Add these methods to the component class:
+
+```typescript
+  onCategoryChange(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    const selected = Array.from(select.selectedOptions).map(o => o.value);
+    this.selectedCategories.set(selected);
+  }
+
+  onCompanyChange(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    const selected = Array.from(select.selectedOptions).map(o => o.value);
+    this.selectedCompanies.set(selected);
+  }
+
+  onKeywordInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.scanKeyword.set(input.value);
+  }
+```
+
+- [ ] **Step 4: Verify the frontend builds**
+
+Run: `cd frontend && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/app/pages/ingestion/ingestion.component.ts frontend/src/app/pages/ingestion/ingestion.component.html
+git commit -m "feat(frontend): add scan portals UI with filters to ingestion page"
+```
+
+---
+
+## Task 16: Run full test suite and verify
+
+- [ ] **Step 1: Run all backend tests**
+
+Run: `cd backend && uv run pytest tests/ -v`
+Expected: All tests PASS
+
+- [ ] **Step 2: Run frontend build**
+
+Run: `cd frontend && npm run build`
+Expected: Build succeeds
+
+- [ ] **Step 3: Run linter**
+
+Run: `cd backend && uv run ruff check src/ tests/`
+Expected: No errors
+
+- [ ] **Step 4: Final commit if any lint fixes needed**
+
+```bash
+git add -A
+git commit -m "fix: address lint issues from portal scanning implementation"
+```

--- a/docs/superpowers/specs/2026-04-06-portal-scanning-design.md
+++ b/docs/superpowers/specs/2026-04-06-portal-scanning-design.md
@@ -1,0 +1,342 @@
+# Portal Scanning — Design Spec
+
+**Date:** 2026-04-06
+**Status:** Approved
+**Phase:** 1 of 6 (career-ops feature adoption roadmap)
+
+## Overview
+
+Extend the existing ingestion module with three new job board platform adapters — Greenhouse, Lever, and Ashby — enabling HireSense to scan 45+ company career pages via their public APIs. Companies are configured in a YAML registry file, making it easy to add or remove portals without code changes.
+
+## Goals
+
+- Scan company career pages across Greenhouse, Lever, and Ashby ATS platforms
+- Ship with a default company list, fully configurable via YAML
+- Reuse existing ingestion architecture (adapter pattern, normalizers, dedup, events)
+- Manual trigger now, architecture ready for scheduled scanning later
+- Prepare for future migration to DB-backed portal configuration
+
+## Non-Goals
+
+- Scheduled/cron scanning (future phase)
+- Database-backed portal config (future phase)
+- Scraping non-API career pages (HTML scraping)
+- Authentication-gated job boards
+
+---
+
+## Architecture
+
+### File Structure
+
+```
+backend/src/hiresense/ingestion/
+├── adapters/
+│   ├── remotive.py              (existing)
+│   ├── remoteok.py              (existing)
+│   ├── greenhouse_adapter.py    (new)
+│   ├── lever_adapter.py         (new)
+│   └── ashby_adapter.py         (new)
+├── domain/
+│   ├── normalizers/
+│   │   ├── remotive.py          (existing)
+│   │   ├── remoteok.py          (existing)
+│   │   ├── greenhouse.py        (new)
+│   │   ├── lever.py             (new)
+│   │   └── ashby.py             (new)
+│   └── services.py              (extend with scan_portals)
+├── config/
+│   └── portals.yml              (new — company registry)
+├── api/
+│   ├── routes.py                (extend with POST /scan-portals)
+│   └── dependencies.py          (existing)
+```
+
+### Dependency Flow
+
+```
+routes.py (POST /scan-portals)
+  → IngestionService.scan_portals(filters)
+    → load portals.yml, filter by category/company
+    → group portals by platform
+    → fan out to adapters (parallel across platforms, sequential within)
+    → normalize via platform-specific normalizer
+    → deduplicate against existing jobs
+    → publish JobsIngestedEvent
+    → return ScanResult
+```
+
+---
+
+## Portal Configuration
+
+### File: `backend/src/hiresense/ingestion/config/portals.yml`
+
+```yaml
+portals:
+  # AI Research Labs
+  - name: Anthropic
+    platform: greenhouse
+    board_id: anthropic
+    categories: [ai-research]
+
+  - name: OpenAI
+    platform: greenhouse
+    board_id: openai
+    categories: [ai-research]
+
+  - name: Mistral
+    platform: greenhouse
+    board_id: mistralai
+    categories: [ai-research]
+
+  - name: Cohere
+    platform: greenhouse
+    board_id: cohere
+    categories: [ai-research]
+
+  - name: LangChain
+    platform: greenhouse
+    board_id: langchain
+    categories: [ai-research]
+
+  # Voice Technology
+  - name: ElevenLabs
+    platform: ashby
+    board_id: elevenlabs
+    categories: [voice-tech]
+
+  - name: Deepgram
+    platform: greenhouse
+    board_id: deepgram
+    categories: [voice-tech]
+
+  # Development Platforms
+  - name: Retool
+    platform: lever
+    board_id: retool
+    categories: [dev-platforms]
+
+  - name: Vercel
+    platform: greenhouse
+    board_id: vercel
+    categories: [dev-platforms]
+
+  - name: Temporal
+    platform: greenhouse
+    board_id: temporal
+    categories: [dev-platforms]
+
+  # LLM Operations
+  - name: Weights & Biases
+    platform: greenhouse
+    board_id: wandb
+    categories: [llm-ops]
+
+  # Workflow Automation
+  - name: n8n
+    platform: greenhouse
+    board_id: n8n
+    categories: [workflow-automation]
+```
+
+### Config Model (Pydantic)
+
+```python
+class PortalEntry(BaseModel):
+    name: str
+    platform: Literal["greenhouse", "lever", "ashby"]
+    board_id: str
+    categories: list[str] = []
+
+class PortalsConfig(BaseModel):
+    portals: list[PortalEntry]
+```
+
+### Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORTALS_CONFIG_PATH` | `ingestion/config/portals.yml` | Path to portal registry (relative to backend/src/hiresense/) |
+| `PORTAL_SCAN_TIMEOUT` | `30` | HTTP timeout per portal in seconds |
+| `GREENHOUSE_API_URL` | `https://boards-api.greenhouse.io/v1/boards` | Greenhouse API base URL |
+| `LEVER_API_URL` | `https://api.lever.co/v0/postings` | Lever API base URL |
+| `ASHBY_API_URL` | `https://api.ashbyhq.com/posting-api/job-board` | Ashby API base URL |
+
+---
+
+## Platform Adapters
+
+Each adapter implements the existing source port interface and calls the platform's public API.
+
+### Greenhouse Adapter
+
+- **Endpoint:** `GET {GREENHOUSE_API_URL}/{board_id}/jobs?content=true`
+- **Auth:** None (public API)
+- **Response:** JSON array of job objects
+- **Key fields:** `title`, `location.name`, `content` (HTML), `absolute_url`, `updated_at`, `departments[].name`
+- **Pagination:** `?page=1&per_page=100` — iterate until empty page
+
+### Lever Adapter
+
+- **Endpoint:** `GET {LEVER_API_URL}/{board_id}?mode=json`
+- **Auth:** None (public postings API)
+- **Response:** JSON array of posting objects
+- **Key fields:** `text` (title), `categories.location`, `description` (HTML), `hostedUrl`, `createdAt`, `categories.team`
+- **Pagination:** `?skip=0&limit=100` with `hasNext` field
+
+### Ashby Adapter
+
+- **Endpoint:** `POST {ASHBY_API_URL}/{board_id}`
+- **Auth:** None (public posting API)
+- **Response:** JSON with `jobs[]` array
+- **Key fields:** `title`, `location`, `descriptionHtml`, `jobUrl`, `publishedAt`, `departmentName`
+- **Pagination:** Not paginated (returns all postings)
+
+---
+
+## Normalizer Mapping
+
+Each normalizer maps platform-specific fields to `NormalizedJobDTO`:
+
+| NormalizedJobDTO field | Greenhouse | Lever | Ashby |
+|---|---|---|---|
+| `title` | `title` | `text` | `title` |
+| `company` | from `portals.yml` entry | from `portals.yml` entry | from `portals.yml` entry |
+| `description` | `content` (strip HTML) | `description` (strip HTML) | `descriptionHtml` (strip HTML) |
+| `url` | `absolute_url` | `hostedUrl` | `jobUrl` |
+| `location` | `location.name` | `categories.location` | `location` |
+| `source` | `"greenhouse"` | `"lever"` | `"ashby"` |
+| `posted_at` | `updated_at` | `createdAt` | `publishedAt` |
+| `department` | `departments[0].name` | `categories.team` | `departmentName` |
+
+HTML stripping uses a shared utility that converts HTML to plain text, preserving paragraph breaks.
+
+**Note:** `NormalizedJobDTO` may need two new optional fields: `posted_at: datetime | None` and `department: str | None`. These should be added if not already present.
+
+---
+
+## API Endpoint
+
+### `POST /api/ingestion/scan-portals`
+
+**Request body (all fields optional):**
+
+```json
+{
+  "categories": ["ai-research", "voice-tech"],
+  "companies": ["Anthropic", "ElevenLabs"],
+  "keyword": "engineer"
+}
+```
+
+- Empty body scans all portals in `portals.yml`
+- `categories` — filter portals by category tag
+- `companies` — filter portals by company name
+- `keyword` — passed as query parameter to APIs that support search (Greenhouse `content` param)
+
+**Response:**
+
+```json
+{
+  "total_fetched": 45,
+  "new": 32,
+  "duplicates": 13,
+  "jobs": [
+    {
+      "title": "Senior Backend Engineer",
+      "company": "Anthropic",
+      "location": "San Francisco, CA",
+      "url": "https://boards.greenhouse.io/anthropic/jobs/123",
+      "source": "greenhouse",
+      "posted_at": "2026-04-01T00:00:00Z"
+    }
+  ],
+  "errors": [
+    {
+      "portal": "ElevenLabs",
+      "platform": "ashby",
+      "error": "Request timeout after 30s"
+    }
+  ]
+}
+```
+
+### Request/Response Models (Pydantic)
+
+```python
+class ScanPortalsRequest(BaseModel):
+    categories: list[str] = []
+    companies: list[str] = []
+    keyword: str | None = None
+
+class ScanError(BaseModel):
+    portal: str
+    platform: str
+    error: str
+
+class ScanResult(BaseModel):
+    total_fetched: int
+    new: int
+    duplicates: int
+    jobs: list[NormalizedJobDTO]
+    errors: list[ScanError]
+```
+
+---
+
+## Error Handling
+
+- **Isolation:** Each portal scanned independently. A failure on one portal does not block others.
+- **Timeout:** Configurable via `PORTAL_SCAN_TIMEOUT` env var (default 30s per portal).
+- **Error collection:** Failed portals returned in `errors[]` alongside successful results.
+- **Rate limiting:** Requests are sequential within each platform (avoid hammering same API host), parallel across different platforms.
+- **Retry:** No automatic retries. User can re-trigger scan for failed portals.
+
+---
+
+## Deduplication
+
+- Reuse existing dedup logic: hash of `(url)` or `(title, company)` as fallback.
+- Jobs already ingested from Remotive/RemoteOK are deduped against portal scan results.
+- Scan response reports `new` vs `duplicates` counts.
+
+---
+
+## Frontend Changes
+
+### Ingestion Page Additions
+
+1. **"Scan Portals" button** — alongside existing "Fetch Jobs" button
+2. **Filter controls** (collapsible):
+   - Category multi-select dropdown (populated from `portals.yml` categories)
+   - Company multi-select dropdown (populated from `portals.yml` names)
+   - Keyword text input
+3. **Scan summary banner** — shows after scan: "Found 32 new jobs (13 duplicates). 1 portal failed."
+4. **Error details** — expandable section showing which portals failed and why
+5. **Results** — merge into existing job table with `source` column showing platform name
+
+### New API Calls
+
+```typescript
+// ingestion.service.ts
+scanPortals(filters: ScanPortalsRequest): Observable<ScanResult>
+getPortalConfig(): Observable<PortalEntry[]>  // for populating filter dropdowns
+```
+
+### New Backend Endpoint for Config
+
+```
+GET /api/ingestion/portals
+```
+
+Returns the parsed `portals.yml` so the frontend can populate filter dropdowns without duplicating the company list.
+
+---
+
+## Future Considerations
+
+- **DB-backed config:** Migrate `portals.yml` to a `portals` table, add CRUD API and admin UI
+- **Scheduled scanning:** Add a cron trigger that calls `scan_portals()` on an interval
+- **Webhook support:** Some ATS platforms support webhooks for new postings
+- **Additional platforms:** Wellfound, Workable, RemoteFront, direct HTML scraping

--- a/frontend/src/app/core/models/normalized-job.model.ts
+++ b/frontend/src/app/core/models/normalized-job.model.ts
@@ -1,0 +1,12 @@
+export interface NormalizedJob {
+  id: string;
+  title: string;
+  company: string;
+  description: string;
+  skills: string[];
+  location: string;
+  salary_range: string | null;
+  source: string;
+  url: string;
+  posted_date: string | null;
+}

--- a/frontend/src/app/core/models/portal-entry.model.ts
+++ b/frontend/src/app/core/models/portal-entry.model.ts
@@ -1,0 +1,6 @@
+export interface PortalEntry {
+  name: string;
+  platform: 'greenhouse' | 'lever' | 'ashby';
+  board_id: string;
+  categories: string[];
+}

--- a/frontend/src/app/core/models/scan-portals-request.model.ts
+++ b/frontend/src/app/core/models/scan-portals-request.model.ts
@@ -1,0 +1,5 @@
+export interface ScanPortalsRequest {
+  categories?: string[];
+  companies?: string[];
+  keyword?: string;
+}

--- a/frontend/src/app/core/models/scan-result.model.ts
+++ b/frontend/src/app/core/models/scan-result.model.ts
@@ -1,0 +1,15 @@
+import { NormalizedJob } from './normalized-job.model';
+
+export interface ScanError {
+  portal: string;
+  platform: string;
+  error: string;
+}
+
+export interface ScanResult {
+  total_fetched: number;
+  new: number;
+  duplicates: number;
+  jobs: NormalizedJob[];
+  errors: ScanError[];
+}

--- a/frontend/src/app/pages/ingestion/ingestion.component.html
+++ b/frontend/src/app/pages/ingestion/ingestion.component.html
@@ -10,6 +10,88 @@
     <div class="alert alert-error">{{ error() }}</div>
   }
 
+  <!-- Portal Scanning Section -->
+  <div class="section">
+    <div class="section-header">
+      <h2>Portal Scanning</h2>
+      <div class="section-actions">
+        <button (click)="toggleFilters()" class="btn-secondary">
+          @if (showFilters()) { Hide Filters } @else { Show Filters }
+        </button>
+        <button (click)="scanPortals()" [disabled]="scanning()" class="btn-primary">
+          @if (scanning()) { Scanning... } @else { Scan Portals }
+        </button>
+      </div>
+    </div>
+
+    @if (showFilters()) {
+      <div class="filter-panel">
+        <div class="filter-group">
+          <label for="category-select">Categories</label>
+          <select
+            id="category-select"
+            multiple
+            (change)="onCategoryChange($event)"
+            class="filter-select"
+          >
+            @for (cat of availableCategories(); track cat) {
+              <option [value]="cat">{{ cat }}</option>
+            }
+          </select>
+          @if (availableCategories().length === 0) {
+            <span class="filter-hint">No categories available</span>
+          }
+        </div>
+
+        <div class="filter-group">
+          <label for="company-select">Companies</label>
+          <select
+            id="company-select"
+            multiple
+            (change)="onCompanyChange($event)"
+            class="filter-select"
+          >
+            @for (portal of portals(); track portal.name) {
+              <option [value]="portal.name">{{ portal.name }}</option>
+            }
+          </select>
+          @if (portals().length === 0) {
+            <span class="filter-hint">No portals loaded</span>
+          }
+        </div>
+
+        <div class="filter-group">
+          <label for="keyword-input">Keyword</label>
+          <input
+            id="keyword-input"
+            type="text"
+            [value]="scanKeyword()"
+            (input)="onKeywordInput($event)"
+            placeholder="e.g. React, Python, remote..."
+            class="filter-input"
+          />
+        </div>
+      </div>
+    }
+
+    @if (scanSummary()) {
+      <div class="alert alert-info">{{ scanSummary() }}</div>
+    }
+
+    @if (scanErrors().length > 0) {
+      <details class="scan-errors">
+        <summary>{{ scanErrors().length }} portal error(s)</summary>
+        <ul>
+          @for (err of scanErrors(); track err.portal) {
+            <li>
+              <strong>{{ err.portal }}</strong> ({{ err.platform }}): {{ err.error }}
+            </li>
+          }
+        </ul>
+      </details>
+    }
+  </div>
+
   @if (jobs().length > 0) {
     <div class="stats">
       <span class="stat">{{ jobs().length }} jobs found</span>

--- a/frontend/src/app/pages/ingestion/ingestion.component.ts
+++ b/frontend/src/app/pages/ingestion/ingestion.component.ts
@@ -1,19 +1,10 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../../environments/environment';
-
-interface NormalizedJob {
-  id: string;
-  title: string;
-  company: string;
-  description: string;
-  skills: string[];
-  location: string;
-  salary_range: string | null;
-  source: string;
-  url: string;
-  posted_date: string | null;
-}
+import { NormalizedJob } from '../../core/models/normalized-job.model';
+import { PortalEntry } from '../../core/models/portal-entry.model';
+import { ScanPortalsRequest } from '../../core/models/scan-portals-request.model';
+import { ScanError, ScanResult } from '../../core/models/scan-result.model';
 
 interface FetchResponse {
   count: number;
@@ -27,12 +18,27 @@ interface FetchResponse {
   templateUrl: './ingestion.component.html',
   styleUrl: './ingestion.component.scss',
 })
-export class IngestionComponent {
+export class IngestionComponent implements OnInit {
   jobs = signal<NormalizedJob[]>([]);
   loading = signal(false);
   error = signal('');
 
+  // Portal scanning state
+  portals = signal<PortalEntry[]>([]);
+  availableCategories = signal<string[]>([]);
+  selectedCategories = signal<string[]>([]);
+  selectedCompanies = signal<string[]>([]);
+  scanKeyword = signal('');
+  scanning = signal(false);
+  scanSummary = signal('');
+  scanErrors = signal<ScanError[]>([]);
+  showFilters = signal(false);
+
   constructor(private http: HttpClient) {}
+
+  ngOnInit(): void {
+    this.loadPortals();
+  }
 
   fetchJobs(): void {
     this.loading.set(true);
@@ -47,5 +53,77 @@ export class IngestionComponent {
         this.loading.set(false);
       },
     });
+  }
+
+  loadPortals(): void {
+    this.http.get<PortalEntry[]>(`${environment.apiUrl}/ingestion/portals`).subscribe({
+      next: (portals) => {
+        this.portals.set(portals);
+        const allCategories = portals.flatMap((p) => p.categories);
+        const unique = [...new Set(allCategories)].sort();
+        this.availableCategories.set(unique);
+      },
+      error: () => {
+        // Non-fatal: portal list is optional
+      },
+    });
+  }
+
+  scanPortals(): void {
+    this.scanning.set(true);
+    this.scanSummary.set('');
+    this.scanErrors.set([]);
+
+    const body: ScanPortalsRequest = {};
+    if (this.selectedCategories().length > 0) {
+      body.categories = this.selectedCategories();
+    }
+    if (this.selectedCompanies().length > 0) {
+      body.companies = this.selectedCompanies();
+    }
+    const kw = this.scanKeyword().trim();
+    if (kw) {
+      body.keyword = kw;
+    }
+
+    this.http.post<ScanResult>(`${environment.apiUrl}/ingestion/scan-portals`, body).subscribe({
+      next: (res) => {
+        // Merge new jobs (deduplicate by id)
+        const existing = this.jobs();
+        const existingIds = new Set(existing.map((j) => j.id));
+        const merged = [...existing, ...res.jobs.filter((j) => !existingIds.has(j.id))];
+        this.jobs.set(merged);
+        this.scanSummary.set(
+          `Scan complete: ${res.total_fetched} fetched, ${res.new} new, ${res.duplicates} duplicates.`,
+        );
+        this.scanErrors.set(res.errors);
+        this.scanning.set(false);
+      },
+      error: (err) => {
+        this.scanSummary.set(err.error?.detail || 'Scan failed.');
+        this.scanning.set(false);
+      },
+    });
+  }
+
+  toggleFilters(): void {
+    this.showFilters.update((v) => !v);
+  }
+
+  onCategoryChange(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    const selected = Array.from(select.selectedOptions).map((o) => o.value);
+    this.selectedCategories.set(selected);
+  }
+
+  onCompanyChange(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    const selected = Array.from(select.selectedOptions).map((o) => o.value);
+    this.selectedCompanies.set(selected);
+  }
+
+  onKeywordInput(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    this.scanKeyword.set(input.value);
   }
 }


### PR DESCRIPTION
## Summary

- Add three new ATS platform adapters (Greenhouse, Lever, Ashby) to the ingestion module for scanning company career pages via public APIs
- Ship with a configurable YAML registry of 12 default companies across 5 categories (AI research, voice tech, dev platforms, LLM ops, workflow automation)
- New `POST /api/ingestion/scan-portals` endpoint with category/company/keyword filtering, deduplication, and error isolation per portal
- New `GET /api/ingestion/portals` endpoint for frontend to populate filter dropdowns
- Frontend scan portals UI with collapsible filters, summary banner, and error details on the ingestion page
- 54 new unit tests covering all adapters, normalizers, scanner orchestrator, and API routes (132 total passing)

## Test plan

- [x] All 132 backend unit tests pass (`uv run pytest tests/ -v`)
- [x] Frontend builds clean (`npm run build`)
- [x] Lint clean on new code (`ruff check`)
- [ ] Manual test: scan portals with default config and verify jobs returned
- [ ] Manual test: filter by category and verify only matching portals scanned
- [ ] Manual test: verify error handling when a portal is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)