### PR TITLE
feat: add profile file upload and matching preload

### DIFF
--- a/backend/alembic/versions/004_create_profiles.py
+++ b/backend/alembic/versions/004_create_profiles.py
@@ -24,10 +24,10 @@ def upgrade() -> None:
         sa.Column("email", sa.String(255), nullable=True),
         sa.Column("phone", sa.String(100), nullable=True),
         sa.Column("location", sa.String(255), nullable=True),
-        sa.Column("sections", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("sections", sa.JSON(), nullable=True),
         sa.Column("raw_tex", sa.Text(), nullable=True),
         sa.Column("language", sa.String(10), nullable=False, server_default="en"),
-        sa.Column("skills", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("skills", sa.JSON(), nullable=True),
         sa.Column("original_filename", sa.String(500), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
     )

--- a/backend/alembic/versions/004_create_profiles.py
+++ b/backend/alembic/versions/004_create_profiles.py
@@ -1,0 +1,39 @@
+"""create profiles table
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-04-12
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "profiles",
+        sa.Column("id", sa.Uuid(), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("email", sa.String(255), nullable=True),
+        sa.Column("phone", sa.String(100), nullable=True),
+        sa.Column("location", sa.String(255), nullable=True),
+        sa.Column("sections", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("raw_tex", sa.Text(), nullable=True),
+        sa.Column("language", sa.String(10), nullable=False, server_default="en"),
+        sa.Column("skills", sa.dialects.postgresql.JSONB(), nullable=True),
+        sa.Column("original_filename", sa.String(500), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+    )
+    op.create_index("ix_profiles_created_at", "profiles", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_profiles_created_at", table_name="profiles")
+    op.drop_table("profiles")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "beautifulsoup4>=4.12.0",
     "pyyaml>=6.0",
     "psycopg2-binary>=2.9.11",
+    "pymupdf>=1.25.0",
 ]
 
 [project.optional-dependencies]

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -113,6 +113,9 @@ class Settings(BaseSettings):
     weight_application: int = 10
     weight_interview: int = 10
 
+    # Upload
+    max_upload_bytes: int = 10 * 1024 * 1024  # 10 MB
+
     # Batch processing
     batch_concurrency: int = 3
 

--- a/backend/src/hiresense/infrastructure/registry.py
+++ b/backend/src/hiresense/infrastructure/registry.py
@@ -1,5 +1,6 @@
 """Import all ORM models so Base.metadata is fully populated for Alembic."""
 
 from hiresense.interview.domain.models import Story  # noqa: F401
+from hiresense.profile.domain.models import Profile  # noqa: F401
 from hiresense.research.domain.models import CompanyResearch  # noqa: F401
 from hiresense.tracking.domain.models import TrackedApplication  # noqa: F401

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -47,6 +47,13 @@ async def scan_portals(
     return await scanner.scan(filters)
 
 
+@router.get("/jobs", response_model=list[NormalizedJob])
+async def list_jobs(
+    orchestrator: Annotated[IngestionOrchestrator, Depends(get_ingestion_orchestrator)],
+) -> list[NormalizedJob]:
+    return orchestrator.list_jobs()
+
+
 @router.get("/portals", response_model=list[PortalEntry])
 async def list_portals(
     config: Annotated[PortalsConfig, Depends(get_portals_config)],

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -95,6 +95,9 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
+    # --- Settings ---
+    app.state.settings = settings
+
     # --- Shared infrastructure ---
     event_bus = InMemoryEventBus()
 

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -60,7 +60,8 @@ from hiresense.optimization.api.provider import OptimizationProvider
 from hiresense.optimization.domain import CVOptimizer
 from hiresense.profile.api import router as profile_router
 from hiresense.profile.api.provider import ProfileProvider
-from hiresense.profile.domain import LaTeXParser, ProfileService, SkillExtractor
+from hiresense.profile.domain import LaTeXParser, PDFParser, ProfileService, SkillExtractor
+from hiresense.profile.infrastructure import ProfileRepository
 from hiresense.tracking.api import router as tracking_router
 from hiresense.tracking.api.provider import TrackingProvider
 from hiresense.tracking.domain import TrackingService
@@ -200,9 +201,17 @@ def create_app() -> FastAPI:
     app.include_router(ingestion_router)
 
     # --- Profile ---
+    profile_repo = ProfileRepository(session_factory=sync_session_factory)
     latex_parser = LaTeXParser()
+    pdf_parser = PDFParser(llm=llm)
     skill_extractor = SkillExtractor()
-    profile_service = ProfileService(parser=latex_parser, skill_extractor=skill_extractor)
+    profile_service = ProfileService(
+        parser=latex_parser,
+        skill_extractor=skill_extractor,
+        repository=profile_repo,
+        pdf_parser=pdf_parser,
+        cv_directory=settings.cv_directory,
+    )
     app.state.profile = ProfileProvider(profile_service=profile_service)
     app.include_router(profile_router)
 

--- a/backend/src/hiresense/profile/api/routes.py
+++ b/backend/src/hiresense/profile/api/routes.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Annotated
+from pathlib import Path
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile, status
 from pydantic import BaseModel
 
 from hiresense.profile.api.dependencies import get_profile_service
@@ -28,18 +29,30 @@ async def upload_cv(
 
 @router.post("/upload-file", response_model=CandidateProfile)
 async def upload_file(
+    request: Request,
     service: Annotated[object, Depends(get_profile_service)],
     file: UploadFile = File(...),
-    language: str = Form("en"),
+    language: Literal["en", "es"] = Form("en"),
 ) -> CandidateProfile:
     filename = file.filename or "unknown"
-    ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    ext = Path(filename).suffix.lower()
     if ext not in _ALLOWED_EXTENSIONS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Unsupported file type: {ext}. Allowed: {', '.join(_ALLOWED_EXTENSIONS)}",
         )
+    max_bytes = request.app.state.settings.max_upload_bytes
+    if file.size and file.size > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {max_bytes // (1024 * 1024)} MB",
+        )
     file_bytes = await file.read()
+    if len(file_bytes) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {max_bytes // (1024 * 1024)} MB",
+        )
     return await service.parse_file_and_create(file_bytes, filename, language)
 
 

--- a/backend/src/hiresense/profile/api/routes.py
+++ b/backend/src/hiresense/profile/api/routes.py
@@ -2,13 +2,15 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile, status
 from pydantic import BaseModel
 
 from hiresense.profile.api.dependencies import get_profile_service
 from hiresense.profile.domain.models import CandidateProfile
 
 router = APIRouter(prefix="/profile", tags=["profile"])
+
+_ALLOWED_EXTENSIONS = {".pdf", ".tex"}
 
 
 class UploadCVRequest(BaseModel):
@@ -22,6 +24,33 @@ async def upload_cv(
     service: Annotated[object, Depends(get_profile_service)],
 ) -> CandidateProfile:
     return await service.parse_and_create(body.tex_content, body.language)
+
+
+@router.post("/upload-file", response_model=CandidateProfile)
+async def upload_file(
+    service: Annotated[object, Depends(get_profile_service)],
+    file: UploadFile = File(...),
+    language: str = Form("en"),
+) -> CandidateProfile:
+    filename = file.filename or "unknown"
+    ext = "." + filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    if ext not in _ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported file type: {ext}. Allowed: {', '.join(_ALLOWED_EXTENSIONS)}",
+        )
+    file_bytes = await file.read()
+    return await service.parse_file_and_create(file_bytes, filename, language)
+
+
+@router.get("/current", response_model=CandidateProfile)
+async def get_current_profile(
+    service: Annotated[object, Depends(get_profile_service)],
+) -> CandidateProfile:
+    profile = await service.get_current_profile()
+    if profile is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="No profile found")
+    return profile
 
 
 @router.get("/{profile_id}", response_model=CandidateProfile)

--- a/backend/src/hiresense/profile/domain/__init__.py
+++ b/backend/src/hiresense/profile/domain/__init__.py
@@ -1,5 +1,6 @@
 from hiresense.profile.domain.latex_parser import LaTeXParser
+from hiresense.profile.domain.pdf_parser import PDFParser
 from hiresense.profile.domain.services import ProfileService
 from hiresense.profile.domain.skill_extractor import SkillExtractor
 
-__all__ = ["LaTeXParser", "ProfileService", "SkillExtractor"]
+__all__ = ["LaTeXParser", "PDFParser", "ProfileService", "SkillExtractor"]

--- a/backend/src/hiresense/profile/domain/models.py
+++ b/backend/src/hiresense/profile/domain/models.py
@@ -4,8 +4,7 @@ import uuid as uuid_mod
 from datetime import datetime
 
 from pydantic import BaseModel, Field
-from sqlalchemy import DateTime, Index, String, Text, Uuid, func
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import DateTime, Index, JSON, String, Text, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from hiresense.infrastructure.database import Base
@@ -42,10 +41,10 @@ class Profile(Base):
     email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     phone: Mapped[str | None] = mapped_column(String(100), nullable=True)
     location: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    sections: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    sections: Mapped[list | None] = mapped_column(JSON, nullable=True)
     raw_tex: Mapped[str | None] = mapped_column(Text, nullable=True)
     language: Mapped[str] = mapped_column(String(10), default="en")
-    skills: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    skills: Mapped[list | None] = mapped_column(JSON, nullable=True)
     original_filename: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now()

--- a/backend/src/hiresense/profile/domain/models.py
+++ b/backend/src/hiresense/profile/domain/models.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
+import uuid as uuid_mod
+from datetime import datetime
+
 from pydantic import BaseModel, Field
+from sqlalchemy import DateTime, Index, String, Text, Uuid, func
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+
+from hiresense.infrastructure.database import Base
 
 
 class CVSection(BaseModel):
@@ -19,3 +27,26 @@ class CandidateProfile(BaseModel):
     language: str = "en"
     skills: list[str] = Field(default_factory=list)
     embedding: list[float] | None = None
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+    __table_args__ = (
+        Index("ix_profiles_created_at", "created_at"),
+    )
+
+    id: Mapped[uuid_mod.UUID] = mapped_column(
+        Uuid, primary_key=True, default=uuid_mod.uuid4
+    )
+    name: Mapped[str] = mapped_column(String(255))
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    phone: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    location: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    sections: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    raw_tex: Mapped[str | None] = mapped_column(Text, nullable=True)
+    language: Mapped[str] = mapped_column(String(10), default="en")
+    skills: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    original_filename: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    created_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), server_default=func.now()
+    )

--- a/backend/src/hiresense/profile/domain/pdf_parser.py
+++ b/backend/src/hiresense/profile/domain/pdf_parser.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import pymupdf
+
+from hiresense.profile.domain.latex_parser import ParsedCV, ParsedSection
+
+if TYPE_CHECKING:
+    from hiresense.ports.llm import LLMPort
+
+logger = logging.getLogger(__name__)
+
+_EXTRACTION_SYSTEM_PROMPT = """\
+You are a CV/resume parser. Extract structured information from the provided CV text.
+Return ONLY valid JSON with this exact schema — no markdown, no explanation:
+{
+  "name": "Full Name",
+  "email": "email@example.com or null",
+  "phone": "phone number or null",
+  "location": "location or null",
+  "sections": [
+    {"name": "Section Title", "content": "Section content as plain text"}
+  ],
+  "skills": ["skill1", "skill2"]
+}
+Rules:
+- Extract ALL sections you can identify (Education, Experience, Skills, Projects, etc.)
+- For skills, extract individual technical skills, tools, languages, and frameworks
+- Keep section content as clean plain text, not HTML or LaTeX
+- If a field is not found, use null (for strings) or [] (for arrays)
+"""
+
+
+class PDFParser:
+    def __init__(self, llm: LLMPort | None = None) -> None:
+        self._llm = llm
+
+    def extract_text(self, file_bytes: bytes) -> str:
+        doc = pymupdf.open(stream=file_bytes, filetype="pdf")
+        pages = [page.get_text() for page in doc]
+        doc.close()
+        return "\n\n".join(pages)
+
+    async def parse(self, file_bytes: bytes) -> ParsedCV:
+        raw_text = self.extract_text(file_bytes)
+
+        if self._llm is None:
+            logger.warning("No LLM configured — returning raw PDF text without structured extraction")
+            return ParsedCV(name="", raw_tex=raw_text)
+
+        prompt = f"Extract structured information from this CV:\n\n{raw_text}"
+        response = await self._llm.complete(prompt, system=_EXTRACTION_SYSTEM_PROMPT)
+
+        return self._parse_llm_response(response, raw_text)
+
+    def _parse_llm_response(self, response: str, raw_text: str) -> ParsedCV:
+        try:
+            cleaned = response.strip()
+            if cleaned.startswith("```"):
+                cleaned = cleaned.split("\n", 1)[1]
+                cleaned = cleaned.rsplit("```", 1)[0]
+
+            data = json.loads(cleaned)
+        except (json.JSONDecodeError, IndexError):
+            logger.error("Failed to parse LLM response as JSON")
+            return ParsedCV(name="", raw_tex=raw_text)
+
+        sections = [
+            ParsedSection(name=s.get("name", ""), content=s.get("content", ""))
+            for s in data.get("sections", [])
+            if s.get("name")
+        ]
+
+        return ParsedCV(
+            name=data.get("name", ""),
+            email=data.get("email"),
+            phone=data.get("phone"),
+            location=data.get("location"),
+            sections=sections,
+            raw_tex=raw_text,
+        )

--- a/backend/src/hiresense/profile/domain/services.py
+++ b/backend/src/hiresense/profile/domain/services.py
@@ -5,13 +5,13 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from hiresense.profile.domain.latex_parser import LaTeXParser
+from hiresense.profile.domain.latex_parser import LaTeXParser, ParsedCV
 from hiresense.profile.domain.models import CandidateProfile, CVSection, Profile
 from hiresense.profile.domain.skill_extractor import SkillExtractor
 
 if TYPE_CHECKING:
     from hiresense.profile.domain.pdf_parser import PDFParser
-    from hiresense.profile.infrastructure.repository import ProfileRepository
+    from hiresense.profile.ports.repository import ProfileRepositoryPort
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +21,7 @@ class ProfileService:
         self,
         parser: LaTeXParser,
         skill_extractor: SkillExtractor,
-        repository: ProfileRepository | None = None,
+        repository: ProfileRepositoryPort | None = None,
         pdf_parser: PDFParser | None = None,
         cv_directory: str = "./cvs",
     ) -> None:
@@ -120,11 +120,7 @@ class ProfileService:
         orm = self._repository.get_latest()
         return self._to_response(orm) if orm else None
 
-    def _extract_skills_from_parsed(self, parsed: object) -> list[str]:
-        from hiresense.profile.domain.latex_parser import ParsedCV
-
-        if not isinstance(parsed, ParsedCV):
-            return []
+    def _extract_skills_from_parsed(self, parsed: ParsedCV) -> list[str]:
         for section in parsed.sections:
             if "SKILL" in section.name.upper():
                 return self._skill_extractor.extract_from_tabular(section.content)
@@ -133,7 +129,8 @@ class ProfileService:
     def _save_original_file(self, profile_id: str, filename: str, file_bytes: bytes) -> None:
         originals_dir = self._cv_directory / "originals"
         originals_dir.mkdir(parents=True, exist_ok=True)
-        dest = originals_dir / f"{profile_id}_{filename}"
+        safe_name = Path(filename).name
+        dest = originals_dir / f"{profile_id}_{safe_name}"
         dest.write_bytes(file_bytes)
         logger.info("Saved original CV to %s", dest)
 

--- a/backend/src/hiresense/profile/domain/services.py
+++ b/backend/src/hiresense/profile/domain/services.py
@@ -1,22 +1,40 @@
 from __future__ import annotations
 
+import logging
 import uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from hiresense.profile.domain.latex_parser import LaTeXParser
-from hiresense.profile.domain.models import CandidateProfile, CVSection
+from hiresense.profile.domain.models import CandidateProfile, CVSection, Profile
 from hiresense.profile.domain.skill_extractor import SkillExtractor
+
+if TYPE_CHECKING:
+    from hiresense.profile.domain.pdf_parser import PDFParser
+    from hiresense.profile.infrastructure.repository import ProfileRepository
+
+logger = logging.getLogger(__name__)
 
 
 class ProfileService:
-    def __init__(self, parser: LaTeXParser, skill_extractor: SkillExtractor) -> None:
+    def __init__(
+        self,
+        parser: LaTeXParser,
+        skill_extractor: SkillExtractor,
+        repository: ProfileRepository | None = None,
+        pdf_parser: PDFParser | None = None,
+        cv_directory: str = "./cvs",
+    ) -> None:
         self._parser = parser
         self._skill_extractor = skill_extractor
+        self._repository = repository
+        self._pdf_parser = pdf_parser
+        self._cv_directory = Path(cv_directory)
         self._profiles: dict[str, CandidateProfile] = {}
 
     async def parse_and_create(self, tex_content: str, language: str = "en") -> CandidateProfile:
         parsed = self._parser.parse(tex_content)
 
-        # Extract skills from TECHNICAL SKILLS section if found
         skills: list[str] = []
         for section in parsed.sections:
             if "SKILL" in section.name.upper():
@@ -25,8 +43,9 @@ class ProfileService:
 
         sections = [CVSection(name=s.name, content=s.content) for s in parsed.sections]
 
+        profile_id = str(uuid.uuid4())
         profile = CandidateProfile(
-            id=str(uuid.uuid4()),
+            id=profile_id,
             name=parsed.name,
             email=parsed.email,
             phone=parsed.phone,
@@ -36,8 +55,117 @@ class ProfileService:
             language=language,
             skills=skills,
         )
-        self._profiles[profile.id] = profile
+
+        if self._repository is not None:
+            orm_profile = self._to_orm(profile)
+            self._repository.create(orm_profile)
+        else:
+            self._profiles[profile.id] = profile
+
+        return profile
+
+    async def parse_file_and_create(
+        self, file_bytes: bytes, filename: str, language: str = "en"
+    ) -> CandidateProfile:
+        ext = Path(filename).suffix.lower()
+
+        if ext == ".pdf":
+            if self._pdf_parser is None:
+                msg = "PDF parsing not available — no PDFParser configured"
+                raise ValueError(msg)
+            parsed = await self._pdf_parser.parse(file_bytes)
+            skills = self._extract_skills_from_parsed(parsed)
+        elif ext == ".tex":
+            content = file_bytes.decode("utf-8", errors="replace")
+            parsed = self._parser.parse(content)
+            skills = self._extract_skills_from_parsed(parsed)
+        else:
+            msg = f"Unsupported file type: {ext}"
+            raise ValueError(msg)
+
+        profile_id = str(uuid.uuid4())
+        self._save_original_file(profile_id, filename, file_bytes)
+
+        sections = [CVSection(name=s.name, content=s.content) for s in parsed.sections]
+
+        profile = CandidateProfile(
+            id=profile_id,
+            name=parsed.name,
+            email=parsed.email,
+            phone=parsed.phone,
+            location=parsed.location,
+            sections=sections,
+            raw_tex=parsed.raw_tex,
+            language=language,
+            skills=skills,
+        )
+
+        if self._repository is not None:
+            orm_profile = self._to_orm(profile, original_filename=filename)
+            self._repository.create(orm_profile)
+        else:
+            self._profiles[profile.id] = profile
+
         return profile
 
     async def get_profile(self, profile_id: str) -> CandidateProfile | None:
+        if self._repository is not None:
+            orm = self._repository.get_by_id(uuid.UUID(profile_id))
+            return self._to_response(orm) if orm else None
         return self._profiles.get(profile_id)
+
+    async def get_current_profile(self) -> CandidateProfile | None:
+        if self._repository is None:
+            return None
+        orm = self._repository.get_latest()
+        return self._to_response(orm) if orm else None
+
+    def _extract_skills_from_parsed(self, parsed: object) -> list[str]:
+        from hiresense.profile.domain.latex_parser import ParsedCV
+
+        if not isinstance(parsed, ParsedCV):
+            return []
+        for section in parsed.sections:
+            if "SKILL" in section.name.upper():
+                return self._skill_extractor.extract_from_tabular(section.content)
+        return []
+
+    def _save_original_file(self, profile_id: str, filename: str, file_bytes: bytes) -> None:
+        originals_dir = self._cv_directory / "originals"
+        originals_dir.mkdir(parents=True, exist_ok=True)
+        dest = originals_dir / f"{profile_id}_{filename}"
+        dest.write_bytes(file_bytes)
+        logger.info("Saved original CV to %s", dest)
+
+    def _to_orm(
+        self, profile: CandidateProfile, original_filename: str | None = None
+    ) -> Profile:
+        return Profile(
+            id=uuid.UUID(profile.id),
+            name=profile.name,
+            email=profile.email,
+            phone=profile.phone,
+            location=profile.location,
+            sections=[{"name": s.name, "content": s.content} for s in profile.sections],
+            raw_tex=profile.raw_tex,
+            language=profile.language,
+            skills=profile.skills,
+            original_filename=original_filename,
+        )
+
+    def _to_response(self, orm: Profile) -> CandidateProfile:
+        sections = [
+            CVSection(name=s.get("name", ""), content=s.get("content", ""))
+            for s in (orm.sections or [])
+        ]
+        return CandidateProfile(
+            id=str(orm.id),
+            name=orm.name,
+            email=orm.email,
+            phone=orm.phone,
+            location=orm.location,
+            sections=sections,
+            raw_tex=orm.raw_tex or "",
+            language=orm.language,
+            skills=orm.skills or [],
+        )

--- a/backend/src/hiresense/profile/infrastructure/__init__.py
+++ b/backend/src/hiresense/profile/infrastructure/__init__.py
@@ -1,1 +1,5 @@
 """HireSense - AI-powered job matching and CV optimization."""
+
+from hiresense.profile.infrastructure.repository import ProfileRepository
+
+__all__ = ["ProfileRepository"]

--- a/backend/src/hiresense/profile/infrastructure/repository.py
+++ b/backend/src/hiresense/profile/infrastructure/repository.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+
+from hiresense.profile.domain.models import Profile
+
+
+class ProfileRepository:
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    def get_by_id(self, id: uuid.UUID) -> Profile | None:
+        with self._session_factory() as session:
+            return session.get(Profile, id)
+
+    def get_latest(self) -> Profile | None:
+        with self._session_factory() as session:
+            stmt = select(Profile).order_by(Profile.created_at.desc()).limit(1)
+            return session.scalars(stmt).first()
+
+    def create(self, profile: Profile) -> Profile:
+        with self._session_factory() as session:
+            session.add(profile)
+            session.commit()
+            session.refresh(profile)
+            return profile

--- a/backend/src/hiresense/profile/ports/__init__.py
+++ b/backend/src/hiresense/profile/ports/__init__.py
@@ -1,1 +1,5 @@
 """Profile module ports."""
+
+from hiresense.profile.ports.repository import ProfileRepositoryPort
+
+__all__ = ["ProfileRepositoryPort"]

--- a/backend/src/hiresense/profile/ports/repository.py
+++ b/backend/src/hiresense/profile/ports/repository.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import uuid
+from typing import Protocol
+
+from hiresense.profile.domain.models import Profile
+
+
+class ProfileRepositoryPort(Protocol):
+    def get_by_id(self, id: uuid.UUID) -> Profile | None: ...
+
+    def get_latest(self) -> Profile | None: ...
+
+    def create(self, profile: Profile) -> Profile: ...

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -640,6 +640,7 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pymupdf" },
     { name = "python-jose", extra = ["cryptography"] },
     { name = "python-multipart" },
     { name = "pyyaml" },
@@ -695,6 +696,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
     { name = "pydantic", specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.5.0" },
+    { name = "pymupdf", specifier = ">=1.25.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.3.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0.0" },
@@ -1496,6 +1498,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pymupdf"
+version = "1.27.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/32/f6b645c51d79a188a4844140c5dabca7b487ad56c4be69c4bc782d0d11a9/pymupdf-1.27.2.2.tar.gz", hash = "sha256:ea8fdc3ab6671ca98f629d5ec3032d662c8cf1796b146996b7ad306ac7ed3335", size = 85354380, upload-time = "2026-03-20T09:47:58.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/88/d01992a50165e22dec057a1129826846c547feb4ba07f42720ac030ce438/pymupdf-1.27.2.2-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:800f43e60a6f01f644343c2213b8613db02eaf4f4ba235b417b3351fa99e01c0", size = 23987563, upload-time = "2026-03-19T12:35:42.989Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/0e/9f526bc1d49d8082eff0d1547a69d541a0c5a052e71da625559efaba46a6/pymupdf-1.27.2.2-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:8e2e4299ef1ac0c9dff9be096cbd22783699673abecfa7c3f73173ae06421d73", size = 23263089, upload-time = "2026-03-20T09:44:16.982Z" },
+    { url = "https://files.pythonhosted.org/packages/42/be/984f0d6343935b5dd30afaed6be04fc753146bf55709e63ef28bf9ef7497/pymupdf-1.27.2.2-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c5e3d54922db1c7da844f1208ac1db05704770988752311f81dd36694ae0a07b", size = 24318817, upload-time = "2026-03-20T09:44:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/22/8e/85e9d9f11dbf34036eb1df283805ef6b885f2005a56d6533bb58ab0b8a11/pymupdf-1.27.2.2-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:892698c9768457eb0991c102c96a856c0a7062539371df5e6bee0816f3ef498e", size = 24948135, upload-time = "2026-03-20T09:44:51.012Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e6/386edb017e5b93f1ab0bf6653ae32f3dd8dfc834ed770212e10ca62f4af9/pymupdf-1.27.2.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b4bbfa6ef347fade678771a93f6364971c51a2cdc44cd2400dc4eeed1ddb4e6", size = 25169585, upload-time = "2026-03-20T09:45:05.393Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/fd/f1ebe24fcd31aaea8b85b3a7ac4c3fc96e20388be5466ace27c9a3c546d9/pymupdf-1.27.2.2-cp310-abi3-win32.whl", hash = "sha256:0b8e924433b7e0bd46be820899300259235997d5a747638471fb2762baa8ee30", size = 18008861, upload-time = "2026-03-20T09:45:21.353Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b6/2a9a8556000199bbf80a5915dcd15d550d1e5288894316445c54726aaf53/pymupdf-1.27.2.2-cp310-abi3-win_amd64.whl", hash = "sha256:09bb53f9486ccb5297030cbc2dbdae845ba1c3c5126e96eb2d16c4f118de0b5b", size = 19238032, upload-time = "2026-03-20T09:45:37.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c6/e3e11c42f09b9c34ec332c0f37b817671b59ef4001895b854f0494092105/pymupdf-1.27.2.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6cebfbbdfd219ebdebf4d8e3914624b2e3d3a844c43f4f76935822dd9b13cc12", size = 24985299, upload-time = "2026-03-20T09:45:53.26Z" },
 ]
 
 [[package]]

--- a/docs/superpowers/specs/2026-04-12-profile-upload-and-matching-preload-design.md
+++ b/docs/superpowers/specs/2026-04-12-profile-upload-and-matching-preload-design.md
@@ -1,0 +1,204 @@
+# Profile File Upload & Matching Preload
+
+## Context
+
+HireSense's profile feature only accepts pasted LaTeX (.tex) content, and the matching page requires manually typing job descriptions, CV summaries, and skills every time. Both create unnecessary friction. The user has CVs in various formats and ingested job data already in the system — these should be leveraged automatically.
+
+This design adds PDF/LaTeX file upload to the profile page and preloads matching data from the stored profile and ingested jobs.
+
+## Scope
+
+Two improvements, unified by profile persistence as the shared foundation:
+
+1. **Profile file upload** — accept PDF and .tex file uploads, parse with LLM (PDF) or existing regex parser (.tex)
+2. **Matching preloading** — auto-fill CV data from stored profile, show ingested jobs in a dropdown for selection
+
+## 1. Profile File Upload
+
+### Backend
+
+**New endpoint:** `POST /profile/upload-file`
+- Accepts `multipart/form-data`: file (PDF or .tex) + language field
+- Routes to `PDFParser` or `LaTeXParser` based on file extension
+- Saves uploaded file to `cvs/originals/`
+- Returns `CandidateProfile`
+
+**New class:** `PDFParser` (`profile/domain/pdf_parser.py`)
+- Extracts raw text from PDF using PyMuPDF (`pymupdf` package)
+- Sends extracted text to configured LLM with a structured prompt
+- LLM returns: name, email, phone, location, sections (name + content pairs), skills
+- Parses LLM response into `ParsedCV` dataclass (same as LaTeXParser output)
+
+**Modified class:** `ProfileService` (`profile/domain/services.py`)
+- New method: `parse_file_and_create(file_bytes: bytes, filename: str, language: str) -> CandidateProfile`
+- Checks extension: `.pdf` routes to PDFParser, `.tex` routes to LaTeXParser
+- Saves file to `cvs/originals/{profile_id}_{filename}`
+- Stores profile via repository (see Section 2)
+
+**New dependency:** `pymupdf` added to `pyproject.toml`
+
+### Frontend
+
+**Modified component:** `ProfileComponent`
+- Two tabs: "Upload File" | "Paste LaTeX"
+- Upload File tab: drag-and-drop zone accepting `.pdf` and `.tex`, language selector, upload button
+- Paste LaTeX tab: existing textarea (unchanged behavior)
+- New signal: `activeTab` to toggle between tabs
+- New signal: `selectedFile` for the file reference
+
+**Modified service:** `ProfileService`
+- New method: `uploadFile(file: File, language: string): Observable<CandidateProfile>`
+- Sends `FormData` via POST to `/profile/upload-file`
+
+### Data model
+
+No changes to `CandidateProfile` — existing fields (name, email, phone, location, sections, raw_tex, language, skills, embedding) cover all extracted data. For PDF uploads, `raw_tex` stores the extracted plain text instead of LaTeX.
+
+## 2. Profile Persistence
+
+### Backend
+
+**New migration:** `004_create_profiles.py`
+- Table: `profiles`
+- Columns: `id (PK, varchar)`, `name`, `email`, `phone`, `location`, `sections (JSONB)`, `raw_tex (TEXT)`, `language`, `skills (JSONB)`, `embedding (vector, nullable)`, `created_at (timestamp)`
+
+**New class:** `ProfileRepository` (`profile/infrastructure/repository.py`)
+- Async SQLAlchemy repository
+- Methods: `save(profile)`, `get(profile_id)`, `get_latest() -> CandidateProfile | None`
+- Follows same pattern as existing `TrackingRepository`
+
+**Modified class:** `ProfileService`
+- Constructor accepts `ProfileRepository`
+- `parse_and_create` and `parse_file_and_create` persist via repository instead of in-memory dict
+- Remove `_profiles` dict
+
+**New endpoint:** `GET /profile/current`
+- Returns the most recently created profile
+- Returns 404 if no profile exists
+- Single-user app, so "current" = latest by `created_at`
+
+### Frontend
+
+**Modified service:** `ProfileService`
+- New method: `getCurrentProfile(): Observable<CandidateProfile>`
+- Calls `GET /profile/current`
+
+**Modified component:** `ProfileComponent`
+- On init, calls `getCurrentProfile()`
+- If profile exists: shows profile view immediately (skip upload form)
+- If not: shows upload form
+
+## 3. Matching Page Preloading
+
+### Backend
+
+**New endpoint:** `GET /ingestion/jobs`
+- Returns list of `NormalizedJob` from `IngestionOrchestrator.list_jobs()` (method already exists)
+- Simple read from in-memory store, no new logic needed
+
+### Frontend
+
+**Modified service:** `IngestionService`
+- New method: `listJobs(): Observable<NormalizedJob[]>`
+- Calls `GET /ingestion/jobs`
+
+**Modified component:** `MatchingComponent`
+- On init:
+  1. `ProfileService.getCurrentProfile()` -> auto-fills `cvSummary` (concatenated section content) and `cvSkills` (from skills array, joined with commas)
+  2. `IngestionService.listJobs()` -> populates a job selector dropdown
+- New signal: `jobs` holding the ingested job list
+- New signal: `selectedJob` for the currently selected job
+- When a job is selected from dropdown: auto-fills `jobDescription` (from `description`) and `jobSkills` (from `skills`, joined with commas)
+- Dropdown includes a "Manual entry" option that clears auto-fill and restores blank fields
+- All auto-filled fields remain editable
+
+### UX Flow
+
+1. Navigate to Matching page
+2. CV summary and skills auto-populate from stored profile
+3. Job dropdown shows ingested jobs (title + company)
+4. Select a job -> job description and skills auto-fill
+5. Click "Analyze Match" — no manual typing needed
+6. Or pick "Manual entry" to type everything by hand
+
+## Files to Create
+
+| File | Purpose |
+|------|---------|
+| `backend/src/hiresense/profile/domain/pdf_parser.py` | PDF text extraction + LLM structured parsing |
+| `backend/src/hiresense/profile/infrastructure/repository.py` | SQLAlchemy async profile persistence |
+| `backend/alembic/versions/004_create_profiles.py` | Database migration for profiles table |
+
+## Files to Modify
+
+| File | Changes |
+|------|---------|
+| `backend/pyproject.toml` | Add `pymupdf` dependency |
+| `backend/src/hiresense/profile/domain/services.py` | Add `parse_file_and_create`, switch to repository |
+| `backend/src/hiresense/profile/api/routes.py` | Add `upload-file` and `current` endpoints |
+| `backend/src/hiresense/profile/api/provider.py` | Wire repository into provider |
+| `backend/src/hiresense/profile/api/dependencies.py` | Add repository dependency if needed |
+| `backend/src/hiresense/main.py` | Pass repository + LLM to ProfileService, wire new provider |
+| `backend/src/hiresense/ingestion/api/routes.py` | Add `GET /jobs` endpoint |
+| `frontend/src/app/core/services/profile.service.ts` | Add `uploadFile()` and `getCurrentProfile()` |
+| `frontend/src/app/core/services/ingestion.service.ts` | Add `listJobs()` |
+| `frontend/src/app/pages/profile/profile.component.ts` | Tabbed UI, file upload, load existing profile on init |
+| `frontend/src/app/pages/profile/profile.component.html` | Tab layout, drag-and-drop zone |
+| `frontend/src/app/pages/profile/profile.component.scss` | Tab and dropzone styles |
+| `frontend/src/app/pages/matching/matching.component.ts` | Preload profile + jobs, job selector logic |
+| `frontend/src/app/pages/matching/matching.component.html` | Job dropdown, auto-filled fields |
+| `frontend/src/app/pages/matching/matching.component.scss` | Dropdown styles |
+
+## Existing Code to Reuse
+
+- `LaTeXParser` (`profile/domain/latex_parser.py`) — existing .tex parsing, no changes needed
+- `SkillExtractor` (`profile/domain/skill_extractor.py`) — existing skill extraction
+- `IngestionOrchestrator.list_jobs()` (`ingestion/domain/services.py:92`) — already returns `list[NormalizedJob]`
+- `TrackingRepository` pattern (`tracking/infrastructure/`) — model for `ProfileRepository`
+- `ProfileProvider` pattern (`profile/api/provider.py`) — extend for repository
+- `cvs/originals/` directory — already exists for file storage
+- LLM port (`ports/llm.py`) — use configured LLM for PDF parsing
+
+## Frontend Design Quality
+
+The profile upload and matching pages must be polished and elegant, not just functional. During implementation:
+
+- Use the `frontend-design` skill for creating the UI components (tabbed upload, drag-and-drop zone, job selector dropdown)
+- After each UI implementation step, use Playwright to screenshot and visually verify the result in a real browser
+- Iterate multiple rounds on the design — refine spacing, colors, typography, hover states, transitions, and responsive behavior until the UI feels production-grade
+- Match the existing Indigo (#4f46e5) color scheme and card-based layout already established in the app
+- The drag-and-drop zone should have clear visual states: default, hover/drag-over, file-selected, uploading, success/error
+- The job selector dropdown should feel native and clean, not like an afterthought bolted onto the form
+
+## Verification
+
+1. **Profile file upload (PDF):**
+   - Upload a PDF CV via the drag-and-drop zone
+   - Verify structured profile data is displayed (name, email, skills, sections)
+   - Verify file saved to `cvs/originals/`
+   - Restart backend, navigate to profile — verify profile loads from DB
+
+2. **Profile file upload (.tex):**
+   - Switch to "Paste LaTeX" tab, paste .tex content
+   - Verify existing parsing still works identically
+   - Also test uploading a .tex file via the file upload tab
+
+3. **Profile persistence:**
+   - Upload a profile, restart backend
+   - Navigate to profile page — should show existing profile without re-uploading
+   - Upload a new profile — should replace the displayed one
+
+4. **Matching preloading:**
+   - Ensure a profile exists and jobs have been ingested
+   - Navigate to matching page
+   - Verify CV summary and skills are auto-filled from profile
+   - Verify job dropdown is populated with ingested jobs
+   - Select a job — verify job description and skills populate
+   - Select "Manual entry" — verify fields clear for manual input
+   - Run an analysis with preloaded data — verify results display correctly
+
+5. **Visual polish (iterative):**
+   - Use Playwright to screenshot each page after implementation
+   - Review for spacing, alignment, color consistency, hover states, transitions
+   - Iterate at least 2-3 rounds of visual refinement per page
+   - Verify responsive behavior at common viewport sizes

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -22,6 +22,7 @@
         "@angular/cli": "^21.2.1",
         "@angular/compiler-cli": "^21.2.0",
         "jsdom": "^28.0.0",
+        "playwright": "^1.59.1",
         "prettier": "^3.8.1",
         "typescript": "~5.9.2",
         "vitest": "^4.0.8"
@@ -7094,6 +7095,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "@angular/cli": "^21.2.1",
     "@angular/compiler-cli": "^21.2.0",
     "jsdom": "^28.0.0",
+    "playwright": "^1.59.1",
     "prettier": "^3.8.1",
     "typescript": "~5.9.2",
     "vitest": "^4.0.8"

--- a/frontend/src/app/core/services/ingestion.service.ts
+++ b/frontend/src/app/core/services/ingestion.service.ts
@@ -3,6 +3,7 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { FetchResponse } from '../../pages/ingestion/models/fetch-response.model';
+import { NormalizedJob } from '../../pages/ingestion/models/normalized-job.model';
 import { PortalEntry } from '../../pages/ingestion/models/portal-entry.model';
 import { ScanPortalsRequest } from '../../pages/ingestion/models/scan-portals-request.model';
 import { ScanResult } from '../../pages/ingestion/models/scan-result.model';
@@ -13,6 +14,10 @@ export class IngestionService {
 
   fetchJobs(): Observable<FetchResponse> {
     return this.http.post<FetchResponse>(`${environment.apiUrl}/ingestion/fetch`, {});
+  }
+
+  listJobs(): Observable<NormalizedJob[]> {
+    return this.http.get<NormalizedJob[]>(`${environment.apiUrl}/ingestion/jobs`);
   }
 
   loadPortals(): Observable<PortalEntry[]> {

--- a/frontend/src/app/core/services/profile.service.ts
+++ b/frontend/src/app/core/services/profile.service.ts
@@ -16,4 +16,15 @@ export class ProfileService {
   uploadCV(request: UploadCVRequest): Observable<CandidateProfile> {
     return this.http.post<CandidateProfile>(`${environment.apiUrl}/profile/upload`, request);
   }
+
+  uploadFile(file: File, language: string): Observable<CandidateProfile> {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('language', language);
+    return this.http.post<CandidateProfile>(`${environment.apiUrl}/profile/upload-file`, formData);
+  }
+
+  getCurrentProfile(): Observable<CandidateProfile> {
+    return this.http.get<CandidateProfile>(`${environment.apiUrl}/profile/current`);
+  }
 }

--- a/frontend/src/app/pages/matching/matching.component.html
+++ b/frontend/src/app/pages/matching/matching.component.html
@@ -1,8 +1,38 @@
 <div class="page">
-  <h1>Job Matching</h1>
+  <div class="page-header">
+    <h1>Job Matching</h1>
+    <p class="page-subtitle">Compare your profile against job requirements</p>
+  </div>
 
   @if (!result()) {
     <div class="match-form">
+      @if (profileLoaded()) {
+        <div class="auto-fill-notice">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
+            <polyline points="22 4 12 14.01 9 11.01"/>
+          </svg>
+          Profile loaded — CV fields auto-filled from your profile
+        </div>
+      }
+
+      @if (jobs().length > 0) {
+        <div class="job-selector">
+          <label for="job-select">Select a Job</label>
+          <select
+            id="job-select"
+            [ngModel]="selectedJobId()"
+            (ngModelChange)="onJobSelected($event)"
+            name="jobSelect"
+          >
+            <option value="manual">Manual entry</option>
+            @for (job of jobs(); track job.id) {
+              <option [value]="job.id">{{ job.title }} — {{ job.company }}</option>
+            }
+          </select>
+        </div>
+      }
+
       <div class="form-row">
         <div class="form-group">
           <label>Job Description</label>
@@ -27,14 +57,19 @@
         <div class="alert alert-error">{{ error() }}</div>
       }
       <button (click)="analyze()" [disabled]="loading()" class="btn-primary">
-        @if (loading()) { Analyzing... } @else { Analyze Match }
+        @if (loading()) {
+          <span class="btn-spinner"></span>
+          Analyzing...
+        } @else {
+          Analyze Match
+        }
       </button>
     </div>
   } @else {
     <div class="results">
       <div class="results-header">
         <h2>Match Results</h2>
-        <button (click)="result.set(null)" class="btn-secondary">New Analysis</button>
+        <button (click)="result.set(null); evaluationResult.set(null)" class="btn-secondary">New Analysis</button>
       </div>
 
       <div class="score-overview">
@@ -127,8 +162,13 @@
 
       <!-- Evaluation Section -->
       <section class="evaluation-section">
-        <button (click)="evaluate()" [disabled]="evaluating()">
-          {{ evaluating() ? 'Evaluating...' : 'Run 10-Dimension Evaluation' }}
+        <button (click)="evaluate()" [disabled]="evaluating()" class="btn-primary">
+          @if (evaluating()) {
+            <span class="btn-spinner"></span>
+            Evaluating...
+          } @else {
+            Run 10-Dimension Evaluation
+          }
         </button>
 
         @if (evaluationResult()) {

--- a/frontend/src/app/pages/matching/matching.component.scss
+++ b/frontend/src/app/pages/matching/matching.component.scss
@@ -1,13 +1,98 @@
+$primary: #4f46e5;
+$primary-dark: #4338ca;
+$primary-light: #e0e7ff;
+$primary-bg: #f5f3ff;
+$text-dark: #1a1a2e;
+$text-mid: #444;
+$text-light: #6b7280;
+$border: #e2e5ea;
+$surface: #ffffff;
+$bg: #f8f9fb;
+$danger: #dc2626;
+$danger-bg: #fef2f2;
+$success: #16a34a;
+$success-bg: #f0fdf4;
+$radius: 10px;
+$shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
+$transition: 0.2s ease;
+
 .page {
   max-width: 1000px;
-  h1 { font-size: 1.5rem; color: #1a1a2e; margin-bottom: 1.5rem; }
 }
 
-.match-form {
-  background: white;
-  padding: 1.5rem;
+.page-header {
+  margin-bottom: 1.75rem;
+
+  h1 {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: $text-dark;
+    margin: 0 0 0.35rem;
+    letter-spacing: -0.02em;
+  }
+
+  .page-subtitle {
+    font-size: 0.9rem;
+    color: $text-light;
+    margin: 0;
+  }
+}
+
+// --- Auto-fill Notice ---
+.auto-fill-notice {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  background: $primary-bg;
+  border: 1px solid rgba($primary, 0.15);
   border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  margin-bottom: 1.25rem;
+  font-size: 0.825rem;
+  color: $primary-dark;
+  font-weight: 500;
+
+  svg { color: $primary; flex-shrink: 0; }
+}
+
+// --- Job Selector ---
+.job-selector {
+  margin-bottom: 1.25rem;
+
+  label {
+    display: block;
+    margin-bottom: 0.35rem;
+    font-weight: 500;
+    font-size: 0.825rem;
+    color: $text-mid;
+  }
+
+  select {
+    width: 100%;
+    padding: 0.55rem 0.75rem;
+    border: 1px solid $border;
+    border-radius: 8px;
+    font-size: 0.875rem;
+    font-family: inherit;
+    color: $text-dark;
+    background: $surface;
+    cursor: pointer;
+    transition: border-color $transition, box-shadow $transition;
+
+    &:focus {
+      outline: none;
+      border-color: $primary;
+      box-shadow: 0 0 0 3px rgba($primary, 0.1);
+    }
+  }
+}
+
+// --- Form ---
+.match-form {
+  background: $surface;
+  padding: 1.5rem;
+  border-radius: $radius;
+  box-shadow: $shadow-sm;
 }
 
 .form-row {
@@ -22,70 +107,119 @@
     display: block;
     margin-bottom: 0.35rem;
     font-weight: 500;
-    font-size: 0.875rem;
-    color: #333;
+    font-size: 0.825rem;
+    color: $text-mid;
   }
+
   textarea, input {
     width: 100%;
     padding: 0.5rem 0.75rem;
-    border: 1px solid #d1d5db;
-    border-radius: 6px;
+    border: 1px solid $border;
+    border-radius: 8px;
     font-size: 0.875rem;
     font-family: inherit;
+    color: $text-dark;
     box-sizing: border-box;
-    &:focus { outline: none; border-color: #4f46e5; box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1); }
+    transition: border-color $transition, box-shadow $transition;
+
+    &:focus {
+      outline: none;
+      border-color: $primary;
+      box-shadow: 0 0 0 3px rgba($primary, 0.1);
+    }
+
+    &::placeholder { color: #c0c5ce; }
   }
 }
 
+// --- Buttons ---
 .btn-primary {
-  padding: 0.5rem 1.25rem;
-  background: #4f46e5;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.5rem;
+  background: $primary;
   color: white;
   border: none;
-  border-radius: 6px;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 0.875rem;
-  &:hover:not(:disabled) { background: #4338ca; }
-  &:disabled { opacity: 0.6; cursor: not-allowed; }
+  font-weight: 500;
+  transition: background $transition, box-shadow $transition;
+
+  &:hover:not(:disabled) {
+    background: $primary-dark;
+    box-shadow: 0 2px 8px rgba($primary, 0.25);
+  }
+
+  &:disabled { opacity: 0.55; cursor: not-allowed; }
+}
+
+.btn-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
 .btn-secondary {
-  padding: 0.4rem 1rem;
-  background: white;
-  color: #4f46e5;
-  border: 1px solid #4f46e5;
-  border-radius: 6px;
+  padding: 0.5rem 1.15rem;
+  background: $surface;
+  color: $primary;
+  border: 1px solid rgba($primary, 0.3);
+  border-radius: 8px;
   cursor: pointer;
   font-size: 0.85rem;
-  &:hover { background: #f5f3ff; }
+  font-weight: 500;
+  transition: background $transition, border-color $transition;
+
+  &:hover {
+    background: $primary-bg;
+    border-color: rgba($primary, 0.5);
+  }
 }
 
+// --- Alert ---
 .alert-error {
-  background: #fef2f2;
-  color: #dc2626;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
+  background: $danger-bg;
+  color: $danger;
+  padding: 0.7rem 1rem;
+  border-radius: 8px;
   margin-bottom: 1rem;
-  font-size: 0.875rem;
+  font-size: 0.85rem;
+  border: 1px solid rgba($danger, 0.1);
 }
 
+// --- Results ---
 .results-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 1.5rem;
-  h2 { font-size: 1.25rem; color: #1a1a2e; }
+
+  h2 {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: $text-dark;
+    letter-spacing: -0.01em;
+  }
 }
 
 .score-overview {
   display: flex;
   gap: 2rem;
   align-items: center;
-  background: white;
+  background: $surface;
   padding: 1.5rem;
-  border-radius: 8px;
+  border-radius: $radius;
   margin-bottom: 1rem;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  box-shadow: $shadow-sm;
 }
 
 .overall-score {
@@ -100,7 +234,7 @@
   flex-shrink: 0;
 
   .score-value { font-size: 1.75rem; font-weight: 700; }
-  .score-label { font-size: 0.75rem; color: #888; }
+  .score-label { font-size: 0.75rem; color: $text-light; }
 }
 
 .breakdown { flex: 1; }
@@ -111,10 +245,10 @@
   gap: 0.75rem;
   margin-bottom: 0.5rem;
 
-  .breakdown-label { width: 80px; font-size: 0.8rem; color: #666; }
-  .bar { flex: 1; height: 8px; background: #f0f0f0; border-radius: 4px; overflow: hidden; }
+  .breakdown-label { width: 80px; font-size: 0.8rem; color: $text-light; }
+  .bar { flex: 1; height: 8px; background: $bg; border-radius: 4px; overflow: hidden; }
   .bar-fill { height: 100%; border-radius: 4px; transition: width 0.5s; }
-  .breakdown-value { width: 40px; text-align: right; font-size: 0.8rem; font-weight: 500; }
+  .breakdown-value { width: 40px; text-align: right; font-size: 0.8rem; font-weight: 500; color: $text-mid; }
 }
 
 .details-grid {
@@ -125,12 +259,19 @@
 }
 
 .detail-card {
-  background: white;
+  background: $surface;
   padding: 1.25rem;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  border-radius: $radius;
+  box-shadow: $shadow-sm;
 
-  h3 { font-size: 0.9rem; color: #555; margin-bottom: 0.75rem; }
+  h3 {
+    font-size: 0.8rem;
+    color: $text-light;
+    margin-bottom: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
 
   ul {
     list-style: none;
@@ -138,8 +279,8 @@
     li {
       padding: 0.35rem 0;
       font-size: 0.85rem;
-      &.pro { color: #16a34a; }
-      &.con { color: #dc2626; }
+      &.pro { color: $success; }
+      &.con { color: $danger; }
       &::before { margin-right: 0.5rem; }
     }
     li.pro::before { content: '+'; font-weight: bold; }
@@ -148,23 +289,103 @@
 }
 
 .tags { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+
 .tag {
-  padding: 0.2rem 0.5rem;
-  border-radius: 4px;
-  font-size: 0.8rem;
+  padding: 0.25rem 0.55rem;
+  border-radius: 6px;
+  font-size: 0.78rem;
   font-weight: 500;
 }
-.tag-success { background: #f0fdf4; color: #16a34a; }
-.tag-danger { background: #fef2f2; color: #dc2626; }
+
+.tag-success { background: $success-bg; color: $success; }
+.tag-danger { background: $danger-bg; color: $danger; }
 .no-data { font-size: 0.85rem; color: #aaa; }
 
 .recommendations {
-  background: white;
+  background: $surface;
   padding: 1.25rem;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  border-radius: $radius;
+  box-shadow: $shadow-sm;
 
-  h3 { font-size: 0.9rem; color: #555; margin-bottom: 0.75rem; }
+  h3 {
+    font-size: 0.8rem;
+    color: $text-light;
+    margin-bottom: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: 600;
+  }
+
   ul { padding-left: 1.25rem; }
-  li { font-size: 0.85rem; color: #444; padding: 0.25rem 0; }
+  li { font-size: 0.85rem; color: $text-mid; padding: 0.25rem 0; }
+}
+
+// --- Evaluation ---
+.evaluation-section {
+  margin-top: 1.5rem;
+}
+
+.evaluation-results { margin-top: 1.25rem; }
+
+.composite-score {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1.5rem;
+  background: $surface;
+  border-radius: $radius;
+  box-shadow: $shadow-sm;
+  margin-bottom: 1rem;
+
+  .score-value { font-size: 2.5rem; font-weight: 700; color: $text-dark; }
+  .score-label { font-size: 0.85rem; color: $text-light; }
+}
+
+.dimensions-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.dimension-card {
+  background: $surface;
+  padding: 1.25rem;
+  border-radius: $radius;
+  box-shadow: $shadow-sm;
+}
+
+.dimension-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+
+  .dimension-name { font-weight: 600; font-size: 0.875rem; color: $text-dark; }
+  .dimension-score { font-weight: 600; font-size: 0.875rem; }
+}
+
+.dimension-bar {
+  height: 6px;
+  background: $bg;
+  border-radius: 3px;
+  overflow: hidden;
+  margin-bottom: 0.5rem;
+}
+
+.dimension-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.5s;
+}
+
+.dimension-rationale {
+  font-size: 0.8rem;
+  color: $text-mid;
+  line-height: 1.5;
+  margin: 0 0 0.35rem;
+}
+
+.dimension-weight {
+  font-size: 0.72rem;
+  color: $text-light;
 }

--- a/frontend/src/app/pages/matching/matching.component.ts
+++ b/frontend/src/app/pages/matching/matching.component.ts
@@ -1,6 +1,9 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatchingService } from '../../core/services/matching.service';
+import { ProfileService } from '../../core/services/profile.service';
+import { IngestionService } from '../../core/services/ingestion.service';
+import { NormalizedJob } from '../ingestion/models/normalized-job.model';
 import { EvaluateRequest } from './models/evaluate-request.model';
 import { EvaluationResult } from './models/evaluation-result.model';
 import { MatchResult } from './models/match-result.model';
@@ -12,7 +15,7 @@ import { MatchResult } from './models/match-result.model';
   templateUrl: './matching.component.html',
   styleUrl: './matching.component.scss',
 })
-export class MatchingComponent {
+export class MatchingComponent implements OnInit {
   jobDescription = signal('');
   jobSkills = signal('');
   cvSummary = signal('');
@@ -23,13 +26,55 @@ export class MatchingComponent {
   evaluationResult = signal<EvaluationResult | null>(null);
   evaluating = signal(false);
 
-  constructor(private matchingService: MatchingService) {}
+  jobs = signal<NormalizedJob[]>([]);
+  selectedJobId = signal<string>('manual');
+  profileLoaded = signal(false);
+
+  constructor(
+    private matchingService: MatchingService,
+    private profileService: ProfileService,
+    private ingestionService: IngestionService,
+  ) {}
+
+  ngOnInit(): void {
+    this.profileService.getCurrentProfile().subscribe({
+      next: (profile) => {
+        const summary = profile.sections
+          .map(s => s.content)
+          .join('\n\n')
+          .substring(0, 2000);
+        this.cvSummary.set(summary);
+        this.cvSkills.set(profile.skills.join(', '));
+        this.profileLoaded.set(true);
+      },
+      error: () => {},
+    });
+
+    this.ingestionService.listJobs().subscribe({
+      next: (jobs) => this.jobs.set(jobs),
+      error: () => {},
+    });
+  }
+
+  onJobSelected(jobId: string): void {
+    this.selectedJobId.set(jobId);
+    if (jobId === 'manual') {
+      this.jobDescription.set('');
+      this.jobSkills.set('');
+      return;
+    }
+    const job = this.jobs().find(j => j.id === jobId);
+    if (job) {
+      this.jobDescription.set(job.description);
+      this.jobSkills.set(job.skills.join(', '));
+    }
+  }
 
   analyze(): void {
     this.loading.set(true);
     this.error.set('');
     const payload = {
-      job_id: 'manual',
+      job_id: this.selectedJobId() !== 'manual' ? this.selectedJobId() : 'manual',
       cv_id: 'manual',
       job_description: this.jobDescription(),
       job_skills: this.jobSkills().split(',').map(s => s.trim()).filter(Boolean),

--- a/frontend/src/app/pages/profile/profile.component.html
+++ b/frontend/src/app/pages/profile/profile.component.html
@@ -1,62 +1,194 @@
 <div class="page">
-  <h1>My Profile</h1>
+  <div class="page-header">
+    <h1>My Profile</h1>
+    <p class="page-subtitle">Upload your CV to unlock intelligent job matching</p>
+  </div>
 
-  @if (!profile()) {
-    <div class="upload-section">
-      <h2>Upload LaTeX CV</h2>
-      <div class="form-group">
-        <label for="language">Language</label>
-        <select id="language" [ngModel]="language()" (ngModelChange)="language.set($event)" name="language">
-          <option value="en">English</option>
-          <option value="es">Spanish</option>
-        </select>
+  @if (initialLoading()) {
+    <div class="loading-state">
+      <div class="loading-spinner"></div>
+      <p>Loading profile...</p>
+    </div>
+  } @else if (!profile()) {
+    <div class="upload-card">
+      <div class="tab-bar">
+        <button
+          class="tab"
+          [class.active]="activeTab() === 'upload'"
+          (click)="activeTab.set('upload')"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+            <polyline points="17 8 12 3 7 8"/>
+            <line x1="12" y1="3" x2="12" y2="15"/>
+          </svg>
+          Upload File
+        </button>
+        <button
+          class="tab"
+          [class.active]="activeTab() === 'paste'"
+          (click)="activeTab.set('paste')"
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/>
+            <rect x="8" y="2" width="8" height="4" rx="1" ry="1"/>
+          </svg>
+          Paste LaTeX
+        </button>
       </div>
-      <div class="form-group">
-        <label for="tex">Paste your .tex content</label>
-        <textarea
-          id="tex"
-          [ngModel]="texContent()"
-          (ngModelChange)="texContent.set($event)"
-          name="tex"
-          rows="12"
-          placeholder="Paste your LaTeX CV here..."
-        ></textarea>
+
+      <div class="tab-content">
+        <div class="language-selector">
+          <label for="language">CV Language</label>
+          <select id="language" [ngModel]="language()" (ngModelChange)="language.set($event)" name="language">
+            <option value="en">English</option>
+            <option value="es">Spanish</option>
+          </select>
+        </div>
+
+        @if (activeTab() === 'upload') {
+          <div
+            class="dropzone"
+            [class.drag-over]="dragOver()"
+            [class.has-file]="selectedFile()"
+            (dragover)="onDragOver($event)"
+            (dragleave)="onDragLeave($event)"
+            (drop)="onDrop($event)"
+          >
+            @if (!selectedFile()) {
+              <div class="dropzone-content">
+                <div class="dropzone-icon">
+                  <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                    <polyline points="14 2 14 8 20 8"/>
+                    <line x1="12" y1="18" x2="12" y2="12"/>
+                    <line x1="9" y1="15" x2="12" y2="12"/>
+                    <line x1="15" y1="15" x2="12" y2="12"/>
+                  </svg>
+                </div>
+                <p class="dropzone-title">Drop your CV here</p>
+                <p class="dropzone-hint">or <label for="file-input" class="browse-link">browse files</label></p>
+                <p class="dropzone-formats">PDF or LaTeX (.tex)</p>
+                <input
+                  id="file-input"
+                  type="file"
+                  accept=".pdf,.tex"
+                  (change)="onFileSelected($event)"
+                  hidden
+                />
+              </div>
+            } @else {
+              <div class="file-preview">
+                <div class="file-icon">
+                  @if (selectedFile()!.name.endsWith('.pdf')) {
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                      <polyline points="14 2 14 8 20 8"/>
+                      <path d="M9 15h6"/>
+                      <path d="M9 11h6"/>
+                    </svg>
+                  } @else {
+                    <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                      <polyline points="14 2 14 8 20 8"/>
+                      <path d="M10 12l-2 4h8l-2-4"/>
+                    </svg>
+                  }
+                </div>
+                <div class="file-details">
+                  <span class="file-name">{{ selectedFile()!.name }}</span>
+                  <span class="file-size">{{ formatFileSize(selectedFile()!.size) }}</span>
+                </div>
+                <button class="file-remove" (click)="removeFile()" title="Remove file">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="18" y1="6" x2="6" y2="18"/>
+                    <line x1="6" y1="6" x2="18" y2="18"/>
+                  </svg>
+                </button>
+              </div>
+            }
+          </div>
+
+          @if (error()) {
+            <div class="alert alert-error">{{ error() }}</div>
+          }
+
+          <button
+            (click)="uploadFile()"
+            [disabled]="loading() || !selectedFile()"
+            class="btn-primary"
+          >
+            @if (loading()) {
+              <span class="btn-spinner"></span>
+              Parsing...
+            } @else {
+              Upload & Parse
+            }
+          </button>
+        } @else {
+          <div class="form-group">
+            <label for="tex">Paste your .tex content</label>
+            <textarea
+              id="tex"
+              [ngModel]="texContent()"
+              (ngModelChange)="texContent.set($event)"
+              name="tex"
+              rows="14"
+              placeholder="Paste your LaTeX CV content here..."
+              class="tex-input"
+            ></textarea>
+          </div>
+
+          @if (error()) {
+            <div class="alert alert-error">{{ error() }}</div>
+          }
+
+          <button
+            (click)="uploadLatex()"
+            [disabled]="loading() || !texContent().trim()"
+            class="btn-primary"
+          >
+            @if (loading()) {
+              <span class="btn-spinner"></span>
+              Parsing...
+            } @else {
+              Upload & Parse
+            }
+          </button>
+        }
       </div>
-      @if (error()) {
-        <div class="alert alert-error">{{ error() }}</div>
-      }
-      <button (click)="uploadCV()" [disabled]="loading() || !texContent().trim()" class="btn-primary">
-        @if (loading()) { Parsing... } @else { Upload & Parse }
-      </button>
     </div>
   } @else {
     <div class="profile-view">
       <div class="profile-header">
-        <h2>{{ profile()!.name }}</h2>
-        <button (click)="profile.set(null)" class="btn-secondary">Upload New CV</button>
+        <div class="profile-identity">
+          <div class="avatar">{{ profile()!.name.charAt(0).toUpperCase() }}</div>
+          <div>
+            <h2>{{ profile()!.name }}</h2>
+            @if (profile()!.location) {
+              <span class="profile-location">{{ profile()!.location }}</span>
+            }
+          </div>
+        </div>
+        <button (click)="resetProfile()" class="btn-secondary">Upload New CV</button>
       </div>
+
       <div class="info-grid">
         @if (profile()!.email) {
           <div class="info-item">
             <span class="label">Email</span>
-            <span>{{ profile()!.email }}</span>
+            <span class="value">{{ profile()!.email }}</span>
           </div>
         }
         @if (profile()!.phone) {
           <div class="info-item">
             <span class="label">Phone</span>
-            <span>{{ profile()!.phone }}</span>
-          </div>
-        }
-        @if (profile()!.location) {
-          <div class="info-item">
-            <span class="label">Location</span>
-            <span>{{ profile()!.location }}</span>
+            <span class="value">{{ profile()!.phone }}</span>
           </div>
         }
         <div class="info-item">
           <span class="label">Language</span>
-          <span>{{ profile()!.language.toUpperCase() }}</span>
+          <span class="value">{{ profile()!.language.toUpperCase() }}</span>
         </div>
       </div>
 

--- a/frontend/src/app/pages/profile/profile.component.scss
+++ b/frontend/src/app/pages/profile/profile.component.scss
@@ -1,114 +1,488 @@
+// --- Variables ---
+$primary: #4f46e5;
+$primary-dark: #4338ca;
+$primary-light: #e0e7ff;
+$primary-bg: #f5f3ff;
+$text-dark: #1a1a2e;
+$text-mid: #444;
+$text-light: #6b7280;
+$border: #e2e5ea;
+$surface: #ffffff;
+$bg: #f8f9fb;
+$danger: #dc2626;
+$danger-bg: #fef2f2;
+$radius: 10px;
+$shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
+$shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+$transition: 0.2s ease;
+
+// --- Page Layout ---
 .page {
-  max-width: 900px;
-
-  h1 { font-size: 1.5rem; color: #1a1a2e; margin-bottom: 1.5rem; }
+  max-width: 860px;
 }
 
-.upload-section {
-  background: white;
+.page-header {
+  margin-bottom: 1.75rem;
+
+  h1 {
+    font-size: 1.6rem;
+    font-weight: 700;
+    color: $text-dark;
+    margin: 0 0 0.35rem;
+    letter-spacing: -0.02em;
+  }
+
+  .page-subtitle {
+    font-size: 0.9rem;
+    color: $text-light;
+    margin: 0;
+  }
+}
+
+// --- Loading ---
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4rem 2rem;
+  color: $text-light;
+
+  .loading-spinner {
+    width: 32px;
+    height: 32px;
+    border: 3px solid $border;
+    border-top-color: $primary;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+    margin-bottom: 1rem;
+  }
+
+  p {
+    font-size: 0.9rem;
+    margin: 0;
+  }
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+// --- Upload Card ---
+.upload-card {
+  background: $surface;
+  border-radius: $radius;
+  box-shadow: $shadow-sm;
+  overflow: hidden;
+}
+
+// --- Tab Bar ---
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid $border;
+  background: $bg;
+}
+
+.tab {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: $text-light;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: color $transition, border-color $transition, background $transition;
+
+  svg {
+    opacity: 0.5;
+    transition: opacity $transition;
+  }
+
+  &:hover {
+    color: $text-mid;
+    background: rgba($primary, 0.03);
+
+    svg { opacity: 0.7; }
+  }
+
+  &.active {
+    color: $primary;
+    border-bottom-color: $primary;
+    background: $surface;
+
+    svg { opacity: 1; }
+  }
+}
+
+// --- Tab Content ---
+.tab-content {
   padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
-
-  h2 { font-size: 1.1rem; margin-bottom: 1rem; color: #333; }
 }
 
-.form-group {
-  margin-bottom: 1rem;
+// --- Language Selector ---
+.language-selector {
+  margin-bottom: 1.25rem;
 
   label {
     display: block;
     margin-bottom: 0.35rem;
     font-weight: 500;
-    font-size: 0.875rem;
-    color: #333;
+    font-size: 0.825rem;
+    color: $text-mid;
   }
 
-  select, textarea {
-    width: 100%;
+  select {
     padding: 0.5rem 0.75rem;
-    border: 1px solid #d1d5db;
+    border: 1px solid $border;
     border-radius: 6px;
     font-size: 0.875rem;
     font-family: inherit;
-    box-sizing: border-box;
+    color: $text-dark;
+    background: $surface;
+    min-width: 140px;
+    cursor: pointer;
+    transition: border-color $transition, box-shadow $transition;
 
     &:focus {
       outline: none;
-      border-color: #4f46e5;
-      box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.1);
+      border-color: $primary;
+      box-shadow: 0 0 0 3px rgba($primary, 0.1);
+    }
+  }
+}
+
+// --- Dropzone ---
+.dropzone {
+  border: 2px dashed $border;
+  border-radius: $radius;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+  transition: border-color 0.25s ease, background 0.25s ease, box-shadow 0.25s ease;
+  cursor: pointer;
+  margin-bottom: 1.25rem;
+  position: relative;
+
+  &:hover {
+    border-color: rgba($primary, 0.4);
+    background: rgba($primary, 0.015);
+  }
+
+  &.drag-over {
+    border-color: $primary;
+    background: rgba($primary, 0.04);
+    box-shadow: 0 0 0 4px rgba($primary, 0.08);
+
+    .dropzone-icon svg {
+      transform: translateY(-4px);
+      color: $primary;
     }
   }
 
-  textarea { font-family: 'Consolas', 'Monaco', monospace; resize: vertical; }
+  &.has-file {
+    border-style: solid;
+    border-color: $primary-light;
+    background: rgba($primary, 0.02);
+    padding: 1rem 1.25rem;
+    cursor: default;
+  }
 }
 
-.btn-primary {
-  padding: 0.5rem 1.25rem;
-  background: #4f46e5;
-  color: white;
+.dropzone-content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.dropzone-icon {
+  margin-bottom: 0.5rem;
+
+  svg {
+    color: $text-light;
+    transition: transform 0.3s ease, color 0.3s ease;
+  }
+}
+
+.dropzone-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: $text-dark;
+  margin: 0;
+}
+
+.dropzone-hint {
+  font-size: 0.85rem;
+  color: $text-light;
+  margin: 0;
+}
+
+.browse-link {
+  color: $primary;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: color $transition;
+
+  &:hover {
+    color: $primary-dark;
+    text-decoration: underline;
+  }
+}
+
+.dropzone-formats {
+  font-size: 0.75rem;
+  color: #9ca3af;
+  margin: 0.25rem 0 0;
+}
+
+// --- File Preview ---
+.file-preview {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.file-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  background: $primary-light;
+  border-radius: 8px;
+  flex-shrink: 0;
+
+  svg { color: $primary; }
+}
+
+.file-details {
+  flex: 1;
+  min-width: 0;
+
+  .file-name {
+    display: block;
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: $text-dark;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .file-size {
+    font-size: 0.78rem;
+    color: $text-light;
+  }
+}
+
+.file-remove {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
   border: none;
   border-radius: 6px;
+  background: transparent;
+  color: $text-light;
+  cursor: pointer;
+  flex-shrink: 0;
+  transition: background $transition, color $transition;
+
+  &:hover {
+    background: $danger-bg;
+    color: $danger;
+  }
+}
+
+// --- Textarea ---
+.form-group {
+  margin-bottom: 1.25rem;
+
+  label {
+    display: block;
+    margin-bottom: 0.35rem;
+    font-weight: 500;
+    font-size: 0.825rem;
+    color: $text-mid;
+  }
+}
+
+.tex-input {
+  width: 100%;
+  padding: 0.75rem;
+  border: 1px solid $border;
+  border-radius: 8px;
+  font-size: 0.825rem;
+  font-family: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+  line-height: 1.6;
+  color: $text-dark;
+  background: $bg;
+  box-sizing: border-box;
+  resize: vertical;
+  transition: border-color $transition, box-shadow $transition;
+
+  &::placeholder { color: #c0c5ce; }
+
+  &:focus {
+    outline: none;
+    border-color: $primary;
+    box-shadow: 0 0 0 3px rgba($primary, 0.1);
+    background: $surface;
+  }
+}
+
+// --- Buttons ---
+.btn-primary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1.5rem;
+  background: $primary;
+  color: white;
+  border: none;
+  border-radius: 8px;
   cursor: pointer;
   font-size: 0.875rem;
-  &:hover:not(:disabled) { background: #4338ca; }
-  &:disabled { opacity: 0.6; cursor: not-allowed; }
+  font-weight: 500;
+  transition: background $transition, transform 0.1s ease, box-shadow $transition;
+
+  &:hover:not(:disabled) {
+    background: $primary-dark;
+    box-shadow: 0 2px 8px rgba($primary, 0.25);
+  }
+
+  &:active:not(:disabled) {
+    transform: scale(0.98);
+  }
+
+  &:disabled {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
+}
+
+.btn-spinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.7s linear infinite;
 }
 
 .btn-secondary {
-  padding: 0.4rem 1rem;
-  background: white;
-  color: #4f46e5;
-  border: 1px solid #4f46e5;
-  border-radius: 6px;
+  padding: 0.5rem 1.15rem;
+  background: $surface;
+  color: $primary;
+  border: 1px solid rgba($primary, 0.3);
+  border-radius: 8px;
   cursor: pointer;
   font-size: 0.85rem;
-  &:hover { background: #f5f3ff; }
+  font-weight: 500;
+  transition: background $transition, border-color $transition;
+
+  &:hover {
+    background: $primary-bg;
+    border-color: rgba($primary, 0.5);
+  }
 }
 
+// --- Alert ---
 .alert-error {
-  background: #fef2f2;
-  color: #dc2626;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
+  background: $danger-bg;
+  color: $danger;
+  padding: 0.7rem 1rem;
+  border-radius: 8px;
   margin-bottom: 1rem;
-  font-size: 0.875rem;
+  font-size: 0.85rem;
+  border: 1px solid rgba($danger, 0.1);
 }
 
+// --- Profile View ---
 .profile-view {
-  background: white;
-  padding: 1.5rem;
-  border-radius: 8px;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+  background: $surface;
+  padding: 1.75rem;
+  border-radius: $radius;
+  box-shadow: $shadow-sm;
 }
 
 .profile-header {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid $border;
+}
 
-  h2 { font-size: 1.25rem; color: #1a1a2e; }
+.profile-identity {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+
+  h2 {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: $text-dark;
+    margin: 0;
+    letter-spacing: -0.01em;
+  }
+}
+
+.avatar {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, $primary, $primary-dark);
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.15rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.profile-location {
+  display: block;
+  font-size: 0.82rem;
+  color: $text-light;
+  margin-top: 0.1rem;
 }
 
 .info-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.75rem;
   margin-bottom: 1.5rem;
   padding: 1rem;
-  background: #f8f9fa;
-  border-radius: 6px;
+  background: $bg;
+  border-radius: 8px;
+  border: 1px solid rgba($border, 0.6);
 
   .info-item {
     .label {
       display: block;
-      font-size: 0.75rem;
-      color: #888;
+      font-size: 0.7rem;
+      color: $text-light;
       margin-bottom: 0.15rem;
       text-transform: uppercase;
+      letter-spacing: 0.04em;
+      font-weight: 500;
     }
-    span:last-child { font-size: 0.9rem; color: #333; }
+
+    .value {
+      font-size: 0.875rem;
+      color: $text-dark;
+      font-weight: 500;
+    }
   }
 }
 
@@ -116,17 +490,18 @@
   margin-bottom: 1.25rem;
 
   h3 {
-    font-size: 0.95rem;
-    color: #555;
+    font-size: 0.8rem;
+    color: $text-light;
     margin-bottom: 0.5rem;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.05em;
+    font-weight: 600;
   }
 
   .section-content {
     font-size: 0.875rem;
-    color: #444;
-    line-height: 1.6;
+    color: $text-mid;
+    line-height: 1.65;
     white-space: pre-wrap;
   }
 }
@@ -138,10 +513,11 @@
 }
 
 .skill-tag {
-  padding: 0.25rem 0.6rem;
-  background: #e0e7ff;
-  color: #4338ca;
-  border-radius: 4px;
-  font-size: 0.8rem;
+  padding: 0.3rem 0.65rem;
+  background: $primary-light;
+  color: $primary-dark;
+  border-radius: 6px;
+  font-size: 0.78rem;
   font-weight: 500;
+  letter-spacing: 0.01em;
 }

--- a/frontend/src/app/pages/profile/profile.component.ts
+++ b/frontend/src/app/pages/profile/profile.component.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ProfileService } from '../../core/services/profile.service';
 import { CandidateProfile } from './models/candidate-profile.model';
@@ -10,16 +10,82 @@ import { CandidateProfile } from './models/candidate-profile.model';
   templateUrl: './profile.component.html',
   styleUrl: './profile.component.scss',
 })
-export class ProfileComponent {
+export class ProfileComponent implements OnInit {
+  activeTab = signal<'upload' | 'paste'>('upload');
+  selectedFile = signal<File | null>(null);
+  dragOver = signal(false);
   texContent = signal('');
   language = signal('en');
   profile = signal<CandidateProfile | null>(null);
   loading = signal(false);
+  initialLoading = signal(true);
   error = signal('');
 
   constructor(private profileService: ProfileService) {}
 
-  uploadCV(): void {
+  ngOnInit(): void {
+    this.profileService.getCurrentProfile().subscribe({
+      next: (profile) => {
+        this.profile.set(profile);
+        this.initialLoading.set(false);
+      },
+      error: () => {
+        this.initialLoading.set(false);
+      },
+    });
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dragOver.set(true);
+  }
+
+  onDragLeave(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dragOver.set(false);
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    event.stopPropagation();
+    this.dragOver.set(false);
+    const files = event.dataTransfer?.files;
+    if (files && files.length > 0) {
+      this.handleFile(files[0]);
+    }
+  }
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    if (input.files && input.files.length > 0) {
+      this.handleFile(input.files[0]);
+    }
+  }
+
+  removeFile(): void {
+    this.selectedFile.set(null);
+  }
+
+  uploadFile(): void {
+    const file = this.selectedFile();
+    if (!file) return;
+    this.loading.set(true);
+    this.error.set('');
+    this.profileService.uploadFile(file, this.language()).subscribe({
+      next: (res) => {
+        this.profile.set(res);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.error.set(err.error?.detail || 'Failed to parse file');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  uploadLatex(): void {
     if (!this.texContent().trim()) return;
     this.loading.set(true);
     this.error.set('');
@@ -38,5 +104,28 @@ export class ProfileComponent {
           this.loading.set(false);
         },
       });
+  }
+
+  resetProfile(): void {
+    this.profile.set(null);
+    this.selectedFile.set(null);
+    this.texContent.set('');
+    this.error.set('');
+  }
+
+  private handleFile(file: File): void {
+    const ext = file.name.split('.').pop()?.toLowerCase();
+    if (ext !== 'pdf' && ext !== 'tex') {
+      this.error.set('Only PDF and .tex files are supported');
+      return;
+    }
+    this.error.set('');
+    this.selectedFile.set(file);
+  }
+
+  formatFileSize(bytes: number): string {
+    if (bytes < 1024) return bytes + ' B';
+    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
+    return (bytes / (1024 * 1024)).toFixed(1) + ' MB';
   }
 }


### PR DESCRIPTION
## Summary

- **Profile file upload**: Add PDF and LaTeX (.tex) file upload via drag-and-drop or file picker, with LLM-powered PDF parsing (PyMuPDF + Claude) for structured extraction of name, email, skills, sections
- **Profile persistence**: Persist profiles to PostgreSQL via new `profiles` table and repository, auto-load existing profile on page visit
- **Matching preload**: Auto-fill CV summary and skills from stored profile, add job selector dropdown populated from ingested jobs so users can match without manual data entry
- **UI polish**: Redesigned profile page with tabbed upload interface (Upload File | Paste LaTeX) and refined matching page with auto-fill notice and job selector

## Test plan

- [ ] Upload a PDF CV via drag-and-drop — verify structured profile data displays
- [ ] Upload a .tex file via the file upload tab — verify parsing works
- [ ] Paste .tex content via Paste LaTeX tab — verify existing flow unchanged
- [ ] Restart backend — verify profile persists and loads from DB
- [ ] Navigate to matching page with profile uploaded — verify CV fields auto-filled
- [ ] Ingest jobs, then select one from dropdown — verify job fields populate
- [ ] Select "Manual entry" — verify fields clear for manual input
- [ ] Run `pytest` — all 289 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)