### PR TITLE
Backlog sweep — 17 issues + epic #46 (backend hardening, frontend bugs/tech-debt, full spec coverage)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,32 @@
+name: Bug report
+description: Something isn't working
+title: "bug(scope): "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Where the bug lives and how it manifests.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction
+      description: Steps to reproduce.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs actual
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: file:line links, related issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,33 @@
+name: Feature
+description: New feature or enhancement
+title: "feat(scope): "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What exists today and why this is needed.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: What to build and how it fits the architecture/conventions.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Bullet list of verifiable outcomes.
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: Design docs, file:line links, related issues.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/tech-debt.yml
+++ b/.github/ISSUE_TEMPLATE/tech-debt.yml
@@ -1,0 +1,26 @@
+name: Tech debt
+description: Refactor, robustness, or convention cleanup
+title: "tech-debt(scope): "
+labels: ["tech-debt"]
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What's wrong or fragile today.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: How to fix it.
+    validations:
+      required: true
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: file:line links, related issues.
+    validations:
+      required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,86 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+HireSense — AI-assisted job hunting. Ingests postings from job boards and company ATS portals, ranks them against the user's profile (pgvector ANN semantic pre-ranking + skill overlap + tiered LLM scoring), and manages applications end to end (tracking, CV/cover-letter generation, interview prep, outreach, analytics).
+
+Monorepo: `backend/` (Python 3.13, FastAPI, SQLAlchemy + Alembic, PostgreSQL 16 + pgvector), `frontend/` (Angular 21, standalone components + signals, Vitest), `docker-compose.yml` (db, app, frontend, otel-lgtm/Grafana).
+
+## Commands
+
+### Backend (run from `backend/`, always via `uv`)
+
+```bash
+uv sync                                  # install deps (incl. dev group)
+uv run python -m alembic upgrade head    # apply migrations
+uv run app                               # dev server (uvicorn, reload, port 8000)
+uv run python -m pytest                  # all tests
+uv run python -m pytest tests/unit/outreach                          # one module's tests
+uv run python -m pytest tests/integration/test_outreach_endpoints.py::test_name  # single test
+uv run ruff check .                      # lint
+uv run ruff format .                     # format
+uv run python -m alembic revision --autogenerate -m "msg"            # new migration
+```
+
+**Quirk:** bare `uv run pytest` / `uv run alembic` fail on some Windows setups (broken exe trampolines) — always use the `uv run python -m …` form. `uv run ruff` and `uv run app` work fine.
+
+The full test suite runs **without Postgres** — integration tests build the app against in-memory SQLite. Anything that genuinely needs pgvector (ANN search) can only be validated against a live DB (`docker compose up db`).
+
+### Frontend (run from `frontend/`)
+
+```bash
+npm install
+npm start                                # dev server, proxies /api → backend (proxy.conf.json)
+npm run build                            # production build
+npm test                                 # Vitest via ng test
+npm test -- --include "**/foo.spec.ts"   # single spec file
+npm test -- --filter "test name"         # single test by name
+```
+
+### Docker
+
+```bash
+docker compose up --build    # db :5432, app :8000, frontend :4200, Grafana :3000
+```
+
+Backend config lives in `backend/.env` (copy from `backend/.env.example`). Every configurable value goes through `src/hiresense/config.py` + `.env` — never hardcode URLs, keys, or thresholds; new settings must also be added to `.env.example` with a comment.
+
+### Concurrent sessions / worktrees
+
+The main checkout may be shared with another active session (and lives under OneDrive, which fights with heavy git churn). For multi-commit feature work, prefer an isolated `git worktree` **outside** the OneDrive tree, then `uv sync` and copy `backend/.env` into it. Clean up worktrees when done.
+
+## Architecture
+
+**Required reading before structural backend changes: [`backend/ARCHITECTURE.md`](backend/ARCHITECTURE.md).** It contains the full dependency rules, the per-module layout, the global ports/adapters table, the LLM adapter decorator chain, and a step-by-step "adding a new module" recipe. The summary below is the minimum to orient yourself.
+
+### Backend — hexagonal, bounded contexts
+
+`src/hiresense/<module>/` per bounded context (`ingestion`, `matching`, `applications`, `tracking`, `profile`, `admin`, `analytics`, `outreach`, `autohunt`, `preference`, `interview`, `research`, `optimization`, `identity`, …), each layered `api → domain ← infrastructure`:
+
+- `domain/` is pure Pydantic + business logic. It imports **nothing** from `infrastructure/` and **no** framework packages (`sqlalchemy`, `langchain*`, `httpx`). It depends only on ports (`Protocol`s).
+- `infrastructure/` holds SQLAlchemy `*Orm` classes and repositories that map ORM ↔ domain models. Stateless modules have no `ports/`/`infrastructure/` at all — don't add empty placeholders.
+- Wiring happens only in `bootstrap/` (`build_<module>(infra, …)` → `Provider` stored on `app.state`; `api/dependencies.py` reads it back per request). Never wire via fallback imports in the domain.
+- Cross-cutting ports/adapters (`LLMPort`, `EmbeddingPort`, `VectorStorePort`, `EventBus`, …) live in `src/hiresense/ports/` and `src/hiresense/adapters/`.
+- Every ORM class must be imported in `infrastructure/registry.py` or Alembic `--autogenerate` won't see its table.
+- Every package `__init__.py` re-exports its public symbols; import from the contextual package (`from hiresense.ingestion.adapters import RemotiveAdapter`), never from the implementation file.
+
+Coding standards (DI pattern, domain events, kernel/shared types, LLM scorers, module structure) are documented in `agent-os/standards/backend/`; consult the matching standard before writing code in those areas.
+
+### Frontend — Angular standalone + signals
+
+No NgModules: standalone components with lazy-loaded routes (`app.routes.ts`). All component reactive state uses signals. Structure: `src/app/core/` (guards, interceptors, models, services) and `src/app/pages/<domain>/` mirroring the backend modules. Conventions: per-domain services wrapping HTTP, interfaces in `.model.ts` files by domain — see `agent-os/standards/frontend/`.
+
+### Job lifecycle (cross-cutting behavior)
+
+Jobs are upserted by stable identity (`source` + `source_id`, else `sha256(url)`); a content hash drives in-place updates. Closure detection: snapshot sources (ATS portals) close jobs missing from N consecutive complete fetches; feed sources close via a throttled URL-probe sweep (`POST /ingestion/revalidate`) driven by an **external** cron — the app never self-schedules revalidation. Closed jobs are hidden by default and excluded from semantic search.
+
+## Feature workflow
+
+Feature work follows a spec → plan → implement flow documented under `docs/superpowers/`:
+
+1. Before changing an existing feature, check `docs/superpowers/specs/` and `docs/superpowers/plans/` for its design doc — most features have one (`YYYY-MM-DD-<feature>-design.md`).
+2. New features get a spec in `docs/superpowers/specs/` and an implementation plan in `docs/superpowers/plans/` before code, following the existing naming convention.
+
+Commits follow Conventional Commits (`type(scope): description`), scoped by module (e.g. `feat(outreach): …`).

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -60,6 +60,10 @@ JOB_REVALIDATION_DELAY=1.0
 JOB_CLOSED_MARKERS=no longer accepting applications,position has been filled,this job is closed,this position is no longer available,ya no está disponible,esta oferta ya no está disponible
 
 # === Job Source URLs ===
+# Remotive remote-jobs API base URL.
+REMOTIVE_API_URL=https://remotive.com/api/remote-jobs
+# RemoteOK public API base URL.
+REMOTEOK_API_URL=https://remoteok.com/api
 JOBICY_API_URL=https://jobicy.com/api/v2/remote-jobs
 HIMALAYAS_API_URL=https://himalayas.app/jobs/api
 HN_ALGOLIA_API_URL=https://hn.algolia.com/api/v1

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -181,8 +181,9 @@ OTEL_ENABLED=true
 # Service name shown in Grafana/Tempo.
 OTEL_SERVICE_NAME=hiresense-backend
 # OTLP endpoint. Leave EMPTY for console/terminal fallback (no collector).
-# Under docker-compose set: OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-lgtm:4317
-OTEL_EXPORTER_OTLP_ENDPOINT=
+# Host-run dev with the LGTM stack up: http://localhost:4317. The docker-compose
+# app service overrides this to http://otel-lgtm:4317 automatically.
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
 # Environment label resource attribute.
 DEPLOYMENT_ENVIRONMENT=development
 # Root log level (DEBUG/INFO/WARNING/ERROR).

--- a/backend/src/hiresense/autohunt/infrastructure/__init__.py
+++ b/backend/src/hiresense/autohunt/infrastructure/__init__.py
@@ -1,3 +1,4 @@
+from hiresense.autohunt.infrastructure.orm import DigestOrm
 from hiresense.autohunt.infrastructure.repository import DigestRepository
 
-__all__ = ["DigestRepository"]
+__all__ = ["DigestOrm", "DigestRepository"]

--- a/backend/src/hiresense/bootstrap/ingestion.py
+++ b/backend/src/hiresense/bootstrap/ingestion.py
@@ -65,10 +65,10 @@ def build_ingestion(infra: SharedInfra, tracked: Callable[[str], Any], *, prefer
     normalizers = {}
     for source_name in s.enabled_job_sources:
         if source_name == "remotive":
-            sources.append(RemotiveAdapter(http_client=http_client))
+            sources.append(RemotiveAdapter(http_client=http_client, base_url=s.remotive_api_url))
             normalizers["remotive"] = RemotiveNormalizer()
         elif source_name == "remoteok":
-            sources.append(RemoteOKAdapter(http_client=http_client))
+            sources.append(RemoteOKAdapter(http_client=http_client, base_url=s.remoteok_api_url))
             normalizers["remoteok"] = RemoteOKNormalizer()
         elif source_name == "csv":
             sources.append(CSVImportAdapter())

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -159,6 +159,8 @@ class Settings(BaseSettings):
     ]
 
     # Job source URLs
+    remotive_api_url: str = "https://remotive.com/api/remote-jobs"
+    remoteok_api_url: str = "https://remoteok.com/api"
     jobicy_api_url: str = "https://jobicy.com/api/v2/remote-jobs"
     himalayas_api_url: str = "https://himalayas.app/jobs/api"
     hn_algolia_api_url: str = "https://hn.algolia.com/api/v1"

--- a/backend/src/hiresense/infrastructure/registry.py
+++ b/backend/src/hiresense/infrastructure/registry.py
@@ -13,9 +13,12 @@ from hiresense.applications.infrastructure import (  # noqa: F401
     ApplicationJobSnapshotOrm,
     ApplicationMatchOrm,
 )
+from hiresense.autohunt.infrastructure import DigestOrm  # noqa: F401
 from hiresense.cover_letter_templates.infrastructure import CoverLetterTemplateOrm  # noqa: F401
 from hiresense.ingestion.infrastructure import IngestedJob, JobMatchCache  # noqa: F401
 from hiresense.interview.infrastructure import StoryOrm  # noqa: F401
+from hiresense.outreach.infrastructure import OutreachEventOrm  # noqa: F401
+from hiresense.preference.infrastructure import FeedbackSignalOrm, PreferenceModelOrm  # noqa: F401
 from hiresense.profile.infrastructure import ProfileOrm  # noqa: F401
 from hiresense.research.infrastructure import CompanyResearchOrm  # noqa: F401
 from hiresense.tracking.infrastructure import TrackedApplicationOrm  # noqa: F401

--- a/backend/src/hiresense/ingestion/adapters/remoteok.py
+++ b/backend/src/hiresense/ingestion/adapters/remoteok.py
@@ -5,12 +5,11 @@ from typing import Any
 from hiresense.ingestion.domain.models import RawJobListing
 from hiresense.kernel.value_objects import SourceType
 
-REMOTEOK_API_URL = "https://remoteok.com/api"
-
 
 class RemoteOKAdapter:
-    def __init__(self, http_client: Any) -> None:
+    def __init__(self, http_client: Any, base_url: str) -> None:
         self._http = http_client
+        self._base_url = base_url
 
     def supports_snapshot_closure(self) -> bool:
         return False
@@ -25,7 +24,7 @@ class RemoteOKAdapter:
         self, filters: dict[str, Any] | None = None
     ) -> list[RawJobListing]:
         headers = {"User-Agent": "HireSense/1.0"}
-        response = await self._http.get(REMOTEOK_API_URL, headers=headers)
+        response = await self._http.get(self._base_url, headers=headers)
         response.raise_for_status()
         data = response.json()
         jobs: list[RawJobListing] = []

--- a/backend/src/hiresense/ingestion/adapters/remotive.py
+++ b/backend/src/hiresense/ingestion/adapters/remotive.py
@@ -5,12 +5,11 @@ from typing import Any
 from hiresense.ingestion.domain.models import RawJobListing
 from hiresense.kernel.value_objects import SourceType
 
-REMOTIVE_API_URL = "https://remotive.com/api/remote-jobs"
-
 
 class RemotiveAdapter:
-    def __init__(self, http_client: Any) -> None:
+    def __init__(self, http_client: Any, base_url: str) -> None:
         self._http = http_client
+        self._base_url = base_url
 
     def supports_snapshot_closure(self) -> bool:
         return False
@@ -29,7 +28,7 @@ class RemotiveAdapter:
             params["category"] = filters["category"]
         if filters and "search" in filters:
             params["search"] = filters["search"]
-        response = await self._http.get(REMOTIVE_API_URL, params=params)
+        response = await self._http.get(self._base_url, params=params)
         response.raise_for_status()
         data = response.json()
         return [

--- a/backend/src/hiresense/ingestion/domain/job_filter.py
+++ b/backend/src/hiresense/ingestion/domain/job_filter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from datetime import datetime, timezone
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.seniority import (
@@ -29,7 +29,10 @@ class JobQueryParams(BaseModel):
     sort: str | None = None
     # Hide jobs whose match_score is below this threshold (0.0–1.0). When
     # None, no filter is applied. Jobs with match_score == None (not yet
-    # scored, e.g. no profile) are passed through regardless.
+    # scored, e.g. no profile) are passed through regardless. Jobs whose
+    # semantic_score is still None are also exempt: their match_score is a
+    # skill-only blend that semantic scoring hasn't had a chance to rescue
+    # yet (see filter_and_paginate for the rationale).
     min_score: float | None = None
     # Seniority filter. When set, only jobs whose detected seniority is in
     # this set are returned. UNKNOWN passes through unless explicitly excluded.
@@ -94,9 +97,18 @@ def filter_and_paginate(
 
     if params.min_score is not None:
         threshold = params.min_score
+        # Only gate jobs that have a *fully computed* score. When semantic_score
+        # is None the match_score is a skill-only blend (combine_fit_score falls
+        # back to the skill side); culling on that would unfairly drop a
+        # low-keyword / high-semantic job — e.g. verbose-tag sources like
+        # getonboard suffer tag dilution on the skill side — before the
+        # page-level semantic scoring pass can rescue it. Such jobs pass through
+        # here and are gated, if at all, only once a real semantic score exists.
         filtered = [
             j for j in filtered
-            if j.match_score is None or j.match_score >= threshold
+            if j.match_score is None
+            or j.semantic_score is None
+            or j.match_score >= threshold
         ]
 
     if params.seniority_levels:

--- a/backend/src/hiresense/outreach/infrastructure/__init__.py
+++ b/backend/src/hiresense/outreach/infrastructure/__init__.py
@@ -1,3 +1,4 @@
+from hiresense.outreach.infrastructure.orm import OutreachEventOrm
 from hiresense.outreach.infrastructure.repository import OutreachRepository
 
-__all__ = ["OutreachRepository"]
+__all__ = ["OutreachEventOrm", "OutreachRepository"]

--- a/backend/src/hiresense/preference/infrastructure/__init__.py
+++ b/backend/src/hiresense/preference/infrastructure/__init__.py
@@ -1,3 +1,4 @@
+from hiresense.preference.infrastructure.orm import FeedbackSignalOrm, PreferenceModelOrm
 from hiresense.preference.infrastructure.repository import PreferenceRepository
 
-__all__ = ["PreferenceRepository"]
+__all__ = ["FeedbackSignalOrm", "PreferenceModelOrm", "PreferenceRepository"]

--- a/backend/tests/unit/ingestion/test_job_filter.py
+++ b/backend/tests/unit/ingestion/test_job_filter.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-import pytest
-
-from hiresense.ingestion.domain.job_filter import JobQueryParams, PaginatedResult, filter_and_paginate
+from hiresense.ingestion.domain.job_filter import JobQueryParams, filter_and_paginate
 from hiresense.ingestion.domain.models import NormalizedJob
 
 
@@ -22,6 +20,8 @@ def _job(
     remote_modality: str | None = None,
     countries: list[str] | None = None,
     status: str = "open",
+    match_score: float | None = None,
+    semantic_score: float | None = None,
 ) -> NormalizedJob:
     return NormalizedJob(
         id=id,
@@ -37,6 +37,8 @@ def _job(
         remote_modality=remote_modality,
         countries=countries or [],
         status=status,
+        match_score=match_score,
+        semantic_score=semantic_score,
     )
 
 
@@ -286,3 +288,36 @@ def test_include_closed_shows_all() -> None:
     jobs = [_job(id="1", status="open"), _job(id="2", status="closed")]
     out = filter_and_paginate(jobs, JobQueryParams(include_closed=True))
     assert out.total == 2
+
+
+def test_min_score_gates_fully_scored_jobs() -> None:
+    """A job with a real (semantic-backed) score below the threshold is culled."""
+    jobs = [
+        _job(id="low", match_score=0.2, semantic_score=0.15),
+        _job(id="high", match_score=0.8, semantic_score=0.9),
+    ]
+    out = filter_and_paginate(jobs, JobQueryParams(min_score=0.5))
+    assert {j.id for j in out.jobs} == {"high"}
+
+
+def test_min_score_exempts_unscored_jobs() -> None:
+    """match_score == None means never-scored: always passes the gate."""
+    jobs = [_job(id="1", match_score=None, semantic_score=None)]
+    out = filter_and_paginate(jobs, JobQueryParams(min_score=0.5))
+    assert out.total == 1
+
+
+def test_min_score_exempts_jobs_without_semantic_score() -> None:
+    """Regression for #39: a low skill-only blend (no semantic score yet) must
+    survive the gate so the page-level semantic pass can rescue it.
+
+    Mirrors a verbose-tag source (e.g. getonboard) whose skill-overlap score is
+    diluted to a low value but whose semantic fit hasn't been computed on the
+    first request after restart / passthrough pre-ranking.
+    """
+    jobs = [
+        _job(id="getonboard", match_score=0.1, semantic_score=None),
+        _job(id="culled", match_score=0.1, semantic_score=0.1),
+    ]
+    out = filter_and_paginate(jobs, JobQueryParams(min_score=0.5))
+    assert {j.id for j in out.jobs} == {"getonboard"}

--- a/backend/tests/unit/ingestion/test_remoteok.py
+++ b/backend/tests/unit/ingestion/test_remoteok.py
@@ -13,10 +13,15 @@ class FakeResponse:
         pass
 
 
+TEST_URL = "https://test.example/api"
+
+
 class FakeHttpClient:
     def __init__(self, response_data: list) -> None:
         self._response_data = response_data
+        self.last_url: str | None = None
     async def get(self, url: str, **kwargs) -> FakeResponse:
+        self.last_url = url
         return FakeResponse(self._response_data)
 
 
@@ -38,7 +43,7 @@ async def test_remoteok_fetches_and_normalizes() -> None:
         },
     ]
     client = FakeHttpClient(sample_response)
-    adapter = RemoteOKAdapter(http_client=client)
+    adapter = RemoteOKAdapter(http_client=client, base_url=TEST_URL)
     jobs = await adapter.fetch_jobs()
     assert len(jobs) == 1
     assert jobs[0].source == "remoteok"
@@ -46,7 +51,15 @@ async def test_remoteok_fetches_and_normalizes() -> None:
     assert jobs[0].raw_data["position"] == "Python Developer"
 
 
+@pytest.mark.asyncio
+async def test_remoteok_uses_configured_base_url() -> None:
+    client = FakeHttpClient([])
+    adapter = RemoteOKAdapter(http_client=client, base_url=TEST_URL)
+    await adapter.fetch_jobs()
+    assert client.last_url == TEST_URL
+
+
 def test_remoteok_source_name() -> None:
-    adapter = RemoteOKAdapter(http_client=None)
+    adapter = RemoteOKAdapter(http_client=None, base_url=TEST_URL)
     assert adapter.source_name() == "remoteok"
     assert adapter.source_type() == SourceType.API

--- a/backend/tests/unit/ingestion/test_remotive.py
+++ b/backend/tests/unit/ingestion/test_remotive.py
@@ -13,10 +13,15 @@ class FakeResponse:
         pass
 
 
+TEST_URL = "https://test.example/api/remote-jobs"
+
+
 class FakeHttpClient:
     def __init__(self, response_data: dict) -> None:
         self._response_data = response_data
+        self.last_url: str | None = None
     async def get(self, url: str, **kwargs) -> FakeResponse:
+        self.last_url = url
         return FakeResponse(self._response_data)
 
 
@@ -39,7 +44,7 @@ async def test_remotive_fetches_and_normalizes() -> None:
         ]
     }
     client = FakeHttpClient(sample_response)
-    adapter = RemotiveAdapter(http_client=client)
+    adapter = RemotiveAdapter(http_client=client, base_url=TEST_URL)
     jobs = await adapter.fetch_jobs()
     assert len(jobs) == 1
     assert jobs[0].source == "remotive"
@@ -47,12 +52,20 @@ async def test_remotive_fetches_and_normalizes() -> None:
     assert jobs[0].raw_data["title"] == "Backend Engineer"
 
 
+@pytest.mark.asyncio
+async def test_remotive_uses_configured_base_url() -> None:
+    client = FakeHttpClient({"jobs": []})
+    adapter = RemotiveAdapter(http_client=client, base_url=TEST_URL)
+    await adapter.fetch_jobs()
+    assert client.last_url == TEST_URL
+
+
 def test_remotive_source_name() -> None:
-    adapter = RemotiveAdapter(http_client=None)
+    adapter = RemotiveAdapter(http_client=None, base_url=TEST_URL)
     assert adapter.source_name() == "remotive"
     assert adapter.source_type() == SourceType.API
 
 
 def test_remotive_does_not_support_snapshot_closure() -> None:
-    adapter = RemotiveAdapter(http_client=None)
+    adapter = RemotiveAdapter(http_client=None, base_url=TEST_URL)
     assert adapter.supports_snapshot_closure() is False

--- a/backend/tests/unit/test_orm_registry.py
+++ b/backend/tests/unit/test_orm_registry.py
@@ -1,0 +1,64 @@
+"""Guard that infrastructure/registry.py imports every ORM table.
+
+Alembic's ``--autogenerate`` only sees tables whose ORM classes have been
+imported by the time ``Base.metadata`` is inspected, and the only module it
+imports for that purpose is ``hiresense.infrastructure.registry``. If a new
+``*Orm`` class is added but not wired into the registry, autogenerate silently
+misses its table.
+
+The check runs in a subprocess so import ordering is deterministic: the
+registry is imported first (capturing exactly what it pulls in), then the whole
+package is walked to discover the full set of ORM tables. Any table present in
+the full set but absent from the registry-only set is a missing import.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+_PROBE = textwrap.dedent(
+    """
+    import importlib
+    import json
+    import pkgutil
+
+    import hiresense
+    from hiresense.infrastructure.database import Base
+
+    # Importing the registry alone is what Alembic relies on.
+    importlib.import_module("hiresense.infrastructure.registry")
+    registry_tables = set(Base.metadata.tables)
+
+    # Walk the whole package to discover every mapped table.
+    for module in pkgutil.walk_packages(hiresense.__path__, hiresense.__name__ + "."):
+        try:
+            importlib.import_module(module.name)
+        except Exception:
+            # Some optional modules may fail to import in isolation; their ORM
+            # classes, if any, would have been pulled in via the registry.
+            pass
+    all_tables = set(Base.metadata.tables)
+
+    missing = sorted(all_tables - registry_tables)
+    print(json.dumps(missing))
+    """
+)
+
+
+def test_registry_imports_every_orm_table() -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", _PROBE],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    import json
+
+    missing = json.loads(result.stdout.strip().splitlines()[-1])
+    assert missing == [], (
+        "These ORM tables are not reachable through "
+        "hiresense.infrastructure.registry and will be missed by Alembic "
+        f"autogenerate: {missing}"
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,12 @@ services:
     ports:
       - "${APP_PORT:-8000}:8000"
     env_file: ./backend/.env
+    environment:
+      # In-network overrides: .env is host-oriented (localhost); inside the
+      # compose network the app must address services by name.
+      DATABASE_URL: postgresql+asyncpg://hiresense:hiresense@db:5432/hiresense
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-lgtm:4317
+      LOG_FORMAT: json
     depends_on:
       db:
         condition: service_healthy

--- a/docs/superpowers/specs/2026-06-07-issue-backlog-design.md
+++ b/docs/superpowers/specs/2026-06-07-issue-backlog-design.md
@@ -1,0 +1,232 @@
+# GitHub Issue Backlog — Design & Drafts
+
+**Date:** 2026-06-07
+**Status:** Draft — pending review before creation on GitHub
+**Repo:** `StevSant/HireSense`
+
+## Goal
+
+Seed the repo's (currently empty) issue tracker with a curated backlog (~20 top-level issues + sub-issues) combining: designed-but-unbuilt features from `docs/superpowers/specs`, known bugs, and audit findings from backend + frontend sweeps. Every finding below was verified against actual code; speculative or already-built items were dropped during curation.
+
+## Dropped findings (verified as false positives)
+
+- *Preference feedback frontend missing* — `app-feedback-controls` is wired in both the list rows (`ingestion.component.html:196`) and detail panel, and `app-preference-tuning` is mounted in the toolbar. Built.
+- *Job lifecycle frontend missing* — `status` field exists on `normalized-job.model.ts:26`, closed badge + `include_closed` toggle are implemented. Built.
+- *Analytics/observability/portal-scanning "verify completeness"* — too vague to be actionable issues; no concrete gap found.
+
+## Taxonomy
+
+### Labels (to create)
+
+| Label | Color | Purpose |
+|---|---|---|
+| `tech-debt` | `#c2410c` | Refactors, robustness, convention violations |
+| `testing` | `#0e8a16` | Test coverage and test infrastructure |
+| `epic` | `#3e4b9e` | Parent issue with sub-issues |
+| `priority: P1` | `#b60205` | High value / risky if unfixed |
+| `priority: P2` | `#fbca04` | Should do |
+| `priority: P3` | `#c5def5` | Nice to have |
+| `area: backend` | `#1d76db` | Backend work |
+| `area: frontend` | `#e99695` | Frontend work |
+| `module: ingestion` | `#bfd4f2` | Bounded context |
+| `module: outreach` | `#bfd4f2` | Bounded context |
+| `module: autohunt` | `#bfd4f2` | Bounded context |
+| `module: preference` | `#bfd4f2` | Bounded context |
+| `module: admin` | `#bfd4f2` | Bounded context |
+| `module: identity` | `#bfd4f2` | Bounded context |
+| `module: analytics` | `#bfd4f2` | Bounded context |
+
+Existing defaults reused: `bug`, `enhancement`, `documentation`, `good first issue`.
+
+### Milestones (to create)
+
+1. **Feature completion** — designed features needing UI or next phases
+2. **Stability & robustness** — bugs and risky tech debt
+3. **Quality & conventions** — testing, conventions, docs
+
+### Conventions
+
+- Titles in conventional-commit style: `type(scope): description`
+- Bodies: Context / Proposal / Acceptance criteria / References
+- Big features = parent issue (`epic`) + native GitHub sub-issues
+- `.github/ISSUE_TEMPLATE/` forms committed so future issues keep this shape
+
+---
+
+## Issue drafts
+
+### Milestone: Feature completion
+
+#### 1. [EPIC] feat(outreach): frontend for the outreach module
+`epic` `enhancement` `area: frontend` `module: outreach` `priority: P1`
+
+**Context:** The outreach backend is complete and wired (`POST /outreach/generate`, `POST /outreach/record`, `GET /outreach/events`, nudges via `due_followups`) but has zero frontend — no page, no service, no route.
+**Proposal:** Build the outreach UI following the per-domain conventions (service wrapper in `core/services`, models in `.model.ts`, standalone signal components under `pages/outreach/`).
+**Acceptance criteria:** Sub-issues below complete; outreach reachable from sidebar.
+**References:** `docs/superpowers/specs/2026-05-31-outreach-networking-design.md`, `backend/src/hiresense/outreach/api/routes.py`
+
+- **1a. feat(outreach): frontend service + models** — `OutreachService` wrapping the four endpoints; `outreach-event.model.ts` etc. mirroring backend schemas. `area: frontend` `module: outreach`
+- **1b. feat(outreach): outreach page — generate + record flows** — form to generate a message for a job/contact (kind, style), edit, then record the send; list of past events. `area: frontend` `module: outreach`
+- **1c. feat(outreach): follow-up nudges view** — surface due follow-ups (`due_followups`) with quick "record follow-up" action; badge count in sidebar nav. `area: frontend` `module: outreach`
+
+#### 2. feat(autohunt): frontend for auto-hunt digests
+`enhancement` `area: frontend` `module: autohunt` `priority: P2`
+
+**Context:** AutoHunt backend exposes `POST /autohunt/run`, `GET /autohunt/digests`, `GET /autohunt/digests/latest` but there is no frontend page or service.
+**Proposal:** Digest list + latest-digest view (matched jobs with scores), manual "run now" trigger, per conventions.
+**Acceptance criteria:** Page routed and in sidebar; digests render with links to job detail; run trigger shows progress/result; specs for the service.
+**References:** `docs/superpowers/specs/2026-05-31-proactive-auto-hunt-design.md`, `backend/src/hiresense/autohunt/api/routes.py`
+
+#### 3. [EPIC] feat(preference): learning loop phase 2 — implicit signals, weight nudging, explanation v2
+`epic` `enhancement` `area: backend` `module: preference` `priority: P2`
+
+**Context:** Phase 1 (taste vector + explicit feedback) shipped. Phase 2 design exists but is unimplemented.
+**References:** `docs/superpowers/specs/2026-05-31-preference-learning-loop-phase2-design.md`, `docs/superpowers/specs/2026-05-31-preference-weight-nudging-concept.md`, `docs/superpowers/plans/2026-05-31-preference-phase2-implicit-and-explanation.md`
+
+- **3a. feat(preference): implicit signals from tracking status changes** — publish/subscribe `TrackingStatusChangedEvent`; record implicit feedback (applied/interview/offer = positive). `area: backend` `module: preference`
+- **3b. feat(preference): dimension weight nudging** — needs a brainstorm first per the concept doc (where dimension scores are cached, nudge math, override application in composite scoring). `area: backend` `module: preference`
+- **3c. feat(preference): LLM-phrased explanation v2** — richer "why this score" explanations. `area: backend` `module: preference`
+
+#### 4. feat(identity): real admin role + account settings UI
+`enhancement` `area: backend` `area: frontend` `module: identity` `priority: P2`
+
+**Context:** `frontend/src/app/core/guards/admin.guard.ts:5` has `TODO(#19): gate on real admin role once the backend exposes one` (the referenced issue never existed). Identity backend only exposes `POST /auth/login`; no user/account UI.
+**Proposal:** Backend exposes role on the auth token/user endpoint; admin guard checks it; minimal account settings page.
+**Acceptance criteria:** Admin routes blocked for non-admin users end-to-end; TODO removed and pointed at this issue.
+**References:** `frontend/src/app/core/guards/admin.guard.ts:5`, `backend/src/hiresense/identity/api/routes.py`
+
+### Milestone: Stability & robustness
+
+#### 5. bug(ingestion): min_score gate culls jobs before page-level semantic scoring
+`bug` `area: backend` `module: ingestion` `priority: P1`
+
+**Context:** In `ingestion/api/routes.py`, `filter_and_paginate` applies `min_score` (line 223) before the page-level semantic scoring pass (lines 229–244). When the pre-ranker is passthrough (no vector store / empty profile) or scores aren't yet persisted, jobs are culled on their skill-only score. Verbose-tag sources (e.g., getonboard, 15–30 tags) suffer tag dilution and get unfairly filtered before semantic scoring can rescue them.
+**Proposal:** Apply the min_score gate after semantic scores exist for the candidate set, or exempt jobs with `semantic_score is None` from the gate.
+**Acceptance criteria:** A getonboard-style job with low skill-overlap but high semantic fit survives the first request after restart; regression test.
+**References:** `backend/src/hiresense/ingestion/api/routes.py:196-244`
+
+#### 6. tech-debt(infrastructure): add missing ORM imports to registry.py
+`tech-debt` `area: backend` `priority: P1` `good first issue`
+
+**Context:** `infrastructure/registry.py` must import every ORM class or Alembic `--autogenerate` silently misses tables. Missing: `DigestOrm` (autohunt), `OutreachEventOrm` (outreach), `FeedbackSignalOrm` + `PreferenceModelOrm` (preference).
+**Acceptance criteria:** All four imported; an autogenerate run produces an empty diff; consider a test asserting every `*Orm` subclass of `Base` is reachable via the registry module.
+**References:** `backend/src/hiresense/infrastructure/registry.py`
+
+#### 7. tech-debt(ingestion): retry/backoff for external HTTP adapters
+`tech-debt` `area: backend` `module: ingestion` `priority: P2`
+
+**Context:** All job-source adapters do single un-retried `await self._http.get(...)`; the shared `httpx.AsyncClient` (`main.py:48`) sets only `timeout` — no transport retries, no backoff. Transient 5xx/429/timeouts silently lose jobs for that cycle.
+**Proposal:** Configure `httpx.AsyncHTTPTransport(retries=...)` plus a small backoff helper for 429/5xx in the adapter base; retry counts/backoff via `config.py` + `.env.example`.
+**Acceptance criteria:** Transient failure of one fetch retries before giving up; tests with a flaky mock transport.
+**References:** `backend/src/hiresense/main.py:48`, `backend/src/hiresense/ingestion/adapters/`
+
+#### 8. tech-debt(frontend): standardize subscription teardown with DestroyRef
+`tech-debt` `area: frontend` `priority: P2`
+
+**Context:** 9 page components subscribe to HTTP observables with no teardown (admin-llm-settings, admin-usage, applications, interview, matching, profile, tracking, …). HTTP observables complete on response so these aren't classic leaks, but in-flight responses after navigation write to destroyed-component signals and any future long-lived streams would leak.
+**Proposal:** Adopt `inject(DestroyRef)` + `.pipe(takeUntilDestroyed(this.destroyRef))` as the standard pattern; document it in `agent-os/standards/frontend/`.
+**Acceptance criteria:** All listed components migrated; standard documented.
+**References:** e.g. `frontend/src/app/pages/admin/admin-usage.component.ts:58`, `frontend/src/app/pages/matching/matching.component.ts:57-79`
+
+#### 9. tech-debt(adapters): event bus should log handler exceptions
+`tech-debt` `area: backend` `priority: P3` `good first issue`
+
+**Context:** `adapters/event_bus/in_memory_bus.py:58` catches all handler exceptions, records span status + metric, but never logs which handler failed with what error — silent crashes are hard to debug.
+**Proposal:** `logger.exception(...)` with handler + event names before recording the metric.
+**References:** `backend/src/hiresense/adapters/event_bus/in_memory_bus.py:58`
+
+#### 10. tech-debt(ingestion): clean up orphaned vector embeddings after pruning
+`tech-debt` `area: backend` `module: ingestion` `priority: P3`
+
+**Context:** `prune_older_than()` deletes jobs; vector eviction is best-effort with no FK cascade (acknowledged in migration `014_create_vector_embeddings.py:36`). Orphans accumulate and waste disk; harmless otherwise.
+**Proposal:** Periodic cleanup that deletes `vector_embeddings` rows with no matching job (piggyback on the prune call), or add the FK cascade.
+**References:** `backend/src/hiresense/ingestion/infrastructure/jobs_repository.py:135-151`, `backend/alembic/versions/014_create_vector_embeddings.py:36`
+
+#### 11. bug(identity): login loading state never cleared on success
+`bug` `area: frontend` `module: identity` `priority: P3` `good first issue`
+
+**Context:** `login.component.ts:21-34` navigates away in `next` without `this.loading.set(false)`; spinner persists until navigation completes.
+**References:** `frontend/src/app/pages/login/login.component.ts:21-34`
+
+### Milestone: Quality & conventions
+
+#### 12. [EPIC] testing(frontend): spec coverage for untested page components
+`epic` `testing` `area: frontend` `priority: P2`
+
+**Context:** Only 7 of 35 page components have specs (analytics charts + preference controls). 28 components are untested.
+
+- **12a. testing(frontend): admin specs** — admin-llm-settings, admin-usage. `testing` `module: admin`
+- **12b. testing(frontend): applications + tracking specs** — applications, application-detail, 4 tab components, tracking. `testing`
+- **12c. testing(frontend): ingestion component specs** — job-filters, pagination, deep-analysis, job-detail-panel. `testing` `module: ingestion`
+- **12d. testing(frontend): remaining page specs** — dashboard, login, matching, optimization, profile, interview, applications-prep-list. `testing`
+
+#### 13. testing(ingestion): pgvector ANN validation strategy
+`testing` `area: backend` `module: ingestion` `priority: P2`
+
+**Context:** The suite runs against SQLite; pgvector ANN search has no automated validation at all — only manual checks against `docker compose up db`.
+**Proposal:** Opt-in integration test marker (`pytest -m pgvector`) that runs against the compose DB, exercising upsert → ANN query → eviction; document the workflow in CLAUDE.md/ARCHITECTURE.md.
+**References:** `backend/ARCHITECTURE.md` (ANN validation note), `backend/tests/unit/test_pgvector_adapter.py`
+
+#### 14. tech-debt(admin): align admin module with hexagonal rules
+`tech-debt` `area: backend` `module: admin` `priority: P3`
+
+**Context:** Two known deviations: (1) `llm_factory.py` / `llm_test_runner.py` import langchain from `domain/` (documented follow-up in ARCHITECTURE.md); (2) `usage_aggregator.py:12` imports infrastructure types under `TYPE_CHECKING` — types should live in the port or domain.
+**Acceptance criteria:** LangChain-touching code moved to `infrastructure/`; aggregator typed against port/domain types; ARCHITECTURE.md follow-up note removed.
+**References:** `backend/src/hiresense/admin/domain/llm_factory.py`, `backend/src/hiresense/admin/domain/usage_aggregator.py:12`
+
+#### 15. chore(config): move Remotive/RemoteOK base URLs into config
+`tech-debt` `area: backend` `module: ingestion` `priority: P3` `good first issue`
+
+**Context:** Other sources read base URLs from `config.py`; `RemotiveAdapter` and `RemoteOKAdapter` hardcode theirs, violating the no-hardcoded-values rule and blocking test redirection.
+**Acceptance criteria:** `REMOTIVE_API_URL` / `REMOTEOK_API_URL` in `config.py`, `.env`, `.env.example` (with comments); adapters read from settings.
+**References:** `backend/src/hiresense/ingestion/adapters/remotive.py:8`, `.../remoteok.py:8`
+
+#### 16. tech-debt(cross-cutting): bound large result-set queries
+`tech-debt` `area: backend` `priority: P3`
+
+**Context:** `llm_usage_log_repository.list_recent()` and `analytics corpus_repository.open_skill_lists()` load unbounded result sets into memory; fine today, degrades as the corpus grows.
+**Proposal:** Limits/pagination on `list_recent`; cap or stream `open_skill_lists` (config-driven threshold).
+**References:** `backend/src/hiresense/admin/infrastructure/llm_usage_log_repository.py:87-91`, `backend/src/hiresense/analytics/infrastructure/corpus_repository.py:20`
+
+#### 17. tech-debt(frontend): convention cleanup — inline interfaces, hardcoded suggestions, chart magic numbers
+`tech-debt` `area: frontend` `priority: P3` `good first issue`
+
+**Context:** Bundled small violations: `ExtraParam`/`OverrideDraft` defined inline in `admin-llm-settings.component.ts:10-22` (belong in `.model.ts`); LLM provider/model suggestions hardcoded (`admin-llm-settings.component.ts:27-32`) — fetch from backend or move to `core/constants/`; bar-chart layout magic numbers (`admin-usage.component.ts:128-143`) → named constants/inputs.
+**Acceptance criteria:** All three cleaned up per `agent-os/standards/frontend/`.
+
+#### 18. tech-debt(frontend): error logging strategy
+`tech-debt` `area: frontend` `priority: P3`
+
+**Context:** HTTP errors only land in component UI signals (e.g., `tracking.component.ts:71`); nothing reaches the console or any tracker, so field debugging is blind.
+**Proposal:** Small `ErrorReportingService` (console in dev; hook for OTel/browser tracker later) called from catch paths / a shared interceptor.
+**References:** `frontend/src/app/pages/tracking/tracking.component.ts:71`
+
+#### 19. tech-debt(frontend): accessibility pass
+`tech-debt` `area: frontend` `priority: P3`
+
+**Context:** Quick scan shows missing ARIA labels, table alt text, and keyboard navigation in modals/panels.
+**Proposal:** Run axe (or Angular ESLint a11y rules) on the main pages; fix the high-signal findings; add the lint rules to keep it enforced.
+
+#### 20. docs(architecture): clarify the stateless-module rule vs analytics infrastructure
+`documentation` `area: backend` `module: analytics` `priority: P3`
+
+**Context:** ARCHITECTURE.md says stateless modules (incl. analytics) have no `infrastructure/`, but `analytics/infrastructure/corpus_repository.py` exists as a read-only aggregator over the corpus. Either the rule needs a "read-only query adapters allowed" carve-out, or the repository belongs elsewhere.
+**Acceptance criteria:** ARCHITECTURE.md updated to match reality (or code relocated); the rule unambiguous for future modules.
+**References:** `backend/ARCHITECTURE.md`, `backend/src/hiresense/analytics/infrastructure/corpus_repository.py`
+
+---
+
+## Issue templates (to commit)
+
+`.github/ISSUE_TEMPLATE/` with three YAML forms matching the body convention above:
+
+- `feature.yml` — Context / Proposal / Acceptance criteria / References; auto-label `enhancement`
+- `bug.yml` — Context / Reproduction / Expected vs actual / References; auto-label `bug`
+- `tech-debt.yml` — Context / Proposal / References; auto-label `tech-debt`
+- `config.yml` — `blank_issues_enabled: true`
+
+## Execution order (after approval)
+
+1. Create labels (`gh label create`), milestones (`gh api`)
+2. Create the 20 top-level issues (`gh issue create`), then link sub-issues via the GraphQL `addSubIssue` mutation
+3. Commit issue templates + this design doc


### PR DESCRIPTION
A multi-wave sweep of the independent backlog issues, implemented with parallel agent teams and integrated/verified centrally. One scoped commit per issue.

### Backend
- **#40** registry imports every `*Orm` (Alembic autogenerate) + guard test
- **#39** min_score gate no longer culls jobs lacking a semantic score
- **#54** Remotive/RemoteOK base URLs → config
- **#43** event bus logs the failing handler name + records span exception
- **#59** ARCHITECTURE.md: read-only query-adapter carve-out for stateless modules
- **#41** `RetryingAsyncClient` — retry + exponential backoff for the shared HTTP client
- **#44** end-to-end test proving prune evicts orphaned embeddings
- **#53** admin repositories map ORM → pure domain records; ports reference domain types
- **#55** config-driven caps on `list_recent` + analytics corpus scans

### Frontend
- **#45** login clears its loading spinner via `finalize`
- **#47** CV Optimization prefills from `job_id` with a job-context header + graceful fallback
- **#56** convention cleanup: inline interfaces → `*.model.ts`, suggestions → constants, chart magic numbers → named constants
- **#42** standardize subscription teardown with `inject(DestroyRef)` + `takeUntilDestroyed`; documented standard

### Testing — completes epic #46 (spec coverage)
- **#48** admin specs (28 tests)
- **#49** applications + tracking specs (70 tests)
- **#50** ingestion component specs (35 tests)
- **#51** remaining page specs (20 tests)

### Verification
- Backend: `uv run python -m pytest` → **779 passed**; `ruff check` clean on all new/changed files.
- Frontend: full Vitest → **196 passed (31 files)** (up from 43); `tsc --noEmit` clean for app + spec projects.

Closes #40
Closes #39
Closes #54
Closes #43
Closes #59
Closes #41
Closes #44
Closes #53
Closes #55
Closes #45
Closes #47
Closes #56
Closes #42
Closes #46
Closes #48
Closes #49
Closes #50
Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)