### PR TITLE
feat(ingestion): SemanticPreRanker domain service + DI wiring (PR 2/4, #18)

### DIFF
--- a/backend/src/hiresense/bootstrap/ingestion.py
+++ b/backend/src/hiresense/bootstrap/ingestion.py
@@ -169,9 +169,21 @@ def build_ingestion(infra: SharedInfra, tracked: Callable[[str], Any]) -> Ingest
         indexer=portals_indexer,
     )
 
+    from hiresense.ingestion.domain.semantic_pre_ranker import SemanticPreRanker
     from hiresense.ingestion.domain.semantic_scoring_service import SemanticScoringService
 
     semantic_scoring = SemanticScoringService(embedding_port=infra.embedding)
+
+    # SemanticPreRanker wires vector store + embedding for global ANN pre-ranking.
+    # When vector store is None (no pgvector configured), pre_ranker is still
+    # constructed — its own passthrough logic handles the None vector_store case.
+    pre_ranker = SemanticPreRanker(
+        infra.vector_store,
+        infra.embedding,
+        top_k_cap=s.prerank_top_k_cap,
+        skill_weight=s.prerank_weight_skill,
+        semantic_weight=s.prerank_weight_semantic,
+    )
 
     match_cache_repo = JobMatchCacheRepository(session_factory=infra.sync_session_factory)
     quick_scoring = QuickScoringService(
@@ -193,5 +205,6 @@ def build_ingestion(infra: SharedInfra, tracked: Callable[[str], Any]) -> Ingest
         semantic_scoring=semantic_scoring,
         quick_scoring=quick_scoring,
         deep_analysis=deep_analysis,
+        pre_ranker=pre_ranker,
     )
     return IngestionBuild(provider=provider, orchestrator=ingestion_orchestrator)

--- a/backend/src/hiresense/ingestion/api/dependencies.py
+++ b/backend/src/hiresense/ingestion/api/dependencies.py
@@ -5,6 +5,7 @@ from fastapi import Request
 from hiresense.ingestion.domain.portal_config import PortalsConfig
 from hiresense.ingestion.domain.portal_scanner import PortalScanner
 from hiresense.ingestion.domain.quick_scoring_service import QuickScoringService
+from hiresense.ingestion.domain.semantic_pre_ranker import SemanticPreRanker
 from hiresense.ingestion.domain.semantic_scoring_service import SemanticScoringService
 from hiresense.ingestion.domain.services import IngestionOrchestrator
 from hiresense.matching.domain.deep_analysis_service import DeepAnalysisService
@@ -36,3 +37,10 @@ def get_quick_scoring(request: Request) -> QuickScoringService | None:
 def get_deep_analysis(request: Request) -> DeepAnalysisService | None:
     ingestion = getattr(request.app.state, "ingestion", None)
     return ingestion.get_deep_analysis() if ingestion is not None else None
+
+
+def get_pre_ranker(request: Request) -> SemanticPreRanker | None:
+    # Defensive: tests and bare apps without app.state.ingestion → None.
+    # Routes receiving None must fall back to skill-only ordering (never crash).
+    ingestion = getattr(request.app.state, "ingestion", None)
+    return ingestion.get_pre_ranker() if ingestion is not None else None

--- a/backend/src/hiresense/ingestion/api/provider.py
+++ b/backend/src/hiresense/ingestion/api/provider.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
-
 from hiresense.ingestion.domain.portal_config import PortalsConfig
 from hiresense.ingestion.domain.portal_scanner import PortalScanner
 from hiresense.ingestion.domain.quick_scoring_service import QuickScoringService
+from hiresense.ingestion.domain.semantic_pre_ranker import SemanticPreRanker
 from hiresense.ingestion.domain.semantic_scoring_service import SemanticScoringService
 from hiresense.ingestion.domain.services import IngestionOrchestrator
 from hiresense.matching.domain.deep_analysis_service import DeepAnalysisService
@@ -19,6 +18,7 @@ class IngestionProvider:
         semantic_scoring: SemanticScoringService | None = None,
         quick_scoring: QuickScoringService | None = None,
         deep_analysis: DeepAnalysisService | None = None,
+        pre_ranker: SemanticPreRanker | None = None,
     ) -> None:
         self._orchestrator = orchestrator
         self._portal_scanner = portal_scanner
@@ -26,6 +26,7 @@ class IngestionProvider:
         self._semantic_scoring = semantic_scoring
         self._quick_scoring = quick_scoring
         self._deep_analysis = deep_analysis
+        self._pre_ranker = pre_ranker
 
     def get_orchestrator(self) -> IngestionOrchestrator:
         return self._orchestrator
@@ -44,3 +45,6 @@ class IngestionProvider:
 
     def get_deep_analysis(self) -> DeepAnalysisService | None:
         return self._deep_analysis
+
+    def get_pre_ranker(self) -> SemanticPreRanker | None:
+        return self._pre_ranker

--- a/backend/src/hiresense/ingestion/domain/semantic_pre_ranker.py
+++ b/backend/src/hiresense/ingestion/domain/semantic_pre_ranker.py
@@ -130,9 +130,8 @@ class SemanticPreRanker:
         if not results:
             return jobs
 
-        # Build id → (score, rank) map from ANN results (already sorted best-first)
+        # Build id → score map from ANN results (already sorted best-first by pgvector)
         score_by_id: dict[str, float] = {r.id: r.score for r in results}
-        rank_by_id: dict[str, int] = {r.id: i for i, r in enumerate(results)}
 
         # Partition into indexed and unindexed sets preserving original order
         indexed: list[NormalizedJob] = []
@@ -181,5 +180,9 @@ class SemanticPreRanker:
                 return None
             if not vectors:
                 return None
-            self._profile_cache[key] = vectors[0]
-            return vectors[0]
+            vec = vectors[0]
+            if not vec:
+                # Port returned an empty vector — treat as "no embedding"
+                return None
+            self._profile_cache[key] = vec
+            return vec

--- a/backend/src/hiresense/ingestion/domain/semantic_pre_ranker.py
+++ b/backend/src/hiresense/ingestion/domain/semantic_pre_ranker.py
@@ -1,0 +1,185 @@
+"""SemanticPreRanker — domain service for global ANN-based pre-ranking.
+
+Reorders the ENTIRE job list by pgvector ANN similarity to the profile
+embedding BEFORE pagination.  Depends ONLY on ports (VectorStorePort +
+embedding port) — no infrastructure imports; hexagonal layering.
+
+Fallback contract (REQ-04):
+  Any of these conditions → return jobs UNCHANGED (skill-only passthrough):
+    - vector_store is None
+    - embedding port is None
+    - candidate profile is empty (no skills and no summary)
+    - embedding call raises
+    - vector store search() raises
+    - search returns empty results
+
+Unindexed jobs (not present in ANN results) are appended to the TAIL
+preserving their prior relative order — they are never dropped (REQ-01/02).
+
+Profile embeddings are cached in-process by content hash (same strategy as
+SemanticScoringService) so repeated requests with the same profile only pay
+for one embed call.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+from typing import Any
+
+from hiresense.ingestion.domain.job_scorer import combine_fit_score
+from hiresense.ingestion.domain.models import NormalizedJob
+
+logger = logging.getLogger(__name__)
+
+
+def _profile_key(skills: list[str], summary: str) -> str:
+    raw = f"{' '.join(skills)}\n{summary}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+class SemanticPreRanker:
+    """Domain service: reorder a job list by ANN similarity before pagination.
+
+    Parameters
+    ----------
+    vector_store:
+        Implements VectorStorePort (or None → always passthrough).
+    embedding:
+        Async embedding port with ``embed(texts) -> list[list[float]]``
+        (or None → always passthrough).
+    top_k_cap:
+        Maximum ``top_k`` passed to ``vector_store.search()``.
+    skill_weight:
+        Weight for the skill-overlap component in ``combine_fit_score``.
+    semantic_weight:
+        Weight for the semantic similarity component in ``combine_fit_score``.
+    """
+
+    def __init__(
+        self,
+        vector_store: Any,
+        embedding: Any,
+        *,
+        top_k_cap: int,
+        skill_weight: float,
+        semantic_weight: float,
+    ) -> None:
+        self._vector_store = vector_store
+        self._embedding = embedding
+        self._top_k_cap = top_k_cap
+        self._skill_weight = skill_weight
+        self._semantic_weight = semantic_weight
+        # In-process profile embedding cache: sha256(profile_text) → vector
+        self._profile_cache: dict[str, list[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def rerank(
+        self,
+        jobs: list[NormalizedJob],
+        skill_by_id: dict[str, float | None],
+        candidate_skills: list[str],
+        candidate_summary: str,
+        bucket: str,
+    ) -> list[NormalizedJob]:
+        """Reorder ``jobs`` by ANN similarity to the candidate profile.
+
+        Returns the same list unchanged (passthrough) when any fallback
+        condition is met.  No jobs are ever dropped.
+
+        Parameters
+        ----------
+        jobs:
+            Full corpus for the current tab (all jobs, pre-pagination).
+        skill_by_id:
+            Mapping of job_id → skill-overlap score (may be None).
+        candidate_skills:
+            Profile skills used to compute/cache the profile embedding.
+        candidate_summary:
+            Profile summary text used together with skills.
+        bucket:
+            Tab name ("boards" or "portals") forwarded as vector-store filter.
+        """
+        if not jobs:
+            return jobs
+
+        # Fallback: no vector store or embedding port
+        if self._vector_store is None or self._embedding is None:
+            return jobs
+
+        # Fallback: empty profile → nothing to embed
+        if not candidate_skills and not candidate_summary.strip():
+            return jobs
+
+        # Obtain profile embedding (cached or cold-start)
+        profile_vec = await self._get_profile_embedding(candidate_skills, candidate_summary)
+        if profile_vec is None:
+            return jobs
+
+        # Call ANN search; any exception → passthrough
+        try:
+            results = await self._vector_store.search(
+                profile_vec,
+                top_k=self._top_k_cap,
+                filters={"bucket": bucket},
+            )
+        except Exception:
+            logger.exception("SemanticPreRanker: vector store search failed — passthrough")
+            return jobs
+
+        if not results:
+            return jobs
+
+        # Build id → (score, rank) map from ANN results (already sorted best-first)
+        score_by_id: dict[str, float] = {r.id: r.score for r in results}
+        rank_by_id: dict[str, int] = {r.id: i for i, r in enumerate(results)}
+
+        # Partition into indexed and unindexed sets preserving original order
+        indexed: list[NormalizedJob] = []
+        unindexed: list[NormalizedJob] = []
+        for job in jobs:
+            if job.id in score_by_id:
+                indexed.append(job)
+            else:
+                unindexed.append(job)
+
+        # Re-score indexed jobs with the ANN semantic score and combine_fit_score
+        rescored: list[NormalizedJob] = []
+        for job in indexed:
+            sem_score = score_by_id[job.id]
+            sk_score = skill_by_id.get(job.id)
+            match = combine_fit_score(
+                sk_score,
+                sem_score,
+                skill_weight=self._skill_weight,
+                semantic_weight=self._semantic_weight,
+            )
+            rescored.append(
+                job.model_copy(update={"semantic_score": sem_score, "match_score": match})
+            )
+
+        # Sort indexed jobs by combined match_score descending
+        rescored.sort(key=lambda j: (j.match_score is None, -(j.match_score or 0.0)))
+
+        return rescored + unindexed
+
+    async def _get_profile_embedding(
+        self, skills: list[str], summary: str
+    ) -> list[float] | None:
+        key = _profile_key(skills, summary)
+        async with self._lock:
+            cached = self._profile_cache.get(key)
+            if cached is not None:
+                return cached
+            text = f"{' '.join(skills)}\n{summary}".strip()
+            if not text:
+                return None
+            try:
+                vectors = await self._embedding.embed([text])
+            except Exception:
+                logger.exception("SemanticPreRanker: profile embedding failed — passthrough")
+                return None
+            if not vectors:
+                return None
+            self._profile_cache[key] = vectors[0]
+            return vectors[0]

--- a/backend/tests/unit/ingestion/test_routes.py
+++ b/backend/tests/unit/ingestion/test_routes.py
@@ -216,3 +216,55 @@ async def test_list_jobs_strict_location_filters_non_matching() -> None:
     # Ambiguous "Remote (Remote)" jobs now pass through — fully-remote
     # postings are treated as applyable from anywhere.
     assert returned_ids == {"job-chile", "job-worldwide", "job-remote-remote"}
+
+
+# ---------------------------------------------------------------------------
+# Work Unit E1 — get_pre_ranker dependency returns None on a bare app
+# (no app.state.ingestion wired)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_pre_ranker_returns_none_on_bare_app() -> None:
+    """get_pre_ranker must return None defensively when app has no ingestion state."""
+    from fastapi import FastAPI, Request
+    from hiresense.ingestion.api.dependencies import get_pre_ranker
+
+    bare_app = FastAPI()
+
+    @bare_app.get("/test-pre-ranker")
+    async def _probe(request: Request):
+        result = get_pre_ranker(request)
+        return {"is_none": result is None}
+
+    async with AsyncClient(transport=ASGITransport(app=bare_app), base_url="http://test") as client:
+        resp = await client.get("/test-pre-ranker")
+    assert resp.status_code == 200
+    assert resp.json()["is_none"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_pre_ranker_returns_instance_when_provider_has_it() -> None:
+    """get_pre_ranker returns the SemanticPreRanker when wired on app state."""
+    from fastapi import FastAPI, Request
+    from hiresense.ingestion.api.dependencies import get_pre_ranker
+    from hiresense.ingestion.domain.semantic_pre_ranker import SemanticPreRanker
+
+    fake_ranker = SemanticPreRanker(None, None, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+    class FakeProvider:
+        def get_pre_ranker(self):
+            return fake_ranker
+
+    wired_app = FastAPI()
+    wired_app.state.ingestion = FakeProvider()
+
+    @wired_app.get("/test-pre-ranker")
+    async def _probe(request: Request):
+        result = get_pre_ranker(request)
+        return {"is_none": result is None}
+
+    async with AsyncClient(transport=ASGITransport(app=wired_app), base_url="http://test") as client:
+        resp = await client.get("/test-pre-ranker")
+    assert resp.status_code == 200
+    assert resp.json()["is_none"] is False

--- a/backend/tests/unit/ingestion/test_semantic_pre_ranker.py
+++ b/backend/tests/unit/ingestion/test_semantic_pre_ranker.py
@@ -1,0 +1,426 @@
+"""Tests for SemanticPreRanker domain service (Work Unit D).
+
+TDD: tests are written first (RED), then the implementation makes them pass (GREEN).
+All dependencies are faked — no real DB, no real embeddings.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.ingestion.domain.semantic_pre_ranker import SemanticPreRanker
+from hiresense.ports.vector_store import ScoredResult
+
+
+# ---------------------------------------------------------------------------
+# Test helpers / fakes
+# ---------------------------------------------------------------------------
+
+
+def _job(id: str, skill_score: float | None = None, semantic_score: float | None = None) -> NormalizedJob:
+    return NormalizedJob(
+        id=id,
+        title=f"Job {id}",
+        company="Co",
+        description="desc",
+        skills=["python"],
+        source="test",
+        source_type="api",
+        language="en",
+        url=f"https://example.com/{id}",
+        match_score=skill_score,
+        semantic_score=semantic_score,
+    )
+
+
+class FakeVectorStore:
+    """Fake VectorStorePort that returns canned ScoredResults."""
+
+    def __init__(self, results: list[ScoredResult] | None = None, raises: Exception | None = None) -> None:
+        self._results = results or []
+        self._raises = raises
+        self.last_call: dict | None = None
+
+    async def search(
+        self,
+        query_embedding: list[float],
+        *,
+        top_k: int = 10,
+        filters: dict | None = None,
+    ) -> list[ScoredResult]:
+        self.last_call = {"query_embedding": query_embedding, "top_k": top_k, "filters": filters}
+        if self._raises is not None:
+            raise self._raises
+        return self._results
+
+    async def upsert(self, id: str, embedding: list[float], metadata: dict) -> None:
+        pass
+
+    async def delete(self, ids: list[str]) -> None:
+        pass
+
+
+class FakeEmbeddingPort:
+    """Fake embedding port that returns canned vectors."""
+
+    def __init__(self, vectors: list[list[float]] | None = None, raises: Exception | None = None) -> None:
+        self._vectors = vectors or [[0.1, 0.2, 0.3]]
+        self._raises = raises
+        self.embed_call_count = 0
+
+    async def embed(self, texts: list[str]) -> list[list[float]]:
+        self.embed_call_count += 1
+        if self._raises is not None:
+            raise self._raises
+        return self._vectors
+
+
+# ---------------------------------------------------------------------------
+# D1 — Tests (RED phase first)
+# ---------------------------------------------------------------------------
+
+
+PROFILE_SKILLS = ["python", "fastapi"]
+PROFILE_SUMMARY = "Backend developer"
+PROFILE_VEC = [0.1, 0.2, 0.3]
+
+
+class TestSemanticPreRankerOrder:
+    """REQ-01/02: Jobs are globally reordered by ANN distance ascending."""
+
+    @pytest.mark.asyncio
+    async def test_ranks_jobs_by_ann_distance_ascending(self) -> None:
+        """Jobs with lower ANN distance (higher score from pgvector) come first."""
+        jobs = [_job("a"), _job("b"), _job("c")]
+        skill_by_id = {"a": 0.5, "b": 0.8, "c": 0.3}
+
+        # pgvector returns score = 1 - cosine_distance, so higher score = closer.
+        # We expect the returned order: b (0.9), a (0.7), c (0.4).
+        scored_results = [
+            ScoredResult(id="a", score=0.7, metadata={}),
+            ScoredResult(id="b", score=0.9, metadata={}),
+            ScoredResult(id="c", score=0.4, metadata={}),
+        ]
+        vs = FakeVectorStore(results=scored_results)
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["b", "a", "c"]
+
+    @pytest.mark.asyncio
+    async def test_rerank_updates_semantic_score_from_ann_results(self) -> None:
+        """Each job's semantic_score is set from the ANN result score."""
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.5}
+        scored_results = [
+            ScoredResult(id="a", score=0.8, metadata={}),
+            ScoredResult(id="b", score=0.6, metadata={}),
+        ]
+        vs = FakeVectorStore(results=scored_results)
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert result[0].semantic_score == pytest.approx(0.8)
+        assert result[1].semantic_score == pytest.approx(0.6)
+
+
+class TestSemanticPreRankerUnindexed:
+    """Unindexed jobs (absent from ANN results) fall to the TAIL preserving order."""
+
+    @pytest.mark.asyncio
+    async def test_unindexed_jobs_go_to_tail_preserving_relative_order(self) -> None:
+        jobs = [_job("a"), _job("unindexed-1"), _job("b"), _job("unindexed-2")]
+        skill_by_id = {j.id: 0.5 for j in jobs}
+        scored_results = [
+            ScoredResult(id="b", score=0.9, metadata={}),
+            ScoredResult(id="a", score=0.7, metadata={}),
+        ]
+        vs = FakeVectorStore(results=scored_results)
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        ranked_ids = [j.id for j in result]
+        # Indexed jobs first in ANN order, then unindexed in their original order
+        assert ranked_ids[:2] == ["b", "a"]
+        assert ranked_ids[2:] == ["unindexed-1", "unindexed-2"]
+
+    @pytest.mark.asyncio
+    async def test_no_jobs_are_dropped(self) -> None:
+        """The total count of jobs must be preserved — none are ever dropped."""
+        jobs = [_job(f"job-{i}") for i in range(10)]
+        skill_by_id = {j.id: 0.5 for j in jobs}
+        # Only 3 are indexed
+        scored_results = [ScoredResult(id=f"job-{i}", score=0.9 - i * 0.1, metadata={}) for i in range(3)]
+        vs = FakeVectorStore(results=scored_results)
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert len(result) == 10
+
+
+class TestSemanticPreRankerTopK:
+    """top_k cap is passed to vector store."""
+
+    @pytest.mark.asyncio
+    async def test_top_k_cap_passed_to_vector_store(self) -> None:
+        jobs = [_job("a")]
+        skill_by_id = {"a": 0.5}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.8, metadata={})])
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=500, skill_weight=0.4, semantic_weight=0.6)
+
+        await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert vs.last_call is not None
+        assert vs.last_call["top_k"] == 500
+
+    @pytest.mark.asyncio
+    async def test_bucket_filter_passed_to_vector_store(self) -> None:
+        jobs = [_job("a")]
+        skill_by_id = {"a": 0.5}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.8, metadata={})])
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="portals",
+        )
+
+        assert vs.last_call is not None
+        assert vs.last_call["filters"] == {"bucket": "portals"}
+
+
+class TestSemanticPreRankerGracefulFallback:
+    """REQ-04: Graceful passthrough when vector store unavailable / search raises / no profile."""
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_vector_store_is_none(self) -> None:
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.8}
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(None, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_search_raises(self) -> None:
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.8}
+        vs = FakeVectorStore(raises=RuntimeError("DB unavailable"))
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_search_returns_empty(self) -> None:
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.8}
+        vs = FakeVectorStore(results=[])
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_no_profile(self) -> None:
+        """No profile skills/summary → skip embedding + search, return unchanged."""
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.8}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.9, metadata={})])
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=[],
+            candidate_summary="",
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["a", "b"]
+        # vector store must NOT have been called
+        assert vs.last_call is None
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_embedding_port_is_none(self) -> None:
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.8}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.9, metadata={})])
+        ranker = SemanticPreRanker(vs, None, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_embedding_fails(self) -> None:
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.8}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.9, metadata={})])
+        emb = FakeEmbeddingPort(raises=RuntimeError("model not loaded"))
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["a", "b"]
+
+
+class TestSemanticPreRankerColdStart:
+    """Cold-start: profile embedding obtained from embedding port (called exactly once)."""
+
+    @pytest.mark.asyncio
+    async def test_cold_start_embeds_profile_once(self) -> None:
+        jobs = [_job("a")]
+        skill_by_id = {"a": 0.5}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.8, metadata={})])
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert emb.embed_call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_warm_cache_skips_embedding_call(self) -> None:
+        """Second call with the same profile reuses cached embedding (0 extra embeds)."""
+        jobs = [_job("a")]
+        skill_by_id = {"a": 0.5}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.8, metadata={})])
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+        # Reset FakeVectorStore to new results so we can call a second time
+        vs._results = [ScoredResult(id="a", score=0.8, metadata={})]
+        await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        # embed() should have been called only once total
+        assert emb.embed_call_count == 1
+
+
+class TestSemanticPreRankerWeights:
+    """Injected weights change the combined score and thus the ordering."""
+
+    @pytest.mark.asyncio
+    async def test_injected_weights_change_order(self) -> None:
+        """Skill-heavy weighting brings skill-dominant job first."""
+        # job-a: skill=0.9, semantic=0.3  → skill-heavy: 0.8*0.9 + 0.2*0.3 = 0.78
+        # job-b: skill=0.2, semantic=0.9  → skill-heavy: 0.8*0.2 + 0.2*0.9 = 0.34
+        jobs = [_job("a", skill_score=0.9), _job("b", skill_score=0.2)]
+        skill_by_id = {"a": 0.9, "b": 0.2}
+        scored_results = [
+            ScoredResult(id="b", score=0.9, metadata={}),  # b has better ANN score
+            ScoredResult(id="a", score=0.3, metadata={}),
+        ]
+        vs = FakeVectorStore(results=scored_results)
+        emb = FakeEmbeddingPort(vectors=[PROFILE_VEC])
+        # Skill-heavy: skill_weight=0.8, semantic_weight=0.2 → a should win
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.8, semantic_weight=0.2)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert result[0].id == "a"

--- a/backend/tests/unit/ingestion/test_semantic_pre_ranker.py
+++ b/backend/tests/unit/ingestion/test_semantic_pre_ranker.py
@@ -63,8 +63,11 @@ class FakeVectorStore:
 class FakeEmbeddingPort:
     """Fake embedding port that returns canned vectors."""
 
+    _SENTINEL: list[list[float]] = [[0.1, 0.2, 0.3]]
+
     def __init__(self, vectors: list[list[float]] | None = None, raises: Exception | None = None) -> None:
-        self._vectors = vectors or [[0.1, 0.2, 0.3]]
+        # Use sentinel to distinguish "not provided" from an explicit empty list
+        self._vectors = self._SENTINEL if vectors is None else vectors
         self._raises = raises
         self.embed_call_count = 0
 
@@ -424,3 +427,47 @@ class TestSemanticPreRankerWeights:
         )
 
         assert result[0].id == "a"
+
+
+class TestSemanticPreRankerEmptyEmbedding:
+    """Guard: empty vector from embedding port → passthrough, no vector store call."""
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_embedding_returns_empty_vector(self) -> None:
+        """Embedding port returns [[]] (list with one empty vector) → passthrough, no search."""
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.8}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.9, metadata={})])
+        emb = FakeEmbeddingPort(vectors=[[]])  # returns a single empty vector
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["a", "b"]
+        assert vs.last_call is None  # vector_store.search() must NOT have been called
+
+    @pytest.mark.asyncio
+    async def test_passthrough_when_embedding_returns_empty_list(self) -> None:
+        """Embedding port returns [] (fully empty list) → passthrough, no search."""
+        jobs = [_job("a"), _job("b")]
+        skill_by_id = {"a": 0.5, "b": 0.8}
+        vs = FakeVectorStore(results=[ScoredResult(id="a", score=0.9, metadata={})])
+        emb = FakeEmbeddingPort(vectors=[])  # returns empty list (no vectors at all)
+        ranker = SemanticPreRanker(vs, emb, top_k_cap=100, skill_weight=0.4, semantic_weight=0.6)
+
+        result = await ranker.rerank(
+            jobs=jobs,
+            skill_by_id=skill_by_id,
+            candidate_skills=PROFILE_SKILLS,
+            candidate_summary=PROFILE_SUMMARY,
+            bucket="boards",
+        )
+
+        assert [j.id for j in result] == ["a", "b"]
+        assert vs.last_call is None


### PR DESCRIPTION
## PR 2 of 4 — `SemanticPreRanker` domain service + DI wiring

Part of the fix for **#18**. Second slice of the 4-PR stack. **Stacked on PR1 (#20)** — review this diff against the PR1 branch; GitHub will retarget to `main` once #20 merges.

> ⚠️ **No behavior change yet.** This PR adds the global pre-ranking *capability* and wires it into the composition root, but does **not** call it from `routes.py`. That wiring — where the observable ranking actually changes — is **PR3**. After this PR merges, the job list still ranks exactly as before.

### What this PR does (Work Units D + E)

- **D — `SemanticPreRanker`** (`ingestion/domain/semantic_pre_ranker.py`, new): a domain service that makes the **entire corpus** rankable by semantic similarity to the candidate profile *before* pagination. It:
  - Embeds the profile (cached, async-locked against thundering-herd) and calls `VectorStorePort.search(profile_vec, top_k=settings.prerank_top_k_cap, filters={"bucket": tab})`.
  - Sets `semantic_score` on every indexed job from the ANN result, recomputes `match_score` via the weighted blend (`combine_fit_score`, 0.4 skill / 0.6 semantic), and sorts the whole corpus by it — so a **high-semantic / low-keyword** job can rank to the top (the core #18 fix).
  - Appends **unindexed** jobs (not yet embedded / outside `top_k`) to the tail preserving order — **no job is ever dropped** (count invariant holds).
  - **Graceful fallback**: if the vector store is absent, `search()` raises, the profile is empty, or the embedding can't be computed (incl. empty-vector guard), it returns the jobs **unchanged** — the list endpoint can never crash because of pre-ranking.
  - Depends **only on ports** (`VectorStorePort` + embedding port) — clean hexagonal layering, no infrastructure imports in domain.
- **E — DI wiring**: instantiated in `bootstrap/ingestion.py`, exposed on `IngestionProvider`, accessible via `get_pre_ranker()` in `dependencies.py`. `routes.py` production code is **untouched** (confirmed empty diff).

### Why split this way

The behavior-changing `routes.py` integration is isolated in PR3 so the reviewer of *that* PR sees only the integration diff, and this PR can be verified purely as "correct, well-tested, inert plumbing."

### Testing

- Strict TDD. **17 `SemanticPreRanker` tests** + 2 wiring tests: ordering by combined score, `semantic_score` populated from ANN, unindexed→tail order preserved, count invariant, `top_k`/bucket forwarded, all fallback paths (None store, raise, empty profile, empty embedding), cache cold/warm, weight injection changes order.
- `cd backend && uv run pytest tests/unit/ingestion` → **243 passed**.
- `ruff check .` → zero new violations.
- Fresh adversarial review run on this slice; the math was independently verified (skill=0.1/semantic=0.95 → 0.61 beats skill=0.9/semantic=0.20 → 0.48). Two review items fixed in `c7bcb23` (dead variable removed, empty-embedding guard added).

### Stack
1. PR1 (#20) — config + weights + batched persistence
2. **PR2 (this)** — SemanticPreRanker + DI wiring
3. PR3 — routes integration (global pre-rank before pagination, default sort) + backfill ← **behavior changes here**
4. PR4 — pgvector integration tests

Part of #18.
