### PR TITLE
fix(ingestion): global semantic pre-rank before pagination (PR 3/4, closes #18)

### DIFF
--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -12,16 +12,18 @@ from hiresense.ingestion.api.dependencies import (
     get_ingestion_orchestrator,
     get_portal_scanner,
     get_portals_config,
+    get_pre_ranker,
     get_quick_scoring,
     get_revalidation_service,
     get_semantic_scoring,
 )
 from hiresense.ingestion.domain.job_revalidation_service import JobRevalidationService
+from hiresense.ingestion.domain.semantic_pre_ranker import SemanticPreRanker
+from hiresense.ingestion.ports.jobs_repository import ScoreUpdate
 from hiresense.ingestion.domain.job_filter import JobQueryParams, PaginatedResult, filter_and_paginate
 from hiresense.ingestion.domain.job_scorer import (
     combine_fit_score,
     score_job_against_skills,
-    score_jobs,
 )
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.quick_match_result import QuickMatchResult
@@ -130,6 +132,7 @@ async def list_jobs(
     profile_service: Annotated[ProfileService, Depends(get_profile_service)],
     semantic_scoring: Annotated[SemanticScoringService | None, Depends(get_semantic_scoring)],
     quick_scoring: Annotated[QuickScoringService | None, Depends(get_quick_scoring)],
+    pre_ranker: Annotated[SemanticPreRanker | None, Depends(get_pre_ranker)],
     page: int = 1,
     page_size: int = 20,
     source: str | None = None,
@@ -158,7 +161,13 @@ async def list_jobs(
 
     candidate_skills, candidate_summary = await _gather_profile(profile_service)
 
-    persist_scores = orchestrator.persist_scores if tab == "boards" else scanner.persist_scores
+    persist_scores_batch = (
+        orchestrator.persist_scores_batch if tab == "boards" else scanner.persist_scores_batch
+    )
+
+    # Default to match-descending so the ranking is actually applied when the
+    # client omits sort (otherwise the page reflects insertion order — #18).
+    effective_sort = sort or "match_desc"
 
     # Pre-compute skill-overlap per job (cheap) and fold in any *persisted*
     # semantic score so the sort key matches the displayed value. Keep the
@@ -175,8 +184,21 @@ async def list_jobs(
             )
             for j in all_jobs
         ]
-        for job in all_jobs:
-            persist_scores(job.id, job.match_score, job.semantic_score)
+
+    # GLOBAL pre-rank BEFORE pagination (#18 fix): use the pgvector ANN to set
+    # semantic_score + combined match_score across the WHOLE corpus, so a
+    # high-semantic / low-keyword job can reach page 1 instead of being scored
+    # only after it's already been paginated off. Passthrough (no vector store,
+    # empty profile, etc.) leaves the skill-only ordering intact.
+    if pre_ranker is not None:
+        all_jobs = await pre_ranker.rerank(
+            all_jobs, skill_by_id, candidate_skills, candidate_summary, bucket=tab
+        )
+
+    if candidate_skills:
+        persist_scores_batch(
+            [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in all_jobs]
+        )
 
     params = JobQueryParams(
         page=page,
@@ -189,7 +211,7 @@ async def list_jobs(
         date_to=date_to,
         user_location=user_location,
         strict_location=strict_location,
-        sort=sort,
+        sort=effective_sort,
         min_score=min_score,
         seniority_levels=seniority,
         max_years_experience=max_years_experience,
@@ -230,12 +252,13 @@ async def list_jobs(
             )
             for j in result.jobs
         ]
-        for job in result.jobs:
-            persist_scores(job.id, job.match_score, job.semantic_score)
+        persist_scores_batch(
+            [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in result.jobs]
+        )
         # Page-level re-sort so the order reflects the post-semantic match_score
         # that the user actually sees. Phase-1 sort happens pre-pagination on
         # skill-only scores; without this the displayed % column looks unsorted.
-        if sort == "match_desc":
+        if effective_sort == "match_desc":
             result.jobs = sorted(
                 result.jobs,
                 key=lambda j: (j.match_score if j.match_score is not None else -1.0),
@@ -253,7 +276,7 @@ async def list_jobs(
         )
         if quick_results:
             result.jobs = [_apply_quick(j, quick_results.get(j.id)) for j in result.jobs]
-            if sort == "match_desc":
+            if effective_sort == "match_desc":
                 result.jobs = sorted(
                     result.jobs,
                     key=lambda j: (j.match_score if j.match_score is not None else -1.0),

--- a/backend/tests/unit/ingestion/test_routes.py
+++ b/backend/tests/unit/ingestion/test_routes.py
@@ -55,6 +55,9 @@ class FakeOrchestrator:
     def persist_scores(self, job_id, match_score, semantic_score) -> None:
         pass
 
+    def persist_scores_batch(self, updates) -> None:
+        pass
+
 
 class FakeScanner:
     def list_jobs(self) -> list[NormalizedJob]:
@@ -64,6 +67,9 @@ class FakeScanner:
         return None
 
     def persist_scores(self, job_id, match_score, semantic_score) -> None:
+        pass
+
+    def persist_scores_batch(self, updates) -> None:
         pass
 
 
@@ -197,6 +203,9 @@ async def test_list_jobs_strict_location_filters_non_matching() -> None:
         def persist_scores(self, job_id, match_score, semantic_score) -> None:
             pass
 
+        def persist_scores_batch(self, updates) -> None:
+            pass
+
     app = FastAPI()
     app.dependency_overrides[get_ingestion_orchestrator] = lambda: MultiJobOrchestrator()
     app.dependency_overrides[get_portal_scanner] = lambda: FakeScanner()
@@ -296,3 +305,46 @@ async def test_revalidate_endpoint_503_when_unconfigured() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post("/ingestion/revalidate")
     assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_pre_ranker_promotes_job_to_page_one_before_pagination() -> None:
+    """#18 fix: global pre-rank runs BEFORE pagination, so a job the ANN ranks
+    best reaches page 1 even if it was last in insertion order — and with no
+    explicit sort param (default match_desc)."""
+    from hiresense.ingestion.api.dependencies import get_pre_ranker
+
+    jobs = [
+        NormalizedJob(id=f"job-{i}", title=f"T{i}", company="Co", description="d",
+                      source="remotive", source_type="api", language="en",
+                      url=f"https://e.com/{i}")
+        for i in range(3)
+    ]
+
+    class _Orch:
+        async def run(self, filters=None): return []
+        def list_jobs(self): return list(jobs)
+        def persist_scores(self, *a): pass
+        def persist_scores_batch(self, updates): pass
+
+    class _PreRanker:
+        # Simulate ANN deciding job-2 is the best match (was last in order).
+        async def rerank(self, corpus, skill_by_id, skills, summary, bucket):
+            by_id = {j.id: j for j in corpus}
+            return [by_id["job-2"], by_id["job-0"], by_id["job-1"]]
+
+    app = FastAPI()
+    app.dependency_overrides[get_ingestion_orchestrator] = lambda: _Orch()
+    app.dependency_overrides[get_portal_scanner] = lambda: FakeScanner()
+    app.dependency_overrides[get_profile_service] = lambda: FakeProfileService()
+    app.dependency_overrides[get_semantic_scoring] = lambda: None
+    app.dependency_overrides[get_pre_ranker] = lambda: _PreRanker()
+    app.include_router(router)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # page_size=1, no `sort` param -> default match_desc, pre-rank decides page 1
+        resp = await client.get("/ingestion/jobs", params={"tab": "boards", "page_size": 1, "min_score": 0})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["jobs"][0]["id"] == "job-2"  # pre-ranked to the top, reached page 1


### PR DESCRIPTION
PR 3 of the #18 ranking stack — the **behavior-changing** slice. PR1 (#20) and PR2 (#22) landed the foundation (prerank weights, batched persistence, `SemanticPreRanker` + DI); this wires it into the hot path.

## What changed (`GET /ingestion/jobs`)
- **Global pre-rank before pagination.** After skill-overlap is computed, `SemanticPreRanker.rerank()` runs over the **entire corpus** — pgvector ANN sets `semantic_score` and the combined `match_score` on every job, then `filter_and_paginate` paginates the globally-ranked list. A semantically excellent / low-keyword job can now reach page 1 (the core #18 defect: scoring previously ran *after* pagination).
- **Default sort = `match_desc`.** Previously `sort` defaulted to `None` → insertion order, so ranking was invisible unless the client passed `sort`.
- **Batched persistence.** Replaced the per-job `persist_scores` N+1 loop with `persist_scores_batch` (one round-trip).
- **Passthrough preserved.** No vector store / empty profile / ANN failure → corpus returned unchanged (skill-only ordering), endpoint never crashes.

## Testing
- New `test_pre_ranker_promotes_job_to_page_one_before_pagination`: a job the ANN ranks best reaches page 1 at `page_size=1` with **no** `sort` param.
- Full backend suite **600 passed**; `ruff check` clean.

Closes #18.