### PR TITLE
Application pipeline spec + LinkedIn data + tracking PATCH fix

### DIFF
--- a/backend/src/hiresense/ingestion/adapters/linkedin.py
+++ b/backend/src/hiresense/ingestion/adapters/linkedin.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import re
 from typing import Any
 
 from bs4 import BeautifulSoup
 
+from hiresense.ingestion.domain.html_stripper import strip_html
 from hiresense.ingestion.domain.models import RawJobListing
 from hiresense.kernel.value_objects import SourceType
+
+logger = logging.getLogger(__name__)
 
 USER_AGENT = (
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -17,6 +21,8 @@ USER_AGENT = (
 MAX_PAGES = 4
 PAGE_SIZE = 25
 REQUEST_DELAY = 2.0
+DETAIL_CONCURRENCY = 3
+DETAIL_DELAY = 0.3
 
 
 class LinkedInAdapter:
@@ -36,7 +42,7 @@ class LinkedInAdapter:
         keywords = filters.get("keywords", "software engineer") if filters else "software engineer"
         location = filters.get("location", "") if filters else ""
         headers = {"User-Agent": USER_AGENT}
-        jobs: list[RawJobListing] = []
+        cards: list[dict[str, str]] = []
         for page in range(MAX_PAGES):
             start = page * PAGE_SIZE
             url = f"{self._base_url}/seeMoreJobPostings/search"
@@ -53,26 +59,29 @@ class LinkedInAdapter:
                     break
                 response.raise_for_status()
             except Exception:
-                import logging
-                logging.getLogger(__name__).exception("LinkedIn request failed on page %d", page)
+                logger.exception("LinkedIn request failed on page %d", page)
                 break
             soup = BeautifulSoup(response.text, "html.parser")
-            cards = soup.find_all("div", class_="base-card")
-            if not cards:
+            page_cards = soup.find_all("div", class_="base-card")
+            if not page_cards:
                 break
-            for card in cards:
+            for card in page_cards:
                 parsed = self._parse_card(card)
                 if parsed:
-                    jobs.append(
-                        RawJobListing(
-                            source="linkedin",
-                            source_id=parsed["job_id"],
-                            raw_data=parsed,
-                        )
-                    )
+                    cards.append(parsed)
             if page < MAX_PAGES - 1:
                 await asyncio.sleep(REQUEST_DELAY)
-        return jobs
+
+        await self._enrich_with_details(cards, headers)
+
+        return [
+            RawJobListing(
+                source="linkedin",
+                source_id=c["job_id"],
+                raw_data=c,
+            )
+            for c in cards
+        ]
 
     def _parse_card(self, card: Any) -> dict[str, str] | None:
         link_tag = card.find("a", class_="base-card__full-link")
@@ -85,12 +94,69 @@ class LinkedInAdapter:
         title_tag = card.find("h3", class_="base-search-card__title")
         company_tag = card.find("h4", class_="base-search-card__subtitle")
         location_tag = card.find("span", class_="job-search-card__location")
+        time_tag = card.find("time")
+        posted_date = ""
+        if time_tag and time_tag.get("datetime"):
+            posted_date = time_tag.get("datetime", "").strip()
         return {
             "job_id": job_id,
             "title": title_tag.get_text(strip=True) if title_tag else "",
             "company": company_tag.get_text(strip=True) if company_tag else "",
             "location": location_tag.get_text(strip=True) if location_tag else "",
             "url": href.split("?")[0],
+            "posted_date": posted_date,
+            "description": "",
+        }
+
+    async def _enrich_with_details(
+        self,
+        cards: list[dict[str, str]],
+        headers: dict[str, str],
+    ) -> None:
+        semaphore = asyncio.Semaphore(DETAIL_CONCURRENCY)
+
+        async def fetch_one(card: dict[str, str]) -> None:
+            async with semaphore:
+                await asyncio.sleep(DETAIL_DELAY)
+                detail = await self._fetch_detail(card["job_id"], headers)
+                if detail:
+                    card.update(detail)
+
+        await asyncio.gather(*(fetch_one(c) for c in cards), return_exceptions=True)
+
+    async def _fetch_detail(
+        self,
+        job_id: str,
+        headers: dict[str, str],
+    ) -> dict[str, str] | None:
+        url = f"{self._base_url}/jobPosting/{job_id}"
+        try:
+            response = await self._http.get(url, headers=headers)
+            if response.status_code == 429:
+                logger.warning("LinkedIn detail fetch rate-limited for %s", job_id)
+                return None
+            response.raise_for_status()
+        except Exception:
+            logger.exception("LinkedIn detail fetch failed for %s", job_id)
+            return None
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        desc_tag = soup.find("div", class_="show-more-less-html__markup")
+        description = strip_html(str(desc_tag)) if desc_tag else ""
+
+        criteria: dict[str, str] = {}
+        for item in soup.find_all("li", class_="description__job-criteria-item"):
+            header = item.find("h3", class_="description__job-criteria-subheader")
+            value = item.find("span", class_="description__job-criteria-text")
+            if header and value:
+                criteria[header.get_text(strip=True).lower()] = value.get_text(strip=True)
+
+        return {
+            "description": description,
+            "seniority": criteria.get("seniority level", ""),
+            "employment_type": criteria.get("employment type", ""),
+            "job_function": criteria.get("job function", ""),
+            "industries": criteria.get("industries", ""),
         }
 
     @staticmethod

--- a/backend/src/hiresense/ingestion/adapters/linkedin.py
+++ b/backend/src/hiresense/ingestion/adapters/linkedin.py
@@ -122,7 +122,10 @@ class LinkedInAdapter:
                 if detail:
                     card.update(detail)
 
-        await asyncio.gather(*(fetch_one(c) for c in cards), return_exceptions=True)
+        await asyncio.gather(*(fetch_one(c) for c in cards))
+
+        enriched = sum(1 for c in cards if c.get("description"))
+        logger.info("LinkedIn detail enrichment: %d/%d jobs enriched", enriched, len(cards))
 
     async def _fetch_detail(
         self,

--- a/backend/src/hiresense/ingestion/domain/job_filter.py
+++ b/backend/src/hiresense/ingestion/domain/job_filter.py
@@ -17,6 +17,8 @@ class JobQueryParams(BaseModel):
     skills: str | None = None
     date_from: datetime | None = None
     date_to: datetime | None = None
+    user_location: str | None = None
+    strict_location: bool = False
 
 
 class PaginatedResult(BaseModel):

--- a/backend/src/hiresense/ingestion/domain/normalizers/linkedin_normalizer.py
+++ b/backend/src/hiresense/ingestion/domain/normalizers/linkedin_normalizer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime
 from typing import Any
 
 from hiresense.ingestion.domain.models import RawJobListing
@@ -8,14 +9,26 @@ from hiresense.ingestion.domain.models import RawJobListing
 class LinkedInNormalizer:
     def normalize(self, raw: RawJobListing) -> dict[str, Any]:
         d = raw.raw_data
+        posted_date = self._parse_date(d.get("posted_date", ""))
         return {
             "title": d.get("title", ""),
             "company": d.get("company", ""),
-            "description": "",
+            "description": d.get("description", ""),
             "skills": [],
             "location": d.get("location", ""),
             "salary_range": None,
             "url": d.get("url", ""),
             "language": "en",
-            "posted_date": None,
+            "posted_date": posted_date,
+            "department": d.get("job_function") or None,
+            "categories": [c for c in [d.get("seniority"), d.get("employment_type")] if c],
         }
+
+    @staticmethod
+    def _parse_date(value: str) -> datetime | None:
+        if not value:
+            return None
+        try:
+            return datetime.strptime(value, "%Y-%m-%d")
+        except ValueError:
+            return None

--- a/backend/src/hiresense/tracking/infrastructure/repository.py
+++ b/backend/src/hiresense/tracking/infrastructure/repository.py
@@ -32,6 +32,7 @@ class TrackingRepository:
         with self._session_factory() as session:
             application = session.merge(application)
             session.commit()
+            session.refresh(application)
             return application
 
     def create(self, application: TrackedApplication) -> TrackedApplication:

--- a/backend/tests/unit/ingestion/test_job_filter.py
+++ b/backend/tests/unit/ingestion/test_job_filter.py
@@ -156,3 +156,15 @@ def test_empty_result() -> None:
     assert result.total == 0
     assert result.jobs == []
     assert result.total_pages == 0
+
+
+def test_job_query_params_defaults_for_location_match() -> None:
+    params = JobQueryParams()
+    assert params.user_location is None
+    assert params.strict_location is False
+
+
+def test_job_query_params_accepts_location_match_fields() -> None:
+    params = JobQueryParams(user_location="Chile", strict_location=True)
+    assert params.user_location == "Chile"
+    assert params.strict_location is True

--- a/docs/superpowers/plans/2026-05-24-job-detail-panel-and-location-filter.md
+++ b/docs/superpowers/plans/2026-05-24-job-detail-panel-and-location-filter.md
@@ -1,0 +1,1110 @@
+# Job Detail Panel Layout + Location Filter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the Ingestion job-detail side panel layout so the action buttons stay visible, and add an opt-in "only show jobs I can apply to from my location" filter that works across all sources.
+
+**Architecture:** Backend adds two query params (`user_location`, `strict_location`) to `JobQueryParams` and a new filter step in `filter_and_paginate` that operates on the normalized `location` string. Frontend adds a text input + checkbox to `JobFiltersComponent`, persists them in `localStorage`, and forwards them through `IngestionService.queryJobs`. The detail panel is restructured from a flex column with a competing inner scroll into a 3-row CSS grid (sticky header, scrollable body, sticky footer).
+
+**Tech Stack:** FastAPI + Pydantic (backend), Angular 17+ standalone components with signals (frontend), pytest (backend tests).
+
+**Spec:** `docs/superpowers/specs/2026-05-24-job-detail-panel-and-location-filter-design.md`
+
+---
+
+## File Structure
+
+**Backend**
+- Modify: `backend/src/hiresense/ingestion/domain/job_filter.py` — add `user_location` + `strict_location` to `JobQueryParams`, add filter step in `filter_and_paginate`.
+- Modify: `backend/src/hiresense/ingestion/api/routes.py` — add the two new query params to `list_jobs` and forward them to `JobQueryParams`.
+- Modify: `backend/tests/unit/ingestion/test_job_filter.py` — add tests for the strict-match filter.
+
+**Frontend**
+- Modify: `frontend/src/app/core/services/ingestion.service.ts` — extend `JobFilters` interface + `queryJobs` to send new params.
+- Modify: `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.ts` — load/persist `user_location` + `strict_location` from `localStorage`, emit them in filter updates.
+- Modify: `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.html` — add "My location" text input + "Only matching" checkbox.
+- Modify: `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.scss` — style for the new checkbox row.
+- Modify: `frontend/src/app/pages/ingestion/components/job-detail-panel/job-detail-panel.component.html` — wrap middle sections in `.panel-body`.
+- Modify: `frontend/src/app/pages/ingestion/components/job-detail-panel/job-detail-panel.component.scss` — switch `.panel` to CSS grid, remove description `max-height`.
+
+---
+
+## Task 1: Backend — extend `JobQueryParams` with location-match fields
+
+**Files:**
+- Modify: `backend/src/hiresense/ingestion/domain/job_filter.py`
+- Test: `backend/tests/unit/ingestion/test_job_filter.py`
+
+- [ ] **Step 1: Write failing test for new params on the model**
+
+Append to `backend/tests/unit/ingestion/test_job_filter.py`:
+
+```python
+def test_job_query_params_defaults_for_location_match() -> None:
+    params = JobQueryParams()
+    assert params.user_location is None
+    assert params.strict_location is False
+
+
+def test_job_query_params_accepts_location_match_fields() -> None:
+    params = JobQueryParams(user_location="Chile", strict_location=True)
+    assert params.user_location == "Chile"
+    assert params.strict_location is True
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest backend/tests/unit/ingestion/test_job_filter.py::test_job_query_params_defaults_for_location_match backend/tests/unit/ingestion/test_job_filter.py::test_job_query_params_accepts_location_match_fields -v`
+
+Expected: FAIL — Pydantic raises `ValidationError` (extra fields) or `AttributeError` (no such attribute).
+
+- [ ] **Step 3: Add the fields to `JobQueryParams`**
+
+Edit `backend/src/hiresense/ingestion/domain/job_filter.py`. Inside the `JobQueryParams` class, append two new fields after `date_to`:
+
+```python
+class JobQueryParams(BaseModel):
+    page: int = 1
+    page_size: int = 20
+    source: str | None = None
+    keyword: str | None = None
+    location: str | None = None
+    skills: str | None = None
+    date_from: datetime | None = None
+    date_to: datetime | None = None
+    user_location: str | None = None
+    strict_location: bool = False
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest backend/tests/unit/ingestion/test_job_filter.py::test_job_query_params_defaults_for_location_match backend/tests/unit/ingestion/test_job_filter.py::test_job_query_params_accepts_location_match_fields -v`
+
+Expected: PASS (both tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/domain/job_filter.py backend/tests/unit/ingestion/test_job_filter.py
+git commit -m "feat(ingestion): add user_location and strict_location to JobQueryParams"
+```
+
+---
+
+## Task 2: Backend — strict-match filter logic in `filter_and_paginate`
+
+**Files:**
+- Modify: `backend/src/hiresense/ingestion/domain/job_filter.py`
+- Test: `backend/tests/unit/ingestion/test_job_filter.py`
+
+- [ ] **Step 1: Write failing tests for the strict-match behavior**
+
+Append to `backend/tests/unit/ingestion/test_job_filter.py`:
+
+```python
+def test_strict_location_off_is_no_op() -> None:
+    jobs = [
+        _job(id="1", location="Remote (Remote)"),
+        _job(id="2", location="Chile"),
+        _job(id="3", location="USA only"),
+    ]
+    params = JobQueryParams(user_location="Chile", strict_location=False)
+    result = filter_and_paginate(jobs, params)
+    assert result.total == 3
+
+
+def test_strict_location_requires_user_location_set() -> None:
+    jobs = [_job(id="1", location="USA only"), _job(id="2", location="Chile")]
+    params = JobQueryParams(user_location=None, strict_location=True)
+    result = filter_and_paginate(jobs, params)
+    assert result.total == 2
+
+
+def test_strict_location_includes_empty_location() -> None:
+    jobs = [_job(id="1", location="")]
+    params = JobQueryParams(user_location="Chile", strict_location=True)
+    result = filter_and_paginate(jobs, params)
+    assert result.total == 1
+
+
+def test_strict_location_includes_worldwide_keywords() -> None:
+    jobs = [
+        _job(id="1", location="Worldwide"),
+        _job(id="2", location="Remote - Anywhere"),
+        _job(id="3", location="Global remote"),
+    ]
+    params = JobQueryParams(user_location="Chile", strict_location=True)
+    result = filter_and_paginate(jobs, params)
+    assert result.total == 3
+
+
+def test_strict_location_includes_user_country_substring() -> None:
+    jobs = [
+        _job(id="1", location="Chile"),
+        _job(id="2", location="Chile (Remote)"),
+        _job(id="3", location="Latin America - Chile, Peru"),
+    ]
+    params = JobQueryParams(user_location="Chile", strict_location=True)
+    result = filter_and_paginate(jobs, params)
+    assert result.total == 3
+
+
+def test_strict_location_excludes_non_matching() -> None:
+    jobs = [
+        _job(id="1", location="USA only"),
+        _job(id="2", location="Remote (Remote)"),
+        _job(id="3", location="Europe"),
+    ]
+    params = JobQueryParams(user_location="Chile", strict_location=True)
+    result = filter_and_paginate(jobs, params)
+    assert result.total == 0
+
+
+def test_strict_location_case_insensitive() -> None:
+    jobs = [
+        _job(id="1", location="CHILE"),
+        _job(id="2", location="chile"),
+        _job(id="3", location="WORLDWIDE"),
+    ]
+    params = JobQueryParams(user_location="chile", strict_location=True)
+    result = filter_and_paginate(jobs, params)
+    assert result.total == 3
+
+
+def test_strict_location_trims_user_location() -> None:
+    jobs = [_job(id="1", location="Chile"), _job(id="2", location="USA")]
+    params = JobQueryParams(user_location="  Chile  ", strict_location=True)
+    result = filter_and_paginate(jobs, params)
+    assert result.total == 1
+    assert result.jobs[0].location == "Chile"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest backend/tests/unit/ingestion/test_job_filter.py -k "strict_location" -v`
+
+Expected: PASS only on `test_strict_location_off_is_no_op` and `test_strict_location_requires_user_location_set` (they exercise behavior that already works); FAIL on the rest because the strict filter doesn't exist yet.
+
+Actually `test_strict_location_excludes_non_matching` will fail because all 3 jobs currently pass through (no filter applied) — `result.total == 3`, not `0`. Confirm fail mode.
+
+- [ ] **Step 3: Add the filter step to `filter_and_paginate`**
+
+In `backend/src/hiresense/ingestion/domain/job_filter.py`, locate the `filter_and_paginate` function and add the new filter block immediately **after** the existing `params.date_to` block (line 67 in current code) and **before** the `total = len(filtered)` line.
+
+```python
+    if params.strict_location and params.user_location:
+        user_loc = params.user_location.strip().lower()
+        open_keywords = ("worldwide", "anywhere", "global")
+
+        def _is_open(job_location: str) -> bool:
+            if not job_location:
+                return True
+            loc = job_location.lower()
+            if any(kw in loc for kw in open_keywords):
+                return True
+            return user_loc in loc
+
+        filtered = [j for j in filtered if _is_open(j.location)]
+```
+
+- [ ] **Step 4: Run all strict-location tests to verify they pass**
+
+Run: `uv run pytest backend/tests/unit/ingestion/test_job_filter.py -k "strict_location" -v`
+
+Expected: PASS (all 8 tests).
+
+- [ ] **Step 5: Run the full job-filter test file to confirm no regression**
+
+Run: `uv run pytest backend/tests/unit/ingestion/test_job_filter.py -v`
+
+Expected: PASS (all tests, including the pre-existing ones).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/domain/job_filter.py backend/tests/unit/ingestion/test_job_filter.py
+git commit -m "feat(ingestion): strict location-match filter in filter_and_paginate"
+```
+
+---
+
+## Task 3: Backend — surface the new params on the `/ingestion/jobs` route
+
+**Files:**
+- Modify: `backend/src/hiresense/ingestion/api/routes.py`
+- Test: `backend/tests/unit/ingestion/test_routes.py`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `backend/tests/unit/ingestion/test_routes.py`. The file uses `_make_app()` which builds a fresh app + fake orchestrator/scanner per test. The existing `FakeOrchestrator.list_jobs()` returns a single `BOARD_JOB` with `location="Remote"`. To exercise the strict filter we need an orchestrator that returns multiple jobs with varied locations — define a local fake inline for the new test:
+
+```python
+@pytest.mark.asyncio
+async def test_list_jobs_strict_location_filters_non_matching() -> None:
+    chile_job = NormalizedJob(
+        id="job-chile",
+        title="Chile Engineer",
+        company="Co",
+        description="Job",
+        skills=[],
+        location="Chile (Remote)",
+        source="remotive",
+        source_type="api",
+        language="en",
+        url="https://example.com/chile",
+    )
+    restricted_job = NormalizedJob(
+        id="job-restricted",
+        title="USA Only Engineer",
+        company="Co",
+        description="Job",
+        skills=[],
+        location="USA only",
+        source="remotive",
+        source_type="api",
+        language="en",
+        url="https://example.com/usa",
+    )
+    ambiguous_remote_job = NormalizedJob(
+        id="job-remote-remote",
+        title="Remote Remote Engineer",
+        company="Co",
+        description="Job",
+        skills=[],
+        location="Remote (Remote)",
+        source="getonboard",
+        source_type="api",
+        language="en",
+        url="https://example.com/getonboard",
+    )
+    worldwide_job = NormalizedJob(
+        id="job-worldwide",
+        title="Global Engineer",
+        company="Co",
+        description="Job",
+        skills=[],
+        location="Worldwide",
+        source="remotive",
+        source_type="api",
+        language="en",
+        url="https://example.com/global",
+    )
+
+    class MultiJobOrchestrator:
+        async def run(self, filters=None) -> list[NormalizedJob]:
+            return []
+
+        def list_jobs(self) -> list[NormalizedJob]:
+            return [chile_job, restricted_job, ambiguous_remote_job, worldwide_job]
+
+    app = FastAPI()
+    app.dependency_overrides[get_ingestion_orchestrator] = lambda: MultiJobOrchestrator()
+    app.dependency_overrides[get_portal_scanner] = lambda: FakeScanner()
+    app.include_router(router)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            "/ingestion/jobs",
+            params={"tab": "boards", "user_location": "Chile", "strict_location": "true"},
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    returned_ids = {j["id"] for j in data["jobs"]}
+    assert returned_ids == {"job-chile", "job-worldwide"}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest backend/tests/unit/ingestion/test_routes.py::test_list_jobs_strict_location_filters_non_matching -v`
+
+Expected: FAIL — the route doesn't yet accept `user_location` / `strict_location`. Depending on FastAPI behavior, either the unknown params are silently ignored and all four jobs come back (`returned_ids == 4 ids`), or the test fails on the assertion. Either way it should not pass.
+
+- [ ] **Step 3: Update the route signature**
+
+In `backend/src/hiresense/ingestion/api/routes.py`, the `list_jobs` function (currently lines 52–77). Add two new parameters and forward them into `JobQueryParams`:
+
+```python
+@router.get("/jobs", response_model=PaginatedResult)
+async def list_jobs(
+    tab: Annotated[Literal["boards", "portals"], Query()],
+    orchestrator: Annotated[IngestionOrchestrator, Depends(get_ingestion_orchestrator)],
+    scanner: Annotated[PortalScanner, Depends(get_portal_scanner)],
+    page: int = 1,
+    page_size: int = 20,
+    source: str | None = None,
+    keyword: str | None = None,
+    location: str | None = None,
+    skills: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
+    user_location: str | None = None,
+    strict_location: bool = False,
+) -> PaginatedResult:
+    all_jobs = orchestrator.list_jobs() if tab == "boards" else scanner.list_jobs()
+    params = JobQueryParams(
+        page=page,
+        page_size=page_size,
+        source=source,
+        keyword=keyword,
+        location=location,
+        skills=skills,
+        date_from=date_from,
+        date_to=date_to,
+        user_location=user_location,
+        strict_location=strict_location,
+    )
+    return filter_and_paginate(all_jobs, params)
+```
+
+- [ ] **Step 4: Run the route test to verify it passes**
+
+Run: `uv run pytest backend/tests/unit/ingestion/test_routes.py::test_list_jobs_strict_location_filters_non_matching -v`
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full ingestion unit suite to confirm no regression**
+
+Run: `uv run pytest backend/tests/unit/ingestion -v`
+
+Expected: PASS (all tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/src/hiresense/ingestion/api/routes.py backend/tests/unit/ingestion/test_routes.py
+git commit -m "feat(ingestion): expose user_location and strict_location on jobs endpoint"
+```
+
+---
+
+## Task 4: Frontend — extend `JobFilters` interface and `queryJobs`
+
+**Files:**
+- Modify: `frontend/src/app/core/services/ingestion.service.ts`
+
+- [ ] **Step 1: Extend the `JobFilters` interface**
+
+In `frontend/src/app/core/services/ingestion.service.ts`, replace the existing `JobFilters` interface with:
+
+```ts
+export interface JobFilters {
+  source?: string;
+  keyword?: string;
+  location?: string;
+  skills?: string;
+  date_from?: string;
+  date_to?: string;
+  user_location?: string;
+  strict_location?: boolean;
+}
+```
+
+- [ ] **Step 2: Forward the new params in `queryJobs`**
+
+In the same file, locate the `queryJobs` method (currently lines 31–50). Inside the body, after the existing `if (filters.date_to) ...` line, add:
+
+```ts
+    if (filters.user_location) params = params.set('user_location', filters.user_location);
+    if (filters.strict_location) params = params.set('strict_location', 'true');
+```
+
+Note: only send `strict_location` when it's truthy. Sending `false` is unnecessary because the backend default is `false`.
+
+- [ ] **Step 3: Verify the frontend type-checks**
+
+Run from the frontend directory: `npm run build` (or whatever the project uses — check `frontend/package.json` for the build script; commonly `ng build`).
+
+If a leaner check exists (e.g., `npm run typecheck` or `tsc --noEmit`), prefer it. Expected: build/typecheck succeeds with no new errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/core/services/ingestion.service.ts
+git commit -m "feat(ingestion): extend JobFilters and queryJobs with location-match params"
+```
+
+---
+
+## Task 5: Frontend — UI controls + localStorage persistence in `JobFiltersComponent`
+
+**Files:**
+- Modify: `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.ts`
+- Modify: `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.html`
+- Modify: `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.scss`
+- Modify: `frontend/src/app/pages/ingestion/ingestion.component.ts`
+
+- [ ] **Step 1: Add localStorage keys + persistence helpers + handlers in the component class**
+
+Replace the contents of `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.ts` with:
+
+```ts
+import { Component, OnInit, input, output } from '@angular/core';
+import { JobFilters } from '../../../../core/services/ingestion.service';
+
+const LS_USER_LOCATION = 'hiresense.user_location';
+const LS_STRICT_LOCATION = 'hiresense.strict_location_match';
+
+@Component({
+  selector: 'app-job-filters',
+  standalone: true,
+  imports: [],
+  templateUrl: './job-filters.component.html',
+  styleUrl: './job-filters.component.scss',
+})
+export class JobFiltersComponent implements OnInit {
+  sources = input.required<string[]>();
+  filters = input.required<JobFilters>();
+
+  filtersChange = output<JobFilters>();
+
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  ngOnInit(): void {
+    const storedLocation = localStorage.getItem(LS_USER_LOCATION) ?? '';
+    const storedStrict = localStorage.getItem(LS_STRICT_LOCATION) === 'true';
+    if (storedLocation || storedStrict) {
+      this.emitFilters({
+        user_location: storedLocation || undefined,
+        strict_location: storedStrict || undefined,
+      });
+    }
+  }
+
+  onSourceChange(event: Event): void {
+    const select = event.target as HTMLSelectElement;
+    const value = select.value;
+    this.emitFilters({ source: value || undefined });
+  }
+
+  onKeywordInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value.trim();
+    this.debounceEmit({ keyword: value || undefined });
+  }
+
+  onLocationInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value.trim();
+    this.debounceEmit({ location: value || undefined });
+  }
+
+  onSkillsInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value.trim();
+    this.debounceEmit({ skills: value || undefined });
+  }
+
+  onDateFromChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.emitFilters({ date_from: value || undefined });
+  }
+
+  onDateToChange(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.emitFilters({ date_to: value || undefined });
+  }
+
+  onUserLocationInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value.trim();
+    if (value) {
+      localStorage.setItem(LS_USER_LOCATION, value);
+    } else {
+      localStorage.removeItem(LS_USER_LOCATION);
+    }
+    this.debounceEmit({ user_location: value || undefined });
+  }
+
+  onStrictLocationChange(event: Event): void {
+    const checked = (event.target as HTMLInputElement).checked;
+    localStorage.setItem(LS_STRICT_LOCATION, checked ? 'true' : 'false');
+    this.emitFilters({ strict_location: checked || undefined });
+  }
+
+  clearAll(): void {
+    const userLocation = localStorage.getItem(LS_USER_LOCATION) ?? '';
+    const strict = localStorage.getItem(LS_STRICT_LOCATION) === 'true';
+    this.filtersChange.emit({
+      user_location: userLocation || undefined,
+      strict_location: strict || undefined,
+    });
+  }
+
+  private emitFilters(partial: Partial<JobFilters>): void {
+    this.filtersChange.emit({ ...this.filters(), ...partial });
+  }
+
+  private debounceEmit(partial: Partial<JobFilters>): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => this.emitFilters(partial), 300);
+  }
+}
+```
+
+Key behaviors locked in here:
+- On init, hydrate from localStorage and emit so the parent immediately filters with the stored values.
+- "My location" input writes to localStorage on every keystroke.
+- Strict checkbox writes immediately on change.
+- `clearAll()` preserves the user's location preferences (they're settings, not session filters) — only the search-style filters reset.
+
+- [ ] **Step 2: Add the two new controls to the template**
+
+Replace the contents of `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.html` with:
+
+```html
+<div class="filters-bar">
+  <div class="filter-item">
+    <label class="filter-label">Source</label>
+    <select (change)="onSourceChange($event)" class="filter-control">
+      <option value="">All sources</option>
+      @for (source of sources(); track source) {
+        <option [value]="source" [selected]="filters().source === source">{{ source }}</option>
+      }
+    </select>
+  </div>
+
+  <div class="filter-item">
+    <label class="filter-label">Keyword</label>
+    <input
+      type="text"
+      [value]="filters().keyword ?? ''"
+      (input)="onKeywordInput($event)"
+      placeholder="Search title, description..."
+      class="filter-control"
+    />
+  </div>
+
+  <div class="filter-item">
+    <label class="filter-label">Location</label>
+    <input
+      type="text"
+      [value]="filters().location ?? ''"
+      (input)="onLocationInput($event)"
+      placeholder="e.g. Remote, USA..."
+      class="filter-control"
+    />
+  </div>
+
+  <div class="filter-item">
+    <label class="filter-label">Skills</label>
+    <input
+      type="text"
+      [value]="filters().skills ?? ''"
+      (input)="onSkillsInput($event)"
+      placeholder="Python, React..."
+      class="filter-control"
+    />
+  </div>
+
+  <div class="filter-item">
+    <label class="filter-label">Date From</label>
+    <input
+      type="date"
+      [value]="filters().date_from ?? ''"
+      (change)="onDateFromChange($event)"
+      class="filter-control"
+    />
+  </div>
+
+  <div class="filter-item">
+    <label class="filter-label">Date To</label>
+    <input
+      type="date"
+      [value]="filters().date_to ?? ''"
+      (change)="onDateToChange($event)"
+      class="filter-control"
+    />
+  </div>
+
+  <div class="filter-item filter-item-clear">
+    <button (click)="clearAll()" class="btn-clear">Clear all</button>
+  </div>
+</div>
+
+<div class="location-pref-bar">
+  <div class="filter-item">
+    <label class="filter-label">My location</label>
+    <input
+      type="text"
+      [value]="filters().user_location ?? ''"
+      (input)="onUserLocationInput($event)"
+      placeholder="e.g. Chile, USA, Spain"
+      class="filter-control"
+    />
+  </div>
+  <label class="strict-toggle">
+    <input
+      type="checkbox"
+      [checked]="filters().strict_location ?? false"
+      (change)="onStrictLocationChange($event)"
+    />
+    <span>Only show jobs I can apply to from my location</span>
+  </label>
+</div>
+```
+
+- [ ] **Step 3: Style the new row**
+
+Append to `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.scss`:
+
+```scss
+.location-pref-bar {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  padding: 0.75rem 1.25rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+
+  .filter-item {
+    min-width: 200px;
+    max-width: 280px;
+  }
+}
+
+.strict-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  padding-bottom: 0.375rem;
+
+  input[type="checkbox"] {
+    width: auto;
+    margin: 0;
+    cursor: pointer;
+  }
+
+  span {
+    user-select: none;
+  }
+}
+```
+
+- [ ] **Step 4: Confirm the parent passes filters through unchanged**
+
+Open `frontend/src/app/pages/ingestion/ingestion.component.ts` and verify the `onFiltersChange` handler (line 147) merges/replaces filters as expected. Current code:
+
+```ts
+onFiltersChange(newFilters: JobFilters): void {
+  this.filters.set(newFilters);
+  this.page.set(1);
+  this.loadJobs();
+}
+```
+
+This already replaces the full filter object, so the new `user_location` and `strict_location` propagate without changes. No edit needed — just confirm.
+
+- [ ] **Step 5: Type-check the frontend**
+
+Run from the frontend directory: `npm run build` (or the project's typecheck script).
+
+Expected: succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/app/pages/ingestion/components/job-filters/
+git commit -m "feat(ingestion): add user location + strict-match toggle with localStorage persistence"
+```
+
+---
+
+## Task 6: Frontend — restructure the job-detail panel layout
+
+**Files:**
+- Modify: `frontend/src/app/pages/ingestion/components/job-detail-panel/job-detail-panel.component.html`
+- Modify: `frontend/src/app/pages/ingestion/components/job-detail-panel/job-detail-panel.component.scss`
+
+- [ ] **Step 1: Wrap the scrollable middle in `.panel-body`**
+
+Replace the contents of `frontend/src/app/pages/ingestion/components/job-detail-panel/job-detail-panel.component.html` with:
+
+```html
+<div class="panel-overlay" (click)="onOverlayClick($event)">
+  <div class="panel">
+    <!-- Header -->
+    <div class="panel-header">
+      <div>
+        <h2 class="panel-title">{{ job().title }}</h2>
+        <p class="panel-company">{{ job().company }}</p>
+      </div>
+      <button (click)="close.emit()" class="btn-close">✕</button>
+    </div>
+
+    <!-- Scrollable body -->
+    <div class="panel-body">
+      <!-- Meta grid -->
+      <div class="panel-section meta-grid">
+        <div class="meta-item">
+          <span class="meta-label">Location</span>
+          <span class="meta-value">{{ job().location || '—' }}</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">Posted</span>
+          <span class="meta-value">{{ job().posted_date ? (job().posted_date | date:'longDate') : '—' }}</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">Salary Range</span>
+          <span class="meta-value">{{ job().salary_range || '—' }}</span>
+        </div>
+        <div class="meta-item">
+          <span class="meta-label">Department</span>
+          <span class="meta-value">{{ job().department || '—' }}</span>
+        </div>
+      </div>
+
+      <!-- Source -->
+      <div class="panel-section">
+        <span class="section-label">Source</span>
+        <div class="source-badges">
+          <span class="badge source-badge">{{ job().source }}</span>
+          <span class="badge type-badge">{{ job().source_type }}</span>
+          @if (job().platform) {
+            <span class="badge platform-badge">{{ job().platform }}</span>
+          }
+        </div>
+        @if (job().categories.length > 0) {
+          <div class="category-tags">
+            @for (cat of job().categories; track cat) {
+              <span class="badge category-badge">{{ cat }}</span>
+            }
+          </div>
+        }
+      </div>
+
+      <!-- Skills -->
+      @if (job().skills.length > 0) {
+        <div class="panel-section">
+          <span class="section-label">Skills</span>
+          <div class="skill-chips">
+            @for (skill of job().skills; track skill) {
+              <span class="skill-tag">{{ skill }}</span>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Description -->
+      <div class="panel-section">
+        <span class="section-label">Description</span>
+        <div class="description-text">{{ job().description }}</div>
+      </div>
+    </div>
+
+    <!-- Actions -->
+    <div class="panel-actions">
+      <a [href]="job().url" target="_blank" rel="noopener" class="btn-primary btn-action">
+        View Original ↗
+      </a>
+      @if (tracked()) {
+        <button class="btn-tracked btn-action" disabled>Tracked ✓</button>
+      } @else {
+        <button (click)="onTrack()" class="btn-secondary btn-action">Track</button>
+      }
+    </div>
+  </div>
+</div>
+```
+
+- [ ] **Step 2: Switch `.panel` to grid + remove the description's competing scroll**
+
+Replace the contents of `frontend/src/app/pages/ingestion/components/job-detail-panel/job-detail-panel.component.scss` with:
+
+```scss
+.panel-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 100;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.panel {
+  width: 460px;
+  max-width: 90vw;
+  height: 100%;
+  background: var(--bg-card);
+  border-left: 1px solid var(--border-default);
+  box-shadow: var(--shadow-lg);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  overflow: hidden;
+  animation: slideIn 0.2s var(--ease);
+}
+
+@keyframes slideIn {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-card);
+}
+
+.panel-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.panel-company {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  font-weight: 500;
+  margin: 0.25rem 0 0;
+}
+
+.btn-close {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  line-height: 1;
+
+  &:hover { color: var(--text-primary); }
+}
+
+.panel-body {
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.panel-section {
+  padding: 1rem 1.5rem;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.section-label {
+  display: block;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  margin-bottom: 0.5rem;
+  font-weight: 600;
+}
+
+.meta-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.75rem;
+}
+
+.meta-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.meta-label {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.meta-value {
+  font-size: 0.8125rem;
+  color: var(--text-primary);
+}
+
+.source-badges,
+.category-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.category-tags {
+  margin-top: 0.5rem;
+}
+
+.source-badge {
+  background: var(--accent-bg, #e0f2f1);
+  color: var(--accent);
+}
+
+.type-badge {
+  background: var(--bg-inset);
+  color: var(--text-secondary);
+}
+
+.platform-badge {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.category-badge {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.skill-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.description-text {
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: var(--text-secondary);
+  white-space: pre-line;
+}
+
+.panel-actions {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  gap: 0.75rem;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-card);
+}
+
+.btn-action {
+  flex: 1;
+  text-align: center;
+  padding: 0.625rem 1rem;
+  border-radius: var(--radius-md);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  display: inline-block;
+}
+
+.btn-tracked {
+  background: var(--success-bg);
+  color: var(--success);
+  border: 1px solid #bbf7d0;
+  cursor: default;
+}
+```
+
+Key changes vs. the previous SCSS:
+- `.panel`: `display: grid; grid-template-rows: auto 1fr auto; height: 100%; overflow: hidden;` (was flex column with `overflow-y: auto`).
+- `.panel-body`: new — owns the single scroll region.
+- `.description-text`: lost `max-height: 300px` and inner `overflow-y` so it flows naturally.
+- `.panel-actions`: lost `margin-top: auto` (grid handles bottom row); gained `border-top` and background to look like a footer.
+
+- [ ] **Step 3: Type-check the frontend**
+
+Run from the frontend directory: `npm run build` (or the project's typecheck script).
+
+Expected: succeeds.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/app/pages/ingestion/components/job-detail-panel/
+git commit -m "fix(ingestion): job detail panel uses grid layout with sticky header and footer"
+```
+
+---
+
+## Task 7: Manual browser verification
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Start backend and frontend dev servers**
+
+In separate terminals:
+
+```bash
+# Backend (from backend/)
+uv run uvicorn hiresense.main:app --reload
+
+# Frontend (from frontend/)
+npm start
+```
+
+Wait until both are reachable: backend on its configured port (default `:8000`), frontend on `:4200`.
+
+- [ ] **Step 2: Verify the detail panel layout**
+
+1. Open `http://localhost:4200/dashboard/ingestion` in a browser.
+2. Click any job row to open the side panel.
+3. Confirm: header (title + company + close X) is visible at the top.
+4. Confirm: `View Original` and `Track` buttons are visible at the bottom of the panel.
+5. Scroll inside the panel — only the middle section (`.panel-body`) scrolls; the header and the actions footer stay in place.
+6. Open a job with a long description (e.g., the getonbrd Full-Stack Software Engineer job). Confirm scrolling reaches the end of the description without losing the actions footer.
+
+If the actions footer disappears or the header scrolls away, the grid/`min-height: 0` setup is wrong — re-check Task 6 Step 2.
+
+- [ ] **Step 3: Verify the location filter — strict OFF**
+
+1. Reload the page.
+2. In the new "My location" input, type `Chile`.
+3. Leave the "Only show jobs I can apply to from my location" checkbox **unchecked**.
+4. Confirm the jobs list still shows jobs with locations like `Remote (Remote)`, `Chile`, `USA`, etc. — no filtering should happen because strict is off.
+
+- [ ] **Step 4: Verify the location filter — strict ON**
+
+1. Tick the checkbox.
+2. Confirm jobs with location `Remote (Remote)`, `USA only`, `Europe`, etc. **disappear** from the list.
+3. Confirm jobs with location `Chile`, `Chile (Remote)`, `Worldwide`, `Latin America - Chile`, or empty location **remain**.
+4. Pick a previously-visible getonbrd job tagged `Remote (Remote)` and confirm it is gone from the list.
+
+- [ ] **Step 5: Verify persistence across refresh**
+
+1. Refresh the page (F5).
+2. Confirm the "My location" input still shows `Chile` and the checkbox is still ticked.
+3. Confirm the filtered list matches the strict-on view from Step 4.
+
+- [ ] **Step 6: Verify `Clear all` does not wipe location preferences**
+
+1. Add a keyword filter (e.g., type `engineer` in the Keyword input) and confirm results filter further.
+2. Click `Clear all`.
+3. Confirm the keyword input clears but `My location` and the strict checkbox are still set.
+
+- [ ] **Step 7: Verify untoggling restores the full list**
+
+1. Untick the strict checkbox.
+2. Confirm the previously-excluded jobs (`Remote (Remote)`, `USA only`, etc.) reappear.
+
+- [ ] **Step 8: Document any visual oddities**
+
+If any styling looks off (uneven padding on the new filter row, awkward wrapping at narrow widths, etc.), capture a screenshot and fix in a follow-up commit before declaring the task complete.
+
+- [ ] **Step 9: Stop the dev servers**
+
+Kill both dev server processes.
+
+---
+
+## Final verification
+
+- [ ] **Step 1: Run the full backend test suite**
+
+```bash
+uv run pytest backend/tests
+```
+
+Expected: PASS (or no new failures vs. baseline).
+
+- [ ] **Step 2: Run the frontend build one last time**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: succeeds, no new warnings.
+
+- [ ] **Step 3: Confirm git history is clean**
+
+```bash
+git log --oneline -10
+```
+
+Expected: 6 new commits (one per Task 1–6) on top of `f8f198c`. Task 7 is verification-only — no commit unless visual fixes were needed.

--- a/docs/superpowers/specs/2026-05-24-application-pipeline-redesign-design.md
+++ b/docs/superpowers/specs/2026-05-24-application-pipeline-redesign-design.md
@@ -1,0 +1,251 @@
+# Application Pipeline Redesign
+
+**Status:** Approved, ready for implementation planning
+**Date:** 2026-05-24
+
+## Problem
+
+The product has the right vertical slices (Ingestion, Matching, Optimization, Tracking, Interview) but no spine connecting them. Three concrete pain points:
+
+1. **CV Optimization** asks the user to type the job description, required skills, and missing skills by hand — even when the same job has already been ingested and matched. `MatchResult` already contains `matched_skills` and `missing_skills`, but the optimization page ignores it (the request hard-codes `match_id='manual'`).
+2. **`TrackedApplication` is a stub.** It stores `title`, `company`, `url`, `notes`, `status` only. There is no link to the match result, the optimized CV, or the interview prep. The user can't "dig into" an application because there is nothing to dig into.
+3. **Interview prep** is an island. It accepts free-form `job_title`/`company`/`description` and is not aware of tracked applications. Newly created applications don't surface there.
+
+## Goals
+
+- A tracked application becomes the **central object** of the pipeline. Job, match, CV optimization, and interview prep all hang off it.
+- The optimization page never asks for required/missing skills — they come from the snapshot and the match.
+- Applications created anywhere in the app (Ingestion → Track, or pasted-description quick create) immediately surface on the Interview page.
+- The user can "dig" into any application via a single detail view, edit each piece, and regenerate any artifact.
+
+## Non-goals
+
+- No multi-user / org concerns — this is single-user.
+- No automated CV publishing / submitting to job boards.
+- No retroactive backfill of match/optimization/interview-prep for existing tracked rows — only the job snapshot is backfilled. The user re-runs each artifact on demand.
+
+## Architecture: Approach B — application as aggregate with child artifact tables
+
+`TrackedApplication` stays as the metadata row. Four new child tables, each FK → `tracked_applications.id` with `ON DELETE CASCADE`. The application detail endpoint returns the aggregate (app + 1:1 snapshot + latest of each 1:N artifact) in a single response.
+
+### Data model
+
+```
+tracked_applications                        (unchanged)
+  id, job_id (FK ingestion job, nullable),
+  title, company, url, status, notes,
+  applied_at, created_at, updated_at
+
+application_job_snapshots                   (NEW, 1:1)
+  id (UUID PK)
+  application_id (FK, UNIQUE, CASCADE)
+  description (text)
+  required_skills (JSON list[str])
+  source ('ingested' | 'manual' | 'llm_extracted')
+  created_at, updated_at
+
+application_matches                         (NEW, 1:N)
+  id (UUID PK)
+  application_id (FK, CASCADE)
+  overall_score (float)
+  semantic_score, skill_score, experience_score, language_score (float)
+  matched_skills, missing_skills (JSON list[str])
+  pros, cons, recommendations (JSON list[str])
+  cv_language (str)
+  created_at
+  INDEX (application_id, created_at DESC)
+
+application_cv_optimizations                (NEW, 1:N)
+  id (UUID PK)
+  application_id (FK, CASCADE)
+  match_id (FK application_matches.id, nullable)
+  cv_language (str)
+  original_tex (text)
+  optimized_tex (text)
+  improvement_summary (text)
+  changes (JSON — list of section diffs)
+  created_at
+  INDEX (application_id, created_at DESC)
+
+application_interview_preps                 (NEW, 1:N)
+  id (UUID PK)
+  application_id (FK, CASCADE)
+  competencies_to_probe, technical_topics, negotiation_points (JSON list[str])
+  matched_stories (JSON list[{story_id, story_title, relevance}])
+  created_at
+  INDEX (application_id, created_at DESC)
+```
+
+**Why this shape:**
+- Job snapshot is 1:1 because there's exactly one "current job description" per application. It's mutable but not versioned — when the user edits it, the row updates in place. (If a history of description edits becomes valuable later, this is a one-table refactor.)
+- Match / optimization / interview prep are 1:N because the user will iterate (re-run match after editing skills; try multiple CV versions; regenerate prep after adding stories). Latest is "most recent by `created_at`".
+- Snapshot is **frozen** at creation: if the upstream `NormalizedJob` is later purged or modified, the application remains self-contained.
+
+### New bounded context
+
+A new `hiresense/applications/` package with the same shape as the existing contexts:
+
+```
+hiresense/applications/
+  api/
+    routes.py, schemas.py, dependencies.py, provider.py
+  domain/
+    aggregate.py            (Application aggregate model — wraps snapshot + artifacts)
+    models.py               (SQLAlchemy models for the four new tables)
+    services.py             (ApplicationService — create, get, list, delete)
+    artifact_service.py     (ArtifactService — generate match / opt / prep, persist)
+    skill_extractor.py      (LLM-backed required-skill extractor)
+  infrastructure/
+    repository.py
+  ports/
+    __init__.py             (ApplicationRepositoryPort)
+```
+
+Per the project's `code-style` rule, each class lives in its own file; `__init__.py` re-exports for package-level imports.
+
+The new context **calls into** existing services:
+- `MatchingOrchestrator.analyze()` for match generation.
+- `CvOptimizer.optimize()` for optimization.
+- `InterviewPrepService.prepare()` for interview prep.
+- `ProfileService` to read the user's profile (skills, raw_tex, summary).
+
+Existing services don't move. The new aggregate is the orchestrator that calls them and persists the results into the new tables.
+
+### API surface
+
+New routes under `/applications`:
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/applications` | Create — body is either `{job_id}` (from ingestion) or `{title, company, description, url?}` (manual) |
+| GET | `/applications` | List — each row carries `has_match`, `has_optimization`, `has_prep`, `latest_match_score` flags |
+| GET | `/applications/{id}` | Full aggregate — app + snapshot + latest match + latest optimization + latest prep + history counts |
+| PATCH | `/applications/{id}` | Status, notes (existing tracking semantics) |
+| DELETE | `/applications/{id}` | Cascade |
+| PUT | `/applications/{id}/job-snapshot` | Edit description and/or required_skills |
+| POST | `/applications/{id}/job-snapshot/regenerate-skills` | LLM re-extract skills from current description |
+| POST | `/applications/{id}/match` | Generate new match using snapshot + active profile |
+| GET | `/applications/{id}/matches` | History (paginated) |
+| POST | `/applications/{id}/optimize` | Body `{cv_language, match_id?}` — generate CV optimization |
+| GET | `/applications/{id}/optimizations` | History |
+| POST | `/applications/{id}/interview-prep` | Generate interview prep |
+| GET | `/applications/{id}/interview-preps` | History |
+
+Existing `/tracking/*`, `/matching/analyze`, `/optimization/optimize`, `/interview/prepare` stay during the transition. After the frontend cutover, `/tracking/*` becomes a thin shim that proxies to `/applications`; the others remain as ad-hoc tools accessible only from quick-create paths.
+
+### Skill auto-extraction
+
+`required_skills` is populated **at creation** and updatable on demand:
+
+- **Ingested job**: copy `NormalizedJob.skills` verbatim into the snapshot. `source = 'ingested'`. No LLM call.
+- **Manual description**: synchronous LLM call from `POST /applications`. `source = 'llm_extracted'`. If the LLM call fails, the snapshot is still created with `required_skills=[]` and `source = 'manual'`; the user can hit "Regenerate skills" later.
+- **User edits description**: snapshot updates in place; `required_skills` is **not** auto-cleared. A separate "Regenerate skills" button calls `/job-snapshot/regenerate-skills`.
+
+`missing_skills` is never typed:
+- During match generation: computed as `required_skills − profile.skills` (case-insensitive) and persisted on the `application_matches` row.
+- The CV tab reads `missing_skills` from the latest match. If no match exists, the UI shows a prompt to "Run match first".
+
+### Frontend architecture
+
+**New route** `/dashboard/applications/:id` — `ApplicationDetailComponent`:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Software Engineer — Fieldguide          [status ▼]  ✕   │
+│  San Francisco, CA · Posted 2026-04-20                   │
+├──────────────────────────────────────────────────────────┤
+│  Job  │  Match  │  CV  │  Interview                      │
+├──────────────────────────────────────────────────────────┤
+│  (tab content)                                           │
+└──────────────────────────────────────────────────────────┘
+```
+
+- **Job tab** — description (editable textarea), required skills as removable chips, "Regenerate skills" button.
+- **Match tab** — score breakdown (semantic / skill / experience / language), matched + missing skill chips, pros/cons/recommendations, "Re-run match" button, history dropdown.
+- **CV tab** — language picker, "Generate optimization" button (disabled with hint if no match exists), latest result with `Download .tex`, version dropdown listing older optimizations.
+- **Interview tab** — "Generate prep" button, competencies / technical topics / negotiation points, matched stories with relevance text, history dropdown.
+
+**Repurposed pages**:
+
+- `/dashboard/tracking` — renamed **Applications**. Same list shape with new badges (`has_match`, `has_optimization`, `has_prep`, latest score). Rows link to `/applications/:id`. A "+ New application" button opens a small dialog: pick an ingested job OR paste title+company+description.
+- `/dashboard/optimization` — thin form: "Optimize a CV. Paste a job description, or pick an existing application." Submitting the paste form quick-creates an application and navigates to its CV tab. Removes the standalone manual-skill input that exists today.
+- `/dashboard/matching` — removed from main nav; the quick-create flow is the canonical entry point for ad-hoc matching, and "Re-run match" inside the detail view covers per-application matching. The existing component file stays in the codebase as a temporary shim during transition, then deleted.
+- `/dashboard/interview` — top section becomes **Applications** list (status filter + "Generate prep" button per row → opens detail view on Interview tab). Story bank component stays below, unchanged. The free-form prep form is removed.
+
+Components, one per file per project code-style:
+
+```
+frontend/src/app/pages/applications/
+  applications.component.ts                       (list view, replaces tracking)
+  application-detail.component.ts
+  components/
+    application-create-dialog.component.ts
+    job-tab.component.ts
+    match-tab.component.ts
+    cv-tab.component.ts
+    interview-tab.component.ts
+    skill-chips.component.ts                      (reusable add/remove chips)
+    artifact-history-dropdown.component.ts        (reusable for match/opt/prep history)
+  models/
+    application.model.ts
+    application-aggregate.model.ts
+    job-snapshot.model.ts
+    application-match.model.ts
+    cv-optimization.model.ts
+    application-interview-prep.model.ts
+```
+
+Existing `interview.component.ts` is restructured to use a new `applications-prep-list.component.ts` at the top and keeps the existing `story-bank` section below.
+
+### Pipeline flow
+
+```
+Ingestion job ──Track──> Application created
+                         │
+                         ├── snapshot.source = 'ingested', skills copied from NormalizedJob
+                         │
+Manual paste ──Quick-Create──> Application created
+                               │
+                               └── snapshot.source = 'llm_extracted', LLM extracts skills
+
+Application detail view (/applications/:id):
+  Job tab        — edit description, regenerate skills
+  Match tab      — POST /applications/:id/match  → reads snapshot + profile, persists match
+  CV tab         — POST /applications/:id/optimize → reads snapshot + latest match + profile.raw_tex
+  Interview tab  — POST /applications/:id/interview-prep → reads snapshot + story bank
+                   ↑ also reachable from /dashboard/interview applications list
+```
+
+### Migration (Alembic)
+
+One revision creates the four new tables and runs a data migration:
+
+1. Create `application_job_snapshots`, `application_matches`, `application_cv_optimizations`, `application_interview_preps`.
+2. For each existing `tracked_applications` row:
+   - If `job_id IS NOT NULL` and the referenced `NormalizedJob` exists, insert a snapshot with `description = NormalizedJob.description`, `required_skills = NormalizedJob.skills`, `source = 'ingested'`.
+   - Otherwise insert an empty snapshot (`description=''`, `required_skills=[]`, `source = 'manual'`).
+3. No backfill for match/optimization/interview prep — those are regenerated on demand.
+
+### Error handling and edge cases
+
+- **No active profile** when running match or optimize → 400 with a clear message; UI surfaces "Set up a profile first" with a link to `/dashboard/profile`.
+- **No match when optimizing** → 400; UI shows "Run match first" prompt instead of the optimize button.
+- **No stories when generating interview prep** → still allowed; the prep just returns empty `matched_stories`.
+- **LLM skill extraction fails** at create-time → application still created, `required_skills=[]`, `source='manual'`. UI shows a "Skills could not be extracted automatically — add manually or click Regenerate" banner.
+- **Concurrent regenerate calls** → not guarded at DB level; the latest write wins for snapshot, and each artifact endpoint inserts a new row, so duplicates are fine.
+- **Deleting an application** cascades all four child tables.
+- **Deleting an ingestion job** while an application references it → the application's `job_id` becomes a dangling FK (the ingestion side already allows this). The snapshot is frozen so functionality is unaffected. Add `ON DELETE SET NULL` on `tracked_applications.job_id` if not already configured.
+
+### Testing
+
+- Unit tests for `ApplicationService` (create from ingested, create from manual, edit snapshot, regenerate skills).
+- Unit tests for `ArtifactService` (generate match/opt/prep, history listing).
+- Integration test: full pipeline — ingest → track → match → optimize → prep — asserting each artifact is persisted with correct FKs.
+- Migration test on a fixture DB containing a `tracked_applications` row with and without `job_id`; assert snapshots backfilled correctly.
+- Frontend: Cypress or Playwright walk-through of the detail view's four tabs.
+
+### Open questions
+
+None blocking. Items to revisit during planning:
+- Where the `SkillExtractor` lives — `applications/domain/` vs a shared `nlp/` module — depends on whether other contexts need it.
+- Whether to add a thin DB-level `latest_*` materialized view for the list endpoint, or just compute the aggregates in the service (start with the latter; optimize only if needed).

--- a/docs/superpowers/specs/2026-05-24-job-detail-panel-and-location-filter-design.md
+++ b/docs/superpowers/specs/2026-05-24-job-detail-panel-and-location-filter-design.md
@@ -1,0 +1,178 @@
+# Job Detail Panel Layout Fix + Location Preference Filter — Design
+
+**Date:** 2026-05-24
+**Scope:** Frontend (Angular) + Backend (FastAPI)
+**Status:** Approved
+
+## Problem
+
+Two issues observed on the Ingestion page:
+
+1. **Job detail side panel layout is broken.** When opening a job, the panel's action buttons (`View Original`, `Track`) are pushed below the viewport and become unreachable. The description has its own `max-height: 300px` internal scroll that competes with the panel-level `overflow-y: auto`, producing inconsistent behavior depending on content length.
+
+2. **Jobs marked as `Remote` in our system can be country-restricted on the source platform.** Example: a getonbrd job normalized to `"Remote (Remote)"` actually requires the applicant to be in a specific region. When the user opens the source URL, the platform shows "Your country doesn't match the job's location." The user has no way to express "only show me jobs I can apply to from my location."
+
+## Goals
+
+- Fix the panel layout so all sections remain accessible regardless of content length.
+- Let the user enter their location and opt into strict location matching, applied uniformly across all job sources.
+- Preserve current behavior as the default (strict matching is opt-in).
+
+## Non-Goals
+
+- Per-adapter location parsing improvements (e.g., extracting structured `restricted_countries` from raw source data). The filter operates on the normalized `location` string only.
+- Geo-coding or country-code normalization. Plain substring match on user input.
+- Changing the source URL behavior or surfacing the platform's own country restrictions inside our UI.
+
+---
+
+## Section 1 — Job Detail Panel Layout
+
+### Current structure
+
+`job-detail-panel.component.html` / `.scss`:
+
+- `.panel-overlay` — `position: fixed; inset: 0; display: flex; justify-content: flex-end;`
+- `.panel` — flex child stretched to 100vh; `overflow-y: auto`; `display: flex; flex-direction: column;`
+- Sections inside: header, meta grid, source, skills, description (`max-height: 300px; overflow-y: auto;`), actions (`margin-top: auto`)
+
+The competing scroll regions (panel-level + description-level) plus reliance on `margin-top: auto` push actions off-screen when content is tall.
+
+### New structure
+
+Replace the flex-column layout with a CSS grid that defines three explicit rows:
+
+```scss
+.panel {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  height: 100%;
+  overflow: hidden; // outer container does not scroll
+}
+
+.panel-header { /* row 1 — sticky at top, no change to visual style */ }
+
+.panel-body {
+  overflow-y: auto;
+  // contains: meta grid, source, skills, description
+}
+
+.panel-actions { /* row 3 — always visible at bottom */ }
+```
+
+Template change: wrap meta grid, source, skills, and description in a new `<div class="panel-body">`. Header and actions stay outside it.
+
+Description loses its `max-height: 300px` and inner `overflow-y`. It flows naturally inside the single scrollable `.panel-body`.
+
+### Result
+
+- Header always visible at top.
+- Actions always visible at bottom.
+- One scroll region in the middle covers all variable-length content.
+- No nested scrolls.
+
+---
+
+## Section 2 — Location Preference + Strict-Match Toggle
+
+### Frontend
+
+**`job-filters.component`** gains two new controls:
+
+- **"My location"** — text input (`<input type="text">`). Free-form, e.g. `"Chile"`, `"USA"`, `"Spain"`, `"Latin America"`.
+- **"Only show jobs I can apply to"** — checkbox.
+
+**Persistence:** Both values persist in `localStorage` so they survive page refresh and tab close:
+
+- `hiresense.user_location` — string
+- `hiresense.strict_location_match` — `"true"` | `"false"`
+
+On component init, read both from `localStorage` and initialize the local filter state. On change, write back to `localStorage` and emit the updated filters.
+
+**`JobFilters` interface** (`core/services/ingestion.service.ts`) gains:
+
+```ts
+export interface JobFilters {
+  source?: string;
+  keyword?: string;
+  location?: string;        // existing — job-location keyword search
+  skills?: string;
+  date_from?: string;
+  date_to?: string;
+  user_location?: string;   // new — applicant's location
+  strict_location?: boolean; // new — enforce location match
+}
+```
+
+`IngestionService.queryJobs` adds `user_location` and `strict_location` to the `HttpParams` when set. The existing `location` filter (job-location keyword search) is unchanged and orthogonal to the new fields.
+
+**Default state:** `strict_location` defaults to `false`. If the user has never enabled it, behavior is identical to today.
+
+### Backend
+
+**`JobQueryParams`** (`hiresense/ingestion/domain/job_filter.py`) gains:
+
+```python
+user_location: str | None = None
+strict_location: bool = False
+```
+
+**`filter_and_paginate`** gets a new filter step:
+
+```python
+if params.strict_location and params.user_location:
+    user_loc = params.user_location.strip().lower()
+    open_keywords = ("worldwide", "anywhere", "global")
+    def is_open(job_location: str) -> bool:
+        if not job_location:
+            return True
+        loc = job_location.lower()
+        if any(kw in loc for kw in open_keywords):
+            return True
+        return user_loc in loc
+    filtered = [j for j in filtered if is_open(j.location)]
+```
+
+A job passes when **at least one** holds:
+
+1. `job.location` is empty.
+2. `job.location` (lowercased) contains any of `worldwide`, `anywhere`, `global`.
+3. `job.location` (lowercased) contains `user_location` (lowercased) as a substring.
+
+Otherwise the job is excluded.
+
+**Route binding:** `ingestion/api/routes.py::list_jobs` declares each query param explicitly and constructs `JobQueryParams` by hand. Add `user_location: str | None = None` and `strict_location: bool = False` to the signature and forward them into the `JobQueryParams(...)` call.
+
+### Behavior on the screenshot bug
+
+- Job normalized to `location = "Remote (Remote)"`.
+- User sets `user_location = "Chile"`, `strict_location = true`.
+- Check: empty? no. Has `worldwide`/`anywhere`/`global`? no. Contains `"chile"`? no.
+- Job is excluded. Correct outcome.
+
+### Acknowledged tradeoff
+
+A genuinely worldwide remote job whose `location` field is only `"Remote"` (no `worldwide`/`anywhere`/`global` tokens) will also be excluded under strict mode. The toggle is opt-in; users who want broader results turn it off. This is the explicit purpose of the switch.
+
+---
+
+## Files touched
+
+**Frontend**
+
+- `frontend/src/app/pages/ingestion/components/job-detail-panel/job-detail-panel.component.html` — wrap middle sections in `.panel-body`.
+- `frontend/src/app/pages/ingestion/components/job-detail-panel/job-detail-panel.component.scss` — grid layout, remove description `max-height`.
+- `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.html` — add location input + checkbox.
+- `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.ts` — wire up localStorage persistence + new emit fields.
+- `frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.scss` — minor styling for the new controls.
+- `frontend/src/app/core/services/ingestion.service.ts` — extend `JobFilters` + `queryJobs` params.
+
+**Backend**
+
+- `backend/src/hiresense/ingestion/domain/job_filter.py` — extend `JobQueryParams`, add filter step.
+- `backend/src/hiresense/ingestion/api/routes.py` — surface the new params on the jobs query endpoint (verify Pydantic binding).
+
+## Testing
+
+- **Backend:** unit tests on `filter_and_paginate` covering: empty location, `Worldwide`, `Remote (Remote)` excluded when `user_location="Chile"`, exact country match, mixed case, strict off (no-op).
+- **Frontend:** manual verification in the browser — open detail panel with short and long descriptions, confirm header/actions stay fixed; set `user_location="Chile"` + strict ON, confirm `Remote (Remote)` getonbrd jobs disappear; refresh page, confirm settings persist.


### PR DESCRIPTION
## Problema

- LinkedIn job detail panel renders mostly empty values (description, posted date, seniority, etc.) because the adapter only parsed search-card fields and never fetched the per-job detail page.
- `PATCH /tracking/{id}` returns 500 with `DetachedInstanceError` on `updated_at` — the SQLAlchemy session closes before Pydantic reads the server-side default. Blocks status changes on tracked applications.
- The product has five vertical slices (ingestion → matching → optimization → tracking → interview) but no spine connecting them. Optimization asks the user to manually type required/missing skills that the matching step already computed. `TrackedApplication` is a stub with no link to match/optimized CV/interview prep. Created applications don't surface on the Interview page.

## Cambio

- **LinkedIn adapter (`backend/src/hiresense/ingestion/adapters/linkedin.py`)**: parses `<time datetime>` from the card for `posted_date`; fetches each job's detail page from LinkedIn's guest `jobPosting` endpoint behind a `Semaphore(3)` with per-request delay; extracts description from `div.show-more-less-html__markup` plus the criteria block (seniority level / employment type / job function / industries). Detail-fetch failures are logged per-job and don't abort the batch.
- **LinkedIn normalizer**: surfaces description, parses `posted_date` to `datetime`, maps `job_function` → `department`, packs seniority + employment type into `categories`.
- **`TrackingRepository.save()`**: adds `session.refresh(application)` after commit, mirroring the existing `create()` path so `updated_at` is loaded before the session closes.
- **Spec doc (`docs/superpowers/specs/2026-05-24-application-pipeline-redesign-design.md`)**: Approach B design — `TrackedApplication` becomes the spine; four child artifact tables (job snapshot 1:1; matches/CV optimizations/interview preps 1:N). New `hiresense/applications/` bounded context with full REST surface. Skill auto-extraction (ingested → copy `NormalizedJob.skills`; manual → LLM extract). Missing-skills computed live from snapshot vs profile, persisted on each match row. Frontend gets a unified `/dashboard/applications/:id` detail view with Job / Match / CV / Interview tabs; Tracking renamed to Applications; Interview page surfaces tracked applications at the top.

Also included in this PR (already committed earlier on `main` and rolled into this branch): an earlier ingestion design spec and the job-detail-panel implementation plan.

## Resuelve / Impacto

- LinkedIn detail panel now renders real data on next ingestion run (description, posted date, seniority, employment type).
- `PATCH /tracking/{id}` returns 200 cleanly; status changes work end-to-end.
- Application pipeline redesign is unblocked: implementation plan can be drafted against the committed spec.

## Test plan

- [ ] Re-run a LinkedIn ingestion via `POST /ingestion/fetch` and open the detail panel of a LinkedIn row — verify description, posted date, seniority, and employment type are populated.
- [ ] PATCH a tracked application's status from the UI — verify 200 response (previously 500).
- [ ] Read through `docs/superpowers/specs/2026-05-24-application-pipeline-redesign-design.md` end-to-end.

Generated with [Claude Code](https://claude.com/claude-code)