### PR TITLE
fix(admin): break circular import blocking alembic

### DIFF
--- a/backend/src/hiresense/admin/domain/usage_aggregator.py
+++ b/backend/src/hiresense/admin/domain/usage_aggregator.py
@@ -4,9 +4,12 @@ import csv
 import io
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
 
-from hiresense.admin.infrastructure import UsageBucket, UsageTotals
 from hiresense.admin.ports import LLMUsageLogRepositoryPort
+
+if TYPE_CHECKING:
+    from hiresense.admin.infrastructure import UsageBucket, UsageTotals
 
 
 @dataclass(frozen=True)

--- a/backend/src/hiresense/admin/infrastructure/llm_factory.py
+++ b/backend/src/hiresense/admin/infrastructure/llm_factory.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import hashlib
 import logging
 import threading
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from hiresense.admin.domain.resolved_config import ResolvedConfig
+if TYPE_CHECKING:
+    from hiresense.admin.domain.resolved_config import ResolvedConfig
 
 logger = logging.getLogger(__name__)
 

--- a/backend/src/hiresense/admin/ports/llm_audit_log_repository_port.py
+++ b/backend/src/hiresense/admin/ports/llm_audit_log_repository_port.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from hiresense.admin.infrastructure import LLMAuditLog
+if TYPE_CHECKING:
+    from hiresense.admin.infrastructure import LLMAuditLog
 
 
 class LLMAuditLogRepositoryPort(Protocol):

--- a/backend/src/hiresense/admin/ports/llm_feature_override_repository_port.py
+++ b/backend/src/hiresense/admin/ports/llm_feature_override_repository_port.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from hiresense.admin.infrastructure import LLMFeatureOverride
+if TYPE_CHECKING:
+    from hiresense.admin.infrastructure import LLMFeatureOverride
 
 
 class LLMFeatureOverrideRepositoryPort(Protocol):

--- a/backend/src/hiresense/admin/ports/llm_settings_repository_port.py
+++ b/backend/src/hiresense/admin/ports/llm_settings_repository_port.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from hiresense.admin.infrastructure import LLMSettings
+if TYPE_CHECKING:
+    from hiresense.admin.infrastructure import LLMSettings
 
 
 class LLMSettingsRepositoryPort(Protocol):

--- a/backend/src/hiresense/admin/ports/llm_usage_log_repository_port.py
+++ b/backend/src/hiresense/admin/ports/llm_usage_log_repository_port.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from hiresense.admin.infrastructure import LLMUsageLog, UsageBucket, UsageTotals
+if TYPE_CHECKING:
+    from hiresense.admin.infrastructure import LLMUsageLog, UsageBucket, UsageTotals
 
 
 class LLMUsageLogRepositoryPort(Protocol):


### PR DESCRIPTION
## Problem

Running any Alembic command (`alembic current`, `upgrade`, etc.) crashed with:

```
ImportError: cannot import name 'LLMFeatureOverride' from partially
initialized module 'hiresense.admin.infrastructure' (circular import)
```

This blocked **all** migrations from being applied. The running app survived by luck of import ordering, but `alembic/env.py` imports `hiresense.infrastructure.registry` first, which exposed the cycle:

`admin.infrastructure.__init__` → `llm_factory` → `admin.domain` (whole package `__init__`) → `admin.ports` → back into the half-initialized `admin.infrastructure`.

Concretely, this also meant migration `016` (preference tables) could never be applied, so the app threw `relation "preference_models" does not exist` on every match / job-listing request.

## Fix

Move the type-only cross-layer imports into `TYPE_CHECKING` blocks — the exact convention `llm_factory_port.py` and `llm_test_runner_port.py` already use. Severs the cycle at its source (`llm_factory.py`'s domain import) plus the four repository ports and `usage_aggregator`.

All moved imports are used **only in annotations**, and every file already has `from __future__ import annotations`, so the annotations are lazy strings — **runtime behavior is unchanged**.

## Verification

- `python -m alembic current` / `heads` / `upgrade head` now run cleanly.
- Import smoke test of the previously-cyclic chain passes:
  `import hiresense.infrastructure.registry; from hiresense.admin.infrastructure import LLMFactory, UsageBucket; ...` → `imports OK`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)