### PR TITLE
feat(outreach): frontend epic #29 — service, compose/timeline page, follow-up nudges

### DIFF
--- a/docs/superpowers/specs/2026-06-07-outreach-frontend-design.md
+++ b/docs/superpowers/specs/2026-06-07-outreach-frontend-design.md
@@ -1,0 +1,68 @@
+# Outreach Frontend — Design
+
+**Epic:** #29 · **Children:** #30 (service + models), #31 (page — generate + record), #32 (follow-up nudges view)
+**Depends on:** the existing `outreach` backend module (`/outreach/*` endpoints) and `applications` (to pick a target application).
+
+## Context
+
+The backend outreach loop (generate → record → nudge, copy-only) is built and tested; the
+`2026-05-31-outreach-networking-design.md` doc lists "the frontend compose/timeline UI" as the
+out-of-scope future work. This epic delivers that UI: a single Outreach page that lets the user
+draft an on-brand message for a tracked application, record outreach actions, see the per-application
+timeline, and act on due follow-up nudges.
+
+## Backend contract (already implemented)
+
+All routes are auth-gated under `/outreach`.
+
+| Method | Path | Body | Returns |
+|---|---|---|---|
+| POST | `/outreach/generate` | `{ application_id, contact_name?, channel? }` | `{ message }` — 503 if no LLM, 404 if app missing |
+| POST | `/outreach/record` | `{ application_id, kind, message?, contact_name?, channel? }` | `OutreachEvent` (201) |
+| GET | `/outreach/events?application_id=<uuid>` | — | `OutreachEvent[]` |
+| POST | `/outreach/nudge` | — | `OutreachNudge[]` (due follow-ups) |
+
+- `OutreachEvent { id, application_id, kind, contact_name?, channel?, message?, created_at }`
+- `OutreachNudge { application_id, company, contact_name?, sent_at, days_since }`
+- `OutreachEventKind = 'sent' | 'followed_up' | 'replied'`
+
+## Frontend design
+
+### #30 — service + models
+- `pages/outreach/models/` (one interface per `.model.ts`, package convention): `outreach-event.model.ts`
+  (`OutreachEvent`), `outreach-event-kind.model.ts` (`OutreachEventKind` union), `outreach-nudge.model.ts`
+  (`OutreachNudge`), `generate-request.model.ts`, `generate-response.model.ts`, `record-request.model.ts`.
+- `core/services/outreach.service.ts` (`@Injectable({providedIn:'root'})`, `inject(HttpClient)`,
+  `base = ${environment.apiUrl}/outreach`): `generate(req)`, `record(req)`, `listEvents(applicationId)`,
+  `dueFollowups()`. Mirrors `InterviewService`/`ApplicationsService` style exactly.
+
+### #31 — Outreach page (generate + record), `pages/outreach/outreach.component.ts`
+Standalone component, signal state, route `dashboard/outreach`, sidebar nav entry.
+- **Target picker:** load applications via `ApplicationsService.list()`; a `<select>` of `title @ company`.
+  Accept a `?application_id=` query param to preselect (so the applications page / detail can deep-link in).
+- **Compose:** optional `contactName` + `channel` inputs → **Generate** calls `generate` and fills an
+  editable `message` textarea (the user can tweak before recording). Surface the 503 ("generation
+  unavailable") and 404 states as inline notices, not blank errors. Copy-to-clipboard button.
+- **Record:** **Mark as sent** records `kind:'sent'` with the current message + contact + channel;
+  buttons to record `followed_up` / `replied`. On success, refresh the timeline.
+- **Timeline:** `listEvents(selectedId)` rendered newest-first with kind badge, contact/channel,
+  relative time, and the message body. Empty + error states.
+
+### #32 — follow-up nudges view (section on the same page)
+- On load, `dueFollowups()` populates a "Needs a follow-up" list: company, contact, `days_since`
+  ("sent N days ago"), each row links to that application and offers **Mark followed up** (records
+  `followed_up` for that `application_id`, then removes it from the list and refreshes the timeline if
+  it's the selected app). Empty state ("You're all caught up"). Error state.
+
+### Wiring
+- Add the lazy route to `app.routes.ts` under the `dashboard` children.
+- Add a sidebar nav link in `dashboard.component.html` (same markup as siblings; an envelope/📨 icon).
+- All HTTP subscriptions use `inject(DestroyRef)` + `takeUntilDestroyed` per the teardown standard.
+
+## Testing
+- `outreach.service.spec.ts`: each method hits the right URL/verb/body (HttpTestingController).
+- `outreach.component.spec.ts`: generate happy path fills the message; 503 → notice; record sent →
+  timeline refresh; nudges load + "mark followed up" removes the row. Services mocked.
+
+## Out of scope (unchanged from backend doc)
+Outbound send, inbound-reply inbox, first-class contacts entity. This is copy-only.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -18,6 +18,7 @@ export const routes: Routes = [
       { path: 'matching', loadComponent: () => import('./pages/matching/matching.component').then(m => m.MatchingComponent) },
       { path: 'optimization', loadComponent: () => import('./pages/optimization/optimization.component').then(m => m.OptimizationComponent) },
       { path: 'tracking', loadComponent: () => import('./pages/tracking/tracking.component').then(m => m.TrackingComponent) },
+      { path: 'outreach', loadComponent: () => import('./pages/outreach/outreach.component').then(m => m.OutreachComponent) },
       { path: 'analytics', loadComponent: () => import('./pages/analytics/analytics.component').then(m => m.AnalyticsComponent) },
       { path: 'interview', loadComponent: () => import('./pages/interview/interview.component').then(m => m.InterviewComponent) },
       { path: 'admin/llm-settings', canActivate: [adminGuard], loadComponent: () => import('./pages/admin/admin-llm-settings.component').then(m => m.AdminLLMSettingsComponent) },

--- a/frontend/src/app/core/services/outreach.service.spec.ts
+++ b/frontend/src/app/core/services/outreach.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { OutreachService } from './outreach.service';
+import { environment } from '../../../environments/environment';
+
+describe('OutreachService', () => {
+  let service: OutreachService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [OutreachService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(OutreachService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('generate POSTs /outreach/generate with the request body', () => {
+    const body = { application_id: 'app-1', contact_name: 'Jordan', channel: 'LinkedIn' };
+    service.generate(body).subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/outreach/generate`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush({ message: 'Hello' });
+  });
+
+  it('record POSTs /outreach/record with the request body', () => {
+    const body = { application_id: 'app-1', kind: 'sent' as const, message: 'Hi' };
+    service.record(body).subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/outreach/record`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(body);
+    req.flush({
+      id: 'evt-1',
+      application_id: 'app-1',
+      kind: 'sent',
+      contact_name: null,
+      channel: null,
+      message: 'Hi',
+      created_at: null,
+    });
+  });
+
+  it('listEvents GETs /outreach/events with the application_id param', () => {
+    service.listEvents('app-1').subscribe();
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/outreach/events?application_id=app-1`,
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('application_id')).toBe('app-1');
+    req.flush([]);
+  });
+
+  it('dueFollowups POSTs /outreach/nudge', () => {
+    service.dueFollowups().subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/outreach/nudge`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+    req.flush([]);
+  });
+});

--- a/frontend/src/app/core/services/outreach.service.ts
+++ b/frontend/src/app/core/services/outreach.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { OutreachEvent } from '../../pages/outreach/models/outreach-event.model';
+import { OutreachNudge } from '../../pages/outreach/models/outreach-nudge.model';
+import { GenerateRequest } from '../../pages/outreach/models/generate-request.model';
+import { GenerateResponse } from '../../pages/outreach/models/generate-response.model';
+import { RecordRequest } from '../../pages/outreach/models/record-request.model';
+
+@Injectable({ providedIn: 'root' })
+export class OutreachService {
+  private http = inject(HttpClient);
+  private base = `${environment.apiUrl}/outreach`;
+
+  generate(req: GenerateRequest): Observable<GenerateResponse> {
+    return this.http.post<GenerateResponse>(`${this.base}/generate`, req);
+  }
+
+  record(req: RecordRequest): Observable<OutreachEvent> {
+    return this.http.post<OutreachEvent>(`${this.base}/record`, req);
+  }
+
+  listEvents(applicationId: string): Observable<OutreachEvent[]> {
+    const params = new HttpParams().set('application_id', applicationId);
+    return this.http.get<OutreachEvent[]>(`${this.base}/events`, { params });
+  }
+
+  dueFollowups(): Observable<OutreachNudge[]> {
+    return this.http.post<OutreachNudge[]>(`${this.base}/nudge`, {});
+  }
+}

--- a/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -71,6 +71,15 @@
         </span>
         <span>Tracking</span>
       </a>
+      <a routerLink="outreach" routerLinkActive="active">
+        <span class="nav-icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="2" y="4" width="20" height="16" rx="2"/>
+            <path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/>
+          </svg>
+        </span>
+        <span>Outreach</span>
+      </a>
       <a routerLink="analytics" routerLinkActive="active">
         <span class="nav-icon" aria-hidden="true">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">

--- a/frontend/src/app/pages/outreach/models/generate-request.model.ts
+++ b/frontend/src/app/pages/outreach/models/generate-request.model.ts
@@ -1,0 +1,5 @@
+export interface GenerateRequest {
+  application_id: string;
+  contact_name?: string;
+  channel?: string;
+}

--- a/frontend/src/app/pages/outreach/models/generate-response.model.ts
+++ b/frontend/src/app/pages/outreach/models/generate-response.model.ts
@@ -1,0 +1,3 @@
+export interface GenerateResponse {
+  message: string;
+}

--- a/frontend/src/app/pages/outreach/models/outreach-event-kind.model.ts
+++ b/frontend/src/app/pages/outreach/models/outreach-event-kind.model.ts
@@ -1,0 +1,1 @@
+export type OutreachEventKind = 'sent' | 'followed_up' | 'replied';

--- a/frontend/src/app/pages/outreach/models/outreach-event.model.ts
+++ b/frontend/src/app/pages/outreach/models/outreach-event.model.ts
@@ -1,0 +1,11 @@
+import { OutreachEventKind } from './outreach-event-kind.model';
+
+export interface OutreachEvent {
+  id: string;
+  application_id: string;
+  kind: OutreachEventKind;
+  contact_name: string | null;
+  channel: string | null;
+  message: string | null;
+  created_at: string | null;
+}

--- a/frontend/src/app/pages/outreach/models/outreach-nudge.model.ts
+++ b/frontend/src/app/pages/outreach/models/outreach-nudge.model.ts
@@ -1,0 +1,7 @@
+export interface OutreachNudge {
+  application_id: string;
+  company: string;
+  contact_name: string | null;
+  sent_at: string;
+  days_since: number;
+}

--- a/frontend/src/app/pages/outreach/models/record-request.model.ts
+++ b/frontend/src/app/pages/outreach/models/record-request.model.ts
@@ -1,0 +1,9 @@
+import { OutreachEventKind } from './outreach-event-kind.model';
+
+export interface RecordRequest {
+  application_id: string;
+  kind: OutreachEventKind;
+  message?: string;
+  contact_name?: string;
+  channel?: string;
+}

--- a/frontend/src/app/pages/outreach/outreach.component.html
+++ b/frontend/src/app/pages/outreach/outreach.component.html
@@ -1,0 +1,147 @@
+<div class="page">
+  <h1>Outreach</h1>
+  <p class="hint">
+    Draft an on-brand message for a tracked application, record what you sent, and stay on top of
+    follow-ups.
+  </p>
+
+  <!-- #32 — follow-up nudges -->
+  <section class="card nudges">
+    <h2>Needs a follow-up</h2>
+    @if (nudgesError()) {
+      <div class="alert alert-error">{{ nudgesError() }}</div>
+    } @else if (nudgesLoading()) {
+      <p class="muted">Loading…</p>
+    } @else if (nudges().length === 0) {
+      <p class="muted empty">You're all caught up.</p>
+    } @else {
+      <ul class="nudge-list">
+        @for (nudge of nudges(); track nudge.application_id) {
+          <li class="nudge-row">
+            <button class="nudge-main" (click)="selectNudge(nudge)">
+              <span class="nudge-company">{{ nudge.company }}</span>
+              @if (nudge.contact_name) {
+                <span class="nudge-contact">· {{ nudge.contact_name }}</span>
+              }
+              <span class="nudge-age">sent {{ nudge.days_since }} days ago</span>
+            </button>
+            <button class="btn-secondary" (click)="markFollowedUp(nudge)">Mark followed up</button>
+          </li>
+        }
+      </ul>
+    }
+  </section>
+
+  <!-- Target picker -->
+  <section class="card">
+    <h2>Compose</h2>
+    <div class="field">
+      <label for="application">Application</label>
+      <select
+        id="application"
+        [ngModel]="selectedApplicationId()"
+        (ngModelChange)="onSelectChange($event)"
+      >
+        <option value="">Select an application…</option>
+        @for (app of applications(); track app.id) {
+          <option [value]="app.id">{{ app.title }} @ {{ app.company }}</option>
+        }
+      </select>
+    </div>
+
+    <div class="field-row">
+      <div class="field">
+        <label for="contact">Contact name (optional)</label>
+        <input
+          id="contact"
+          [ngModel]="contactName()"
+          (ngModelChange)="contactName.set($event)"
+          placeholder="e.g. Jordan Lee"
+        />
+      </div>
+      <div class="field">
+        <label for="channel">Channel (optional)</label>
+        <input
+          id="channel"
+          [ngModel]="channel()"
+          (ngModelChange)="channel.set($event)"
+          placeholder="e.g. LinkedIn"
+        />
+      </div>
+    </div>
+
+    <button class="btn-primary" (click)="generate()" [disabled]="generating() || !hasSelection()">
+      @if (generating()) { Generating… } @else { Generate message }
+    </button>
+
+    @if (composeNotice()) {
+      <div class="alert alert-warning">{{ composeNotice() }}</div>
+    }
+
+    <div class="field">
+      <label for="message">Message</label>
+      <textarea
+        id="message"
+        rows="8"
+        [ngModel]="message()"
+        (ngModelChange)="message.set($event)"
+        placeholder="Generate a draft above, or write your own…"
+      ></textarea>
+    </div>
+
+    <div class="actions">
+      <button class="btn-secondary" (click)="copyMessage()" [disabled]="!message()">
+        @if (copied()) { Copied! } @else { Copy }
+      </button>
+      <button class="btn-primary" (click)="record('sent')" [disabled]="recording() || !hasSelection()">
+        Mark as sent
+      </button>
+      <button class="btn-secondary" (click)="record('followed_up')" [disabled]="recording() || !hasSelection()">
+        Followed up
+      </button>
+      <button class="btn-secondary" (click)="record('replied')" [disabled]="recording() || !hasSelection()">
+        Replied
+      </button>
+    </div>
+
+    @if (recordError()) {
+      <div class="alert alert-error">{{ recordError() }}</div>
+    }
+  </section>
+
+  <!-- Timeline -->
+  <section class="card">
+    <h2>Timeline</h2>
+    @if (!hasSelection()) {
+      <p class="muted">Select an application to see its outreach history.</p>
+    } @else if (timelineError()) {
+      <div class="alert alert-error">{{ timelineError() }}</div>
+    } @else if (timelineLoading()) {
+      <p class="muted">Loading…</p>
+    } @else if (events().length === 0) {
+      <p class="muted empty">No outreach recorded yet.</p>
+    } @else {
+      <ul class="timeline">
+        @for (event of events(); track event.id) {
+          <li class="timeline-row">
+            <div class="timeline-head">
+              <span class="badge" [class]="'badge-' + event.kind">{{ event.kind }}</span>
+              @if (event.contact_name) {
+                <span class="timeline-contact">{{ event.contact_name }}</span>
+              }
+              @if (event.channel) {
+                <span class="timeline-channel">· {{ event.channel }}</span>
+              }
+              @if (event.created_at) {
+                <span class="timeline-time">{{ event.created_at }}</span>
+              }
+            </div>
+            @if (event.message) {
+              <p class="timeline-message">{{ event.message }}</p>
+            }
+          </li>
+        }
+      </ul>
+    }
+  </section>
+</div>

--- a/frontend/src/app/pages/outreach/outreach.component.scss
+++ b/frontend/src/app/pages/outreach/outreach.component.scss
@@ -1,0 +1,228 @@
+.page {
+  max-width: 800px;
+}
+
+.hint {
+  color: #6b7280;
+  margin-bottom: 1.5rem;
+}
+
+.card {
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+
+  h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.1em;
+  }
+}
+
+.field {
+  margin-bottom: 1rem;
+
+  label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+  }
+
+  input,
+  textarea,
+  select {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    font-family: inherit;
+    font-size: 0.95em;
+
+    &:focus {
+      outline: none;
+      border-color: #2563eb;
+      box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+    }
+  }
+}
+
+.field-row {
+  display: flex;
+  gap: 1rem;
+
+  .field {
+    flex: 1;
+  }
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.btn-primary {
+  padding: 8px 16px;
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.btn-secondary {
+  padding: 8px 16px;
+  background: #fff;
+  color: #374151;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.muted {
+  color: #6b7280;
+}
+
+.empty {
+  font-style: italic;
+}
+
+.alert {
+  padding: 0.75rem;
+  border-radius: 6px;
+  margin: 0.75rem 0;
+}
+
+.alert-error {
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.alert-warning {
+  background: #fffbeb;
+  color: #92400e;
+}
+
+.nudge-list,
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nudge-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.6rem 0;
+  border-bottom: 1px solid #f3f4f6;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.nudge-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.4rem;
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  font: inherit;
+}
+
+.nudge-company {
+  font-weight: 600;
+  color: #111827;
+}
+
+.nudge-contact {
+  color: #6b7280;
+}
+
+.nudge-age {
+  color: #92400e;
+  font-size: 0.85em;
+}
+
+.timeline-row {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid #f3f4f6;
+
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.timeline-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 0.75em;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+
+.badge-sent {
+  background: #dbeafe;
+  color: #1e40af;
+}
+
+.badge-followed_up {
+  background: #fef3c7;
+  color: #92400e;
+}
+
+.badge-replied {
+  background: #d1fae5;
+  color: #065f46;
+}
+
+.timeline-contact {
+  font-weight: 600;
+  color: #111827;
+}
+
+.timeline-channel {
+  color: #6b7280;
+}
+
+.timeline-time {
+  margin-left: auto;
+  color: #9ca3af;
+  font-size: 0.85em;
+}
+
+.timeline-message {
+  margin: 0.4rem 0 0;
+  white-space: pre-wrap;
+  color: #374151;
+}

--- a/frontend/src/app/pages/outreach/outreach.component.spec.ts
+++ b/frontend/src/app/pages/outreach/outreach.component.spec.ts
@@ -1,0 +1,162 @@
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { OutreachComponent } from './outreach.component';
+import { OutreachService } from '../../core/services/outreach.service';
+import { ApplicationsService } from '../../core/services/applications.service';
+
+function makeApp(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'app-1',
+    title: 'Senior Backend Engineer',
+    company: 'Acme Corp',
+    status: 'tracked',
+    url: null,
+    created_at: null,
+    has_match: false,
+    has_optimization: false,
+    has_prep: false,
+    latest_match_score: null,
+    ...over,
+  };
+}
+
+function makeEvent(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'evt-1',
+    application_id: 'app-1',
+    kind: 'sent',
+    contact_name: null,
+    channel: null,
+    message: 'Hello there',
+    created_at: '2026-06-07T00:00:00Z',
+    ...over,
+  };
+}
+
+function makeNudge(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    application_id: 'app-1',
+    company: 'Acme Corp',
+    contact_name: 'Jordan',
+    sent_at: '2026-06-01T00:00:00Z',
+    days_since: 6,
+    ...over,
+  };
+}
+
+describe('OutreachComponent', () => {
+  function mount(opts: {
+    appId?: string | null;
+    outreach?: Partial<Record<string, unknown>>;
+    applications?: Partial<Record<string, unknown>>;
+  } = {}) {
+    const route = {
+      snapshot: {
+        queryParamMap: {
+          get: (key: string) => (key === 'application_id' ? opts.appId ?? null : null),
+        },
+      },
+    };
+    const outreach = {
+      generate: vi.fn(() => of({ message: 'Generated message' })),
+      record: vi.fn(() => of(makeEvent())),
+      listEvents: vi.fn(() => of([makeEvent()])),
+      dueFollowups: vi.fn(() => of([])),
+      ...opts.outreach,
+    };
+    const applications = {
+      list: vi.fn(() => of([makeApp()])),
+      ...opts.applications,
+    };
+
+    TestBed.configureTestingModule({
+      imports: [OutreachComponent],
+      providers: [
+        { provide: ActivatedRoute, useValue: route },
+        { provide: OutreachService, useValue: outreach },
+        { provide: ApplicationsService, useValue: applications },
+      ],
+    });
+    const fixture = TestBed.createComponent(OutreachComponent);
+    fixture.detectChanges();
+    return { fixture, cmp: fixture.componentInstance, outreach, applications };
+  }
+
+  it('loads applications and preselects from the application_id query param', () => {
+    const { cmp, outreach } = mount({ appId: 'app-1' });
+
+    expect(cmp.applications().length).toBe(1);
+    expect(cmp.selectedApplicationId()).toBe('app-1');
+    expect(outreach.listEvents).toHaveBeenCalledWith('app-1');
+  });
+
+  it('generate happy path fills the message signal', () => {
+    const { cmp, outreach } = mount({ appId: 'app-1' });
+
+    cmp.generate();
+
+    expect(outreach.generate).toHaveBeenCalled();
+    expect(cmp.message()).toBe('Generated message');
+    expect(cmp.composeNotice()).toBe('');
+  });
+
+  it('generate 503 sets the unavailable notice', () => {
+    const generate = vi.fn(() => throwError(() => ({ status: 503 })));
+    const { cmp } = mount({ appId: 'app-1', outreach: { generate } });
+
+    cmp.generate();
+
+    expect(cmp.message()).toBe('');
+    expect(cmp.composeNotice()).toBe(
+      'Message generation is unavailable — check the LLM settings.',
+    );
+  });
+
+  it("record 'sent' triggers a timeline refresh", () => {
+    const record = vi.fn(() => of(makeEvent()));
+    const listEvents = vi.fn(() => of([makeEvent()]));
+    const { cmp, outreach } = mount({ appId: 'app-1', outreach: { record, listEvents } });
+
+    // one listEvents call already happened from preselect on init
+    const callsBefore = outreach.listEvents.mock.calls.length;
+    cmp.message.set('Hi there');
+    cmp.record('sent');
+
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ application_id: 'app-1', kind: 'sent', message: 'Hi there' }),
+    );
+    expect(outreach.listEvents.mock.calls.length).toBe(callsBefore + 1);
+  });
+
+  it('renders the timeline newest-first', () => {
+    const listEvents = vi.fn(() =>
+      of([makeEvent({ id: 'old' }), makeEvent({ id: 'new' })]),
+    );
+    const { cmp } = mount({ appId: 'app-1', outreach: { listEvents } });
+
+    expect(cmp.events().map((e) => e.id)).toEqual(['new', 'old']);
+  });
+
+  it('loads nudges and "mark followed up" removes the row', () => {
+    const dueFollowups = vi.fn(() => of([makeNudge({ application_id: 'app-2' })]));
+    const record = vi.fn(() => of(makeEvent({ application_id: 'app-2' })));
+    const { cmp, outreach } = mount({ outreach: { dueFollowups, record } });
+
+    expect(cmp.nudges().length).toBe(1);
+
+    cmp.markFollowedUp(cmp.nudges()[0]);
+
+    expect(outreach.record).toHaveBeenCalledWith(
+      expect.objectContaining({ application_id: 'app-2', kind: 'followed_up' }),
+    );
+    expect(cmp.nudges().length).toBe(0);
+  });
+
+  it('surfaces a nudges error state', () => {
+    const dueFollowups = vi.fn(() => throwError(() => ({ error: { detail: 'boom' } })));
+    const { cmp } = mount({ outreach: { dueFollowups } });
+
+    expect(cmp.nudgesError()).toBe('boom');
+  });
+});

--- a/frontend/src/app/pages/outreach/outreach.component.ts
+++ b/frontend/src/app/pages/outreach/outreach.component.ts
@@ -1,0 +1,221 @@
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { OutreachService } from '../../core/services/outreach.service';
+import { ApplicationsService } from '../../core/services/applications.service';
+import { ApplicationListItem } from '../applications/models/application-list-item.model';
+import { OutreachEvent } from './models/outreach-event.model';
+import { OutreachEventKind } from './models/outreach-event-kind.model';
+import { OutreachNudge } from './models/outreach-nudge.model';
+
+@Component({
+  selector: 'app-outreach',
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: './outreach.component.html',
+  styleUrl: './outreach.component.scss',
+})
+export class OutreachComponent implements OnInit {
+  private outreach = inject(OutreachService);
+  private applicationsService = inject(ApplicationsService);
+  private route = inject(ActivatedRoute);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // Target picker
+  applications = signal<ApplicationListItem[]>([]);
+  selectedApplicationId = signal('');
+
+  // Compose
+  contactName = signal('');
+  channel = signal('');
+  message = signal('');
+  generating = signal(false);
+  // Inline notice for graceful degradation (503 no LLM, 404 missing app, etc.)
+  composeNotice = signal('');
+  copied = signal(false);
+
+  // Record
+  recording = signal(false);
+  recordError = signal('');
+
+  // Timeline
+  events = signal<OutreachEvent[]>([]);
+  timelineError = signal('');
+  timelineLoading = signal(false);
+
+  // Nudges
+  nudges = signal<OutreachNudge[]>([]);
+  nudgesError = signal('');
+  nudgesLoading = signal(false);
+
+  hasSelection = computed(() => this.selectedApplicationId().trim().length > 0);
+
+  ngOnInit(): void {
+    this.loadApplications();
+    this.loadNudges();
+  }
+
+  private loadApplications(): void {
+    this.applicationsService
+      .list()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (apps) => {
+          this.applications.set(apps);
+          const fromQuery = this.route.snapshot.queryParamMap.get('application_id');
+          if (fromQuery && apps.some((a) => a.id === fromQuery)) {
+            this.selectApplication(fromQuery);
+          }
+        },
+      });
+  }
+
+  selectApplication(id: string): void {
+    this.selectedApplicationId.set(id);
+    this.composeNotice.set('');
+    this.recordError.set('');
+    if (id) {
+      this.loadTimeline();
+    } else {
+      this.events.set([]);
+    }
+  }
+
+  onSelectChange(id: string): void {
+    this.selectApplication(id);
+  }
+
+  generate(): void {
+    const applicationId = this.selectedApplicationId();
+    if (!applicationId) {
+      this.composeNotice.set('Pick an application first.');
+      return;
+    }
+    this.generating.set(true);
+    this.composeNotice.set('');
+    const contact = this.contactName().trim();
+    const channel = this.channel().trim();
+    this.outreach
+      .generate({
+        application_id: applicationId,
+        ...(contact ? { contact_name: contact } : {}),
+        ...(channel ? { channel } : {}),
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          this.message.set(res.message);
+          this.generating.set(false);
+        },
+        error: (err) => {
+          this.generating.set(false);
+          if (err?.status === 503) {
+            this.composeNotice.set('Message generation is unavailable — check the LLM settings.');
+          } else if (err?.status === 404) {
+            this.composeNotice.set('That application could not be found.');
+          } else {
+            this.composeNotice.set(err?.error?.detail ?? 'Could not generate a message.');
+          }
+        },
+      });
+  }
+
+  copyMessage(): void {
+    const text = this.message();
+    if (!text) return;
+    navigator.clipboard?.writeText(text);
+    this.copied.set(true);
+  }
+
+  record(kind: OutreachEventKind): void {
+    const applicationId = this.selectedApplicationId();
+    if (!applicationId) {
+      this.recordError.set('Pick an application first.');
+      return;
+    }
+    this.recording.set(true);
+    this.recordError.set('');
+    const contact = this.contactName().trim();
+    const channel = this.channel().trim();
+    const message = this.message().trim();
+    this.outreach
+      .record({
+        application_id: applicationId,
+        kind,
+        ...(message ? { message } : {}),
+        ...(contact ? { contact_name: contact } : {}),
+        ...(channel ? { channel } : {}),
+      })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.recording.set(false);
+          this.loadTimeline();
+        },
+        error: (err) => {
+          this.recording.set(false);
+          this.recordError.set(err?.error?.detail ?? 'Could not record outreach.');
+        },
+      });
+  }
+
+  private loadTimeline(): void {
+    const applicationId = this.selectedApplicationId();
+    if (!applicationId) return;
+    this.timelineLoading.set(true);
+    this.timelineError.set('');
+    this.outreach
+      .listEvents(applicationId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (events) => {
+          this.events.set([...events].reverse());
+          this.timelineLoading.set(false);
+        },
+        error: (err) => {
+          this.timelineLoading.set(false);
+          this.timelineError.set(err?.error?.detail ?? 'Could not load the timeline.');
+        },
+      });
+  }
+
+  private loadNudges(): void {
+    this.nudgesLoading.set(true);
+    this.nudgesError.set('');
+    this.outreach
+      .dueFollowups()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (nudges) => {
+          this.nudges.set(nudges);
+          this.nudgesLoading.set(false);
+        },
+        error: (err) => {
+          this.nudgesLoading.set(false);
+          this.nudgesError.set(err?.error?.detail ?? 'Could not load follow-up nudges.');
+        },
+      });
+  }
+
+  selectNudge(nudge: OutreachNudge): void {
+    this.selectApplication(nudge.application_id);
+  }
+
+  markFollowedUp(nudge: OutreachNudge): void {
+    this.outreach
+      .record({ application_id: nudge.application_id, kind: 'followed_up' })
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: () => {
+          this.nudges.set(this.nudges().filter((n) => n.application_id !== nudge.application_id));
+          if (nudge.application_id === this.selectedApplicationId()) {
+            this.loadTimeline();
+          }
+        },
+        error: (err) => {
+          this.nudgesError.set(err?.error?.detail ?? 'Could not record the follow-up.');
+        },
+      });
+  }
+}


### PR DESCRIPTION
Delivers the outreach frontend epic (#29) on top of the existing `/outreach` backend. Design doc: `docs/superpowers/specs/2026-06-07-outreach-frontend-design.md`.

- **#30** — `OutreachService` (generate / record / listEvents / dueFollowups) + per-domain models; service spec asserts URL/verb/body.
- **#31** — `/dashboard/outreach` page (lazy route + sidebar nav): application picker (deep-linkable via `?application_id=`), generate an editable on-brand message (copy button, graceful 503/404 notices), record sent/followed_up/replied, per-application timeline newest-first.
- **#32** — "Needs a follow-up" section listing due nudges with one-click "Mark followed up".

All subscriptions use `takeUntilDestroyed`; no hardcoded URLs. Component + service specs included.

### Verification
- Frontend full Vitest → **207 passed (33 files)**; `tsc --noEmit` clean for app + spec projects.

Closes #29
Closes #30
Closes #31
Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)