### PR TITLE
feat(preference): dimension-weight nudging mechanism (Phase 2, #36)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -171,6 +171,15 @@ PREFERENCE_WEIGHT_ACCEPTED=3.0
 PREFERENCE_WEIGHT_REJECTED=1.5
 # Phase 2: enable the LLM-phrased preference drift summary (true/false).
 PREFERENCE_EXPLANATION_ENABLED=true
+# Phase 2 dimension-weight nudging (preference -> matching composite scoring).
+# Minimum outcome-bearing signals before any nudge applies (cold-start gate);
+# below this, all overrides are zero and composite scoring is unchanged.
+PREFERENCE_NUDGE_MIN_OUTCOMES=5
+# Hard absolute clamp on the per-dimension integer weight delta.
+PREFERENCE_NUDGE_CLAMP=3
+# Maps a dimension's [-1, 1] outcome correlation to an integer delta
+# (delta = round(correlation * scale)) before clamping.
+PREFERENCE_NUDGE_SCALE=5.0
 
 # --- Analytics dashboard ---
 ANALYTICS_CACHE_TTL_SECONDS=300

--- a/backend/alembic/versions/020_add_preference_weight_overrides.py
+++ b/backend/alembic/versions/020_add_preference_weight_overrides.py
@@ -1,0 +1,29 @@
+"""add weight_overrides to preference_models (Phase 2 dimension-weight nudging)
+
+Adds a JSONB column holding ``{dimension_name: integer_delta}`` applied on top
+of each scorer's base weight in the matching composite. Nullable with no
+backfill: existing rows read back as NULL and the repository maps that to "no
+overrides", so scoring is unchanged until the nudge gate is met.
+
+Revision ID: 020
+Revises: 019
+Create Date: 2026-06-07
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "020"
+down_revision: Union[str, None] = "019"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE preference_models ADD COLUMN IF NOT EXISTS weight_overrides JSONB"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE preference_models DROP COLUMN IF EXISTS weight_overrides")

--- a/backend/src/hiresense/bootstrap/matching.py
+++ b/backend/src/hiresense/bootstrap/matching.py
@@ -23,7 +23,9 @@ class MatchingBuild:
     orchestrator: MatchingOrchestrator
 
 
-def build_matching(infra: SharedInfra, tracked: Callable[[str], Any]) -> MatchingBuild:
+def build_matching(
+    infra: SharedInfra, tracked: Callable[[str], Any], preference: Any | None = None
+) -> MatchingBuild:
     s = infra.settings
     dimension_scorers = [
         SeniorityScorer(llm=tracked("seniority_scorer"), weight=s.weight_seniority),
@@ -43,6 +45,7 @@ def build_matching(infra: SharedInfra, tracked: Callable[[str], Any]) -> Matchin
         event_bus=infra.event_bus,
         dimension_scorers=dimension_scorers,
         embedding=infra.embedding,
+        preference=preference,
     )
     batch_evaluation_service = BatchEvaluationService(
         orchestrator=matching_orchestrator,

--- a/backend/src/hiresense/bootstrap/preference.py
+++ b/backend/src/hiresense/bootstrap/preference.py
@@ -13,6 +13,7 @@ from hiresense.preference.domain import (
     FeedbackKind,
     PreferenceService,
     TasteVectorCalculator,
+    WeightNudgeCalculator,
     status_to_feedback_kind,
 )
 from hiresense.preference.infrastructure import PreferenceRepository
@@ -35,12 +36,29 @@ def build_preference(infra: SharedInfra, tracked: Callable[[str], Any]) -> Prefe
         tau_days=s.preference_decay_tau_days,
     )
     weights = {kind: float(getattr(s, kind.weight_key)) for kind in FeedbackKind}
+    nudge_calculator = WeightNudgeCalculator(
+        min_outcomes=s.preference_nudge_min_outcomes,
+        clamp=s.preference_nudge_clamp,
+        scale=s.preference_nudge_scale,
+    )
+    # Base composite weights keyed by the scorers' dimension_name, so /weights
+    # can report base + override + effective consistently with matching.
+    base_weights = {
+        "seniority_fit": s.weight_seniority,
+        "compensation": s.weight_compensation,
+        "growth_potential": s.weight_growth,
+        "culture_fit": s.weight_culture,
+        "application_strength": s.weight_application,
+        "interview_readiness": s.weight_interview,
+    }
     service = PreferenceService(
         repository=PreferenceRepository(session_factory=infra.sync_session_factory),
         vector_store=infra.vector_store,
         calculator=calculator,
         weights=weights,
         enabled=s.preference_enabled,
+        nudge_calculator=nudge_calculator,
+        base_weights=base_weights,
         llm=tracked("preference_explanation") if s.preference_explanation_enabled else None,
         explanation_enabled=s.preference_explanation_enabled,
     )

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -253,6 +253,15 @@ class Settings(BaseSettings):
     # Phase 2: layer an LLM-phrased natural-language drift summary over the
     # deterministic explanation. Falls back to summary=None on any LLM failure.
     preference_explanation_enabled: bool = True
+    # Phase 2 dimension-weight nudging (preference -> matching composite).
+    # Gate: minimum number of outcome-bearing signals before any nudge applies.
+    # Below this, all overrides are zero and scoring is identical to today.
+    preference_nudge_min_outcomes: int = 5
+    # Hard clamp on the per-dimension integer weight delta (absolute bound).
+    preference_nudge_clamp: int = 3
+    # Scale factor mapping a dimension's [-1, 1] outcome correlation to an
+    # integer delta before clamping (delta = round(correlation * scale)).
+    preference_nudge_scale: float = 5.0
 
     # --- Analytics dashboard (read-only corpus/funnel aggregation) ---
     # TTL (seconds) for the heavy on-read results (salary distribution, target band).

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -110,7 +110,7 @@ def create_app() -> FastAPI:
     app.include_router(profile_router)
 
     # --- Matching ---
-    matching = build_matching(infra, tracked)
+    matching = build_matching(infra, tracked, preference=preference.service)
     app.state.matching = matching.provider
     app.include_router(matching_router)
 

--- a/backend/src/hiresense/matching/domain/services.py
+++ b/backend/src/hiresense/matching/domain/services.py
@@ -42,11 +42,16 @@ class MatchingOrchestrator:
         event_bus: Any,
         dimension_scorers: list[Any] | None = None,
         embedding: Any | None = None,
+        preference: Any | None = None,
     ) -> None:
         self._llm = llm
         self._event_bus = event_bus
         self._dimension_scorers = dimension_scorers or []
         self._embedding = embedding
+        # Optional, duck-typed preference port: exposes weight_overrides() ->
+        # {dimension: int delta}. None (or no overrides) => composite is computed
+        # exactly as before, so scoring/ranking are byte-identical to today.
+        self._preference = preference
         self._semantic_scorer = SemanticScorer()
         self._skill_matcher = SkillMatcher()
 
@@ -66,8 +71,14 @@ class MatchingOrchestrator:
 
                 results = await asyncio.gather(*[safe_score(s) for s in scorers])
                 dimensions = list(results)
-                total_weight = sum(d.weight for d in dimensions)
-                composite = sum(d.score * d.weight for d in dimensions) / total_weight if total_weight > 0 else 0.5
+                overrides = self._weight_overrides()
+                effective = {d.dimension: self._effective_weight(d, overrides) for d in dimensions}
+                total_weight = sum(effective.values())
+                composite = (
+                    sum(d.score * effective[d.dimension] for d in dimensions) / total_weight
+                    if total_weight > 0
+                    else 0.5
+                )
 
                 result = EvaluationResult(composite_score=round(composite, 4), job_title=title, company=company, dimensions=dimensions)
                 _metrics.matches_completed_total.add(1)
@@ -78,6 +89,28 @@ class MatchingOrchestrator:
             except Exception:
                 span.set_status(trace.Status(trace.StatusCode.ERROR))
                 raise
+
+    def _weight_overrides(self) -> dict[str, int]:
+        # Read learned per-dimension weight deltas from the optional preference
+        # port. Any failure (or no port) yields no overrides, so the composite
+        # falls back to base weights and stays identical to today's behavior.
+        if self._preference is None:
+            return {}
+        try:
+            return self._preference.weight_overrides() or {}
+        except Exception:
+            logger.exception("matching: weight_overrides lookup failed — using base weights")
+            return {}
+
+    @staticmethod
+    def _effective_weight(dimension: DimensionResult, overrides: dict[str, int]) -> int:
+        # clamp(base + delta) with a floor of 0: a learned nudge can lower a
+        # dimension to zero influence but never make it negative. With no delta
+        # for this dimension the base weight is returned unchanged.
+        delta = overrides.get(dimension.dimension, 0)
+        if delta == 0:
+            return dimension.weight
+        return max(0, dimension.weight + delta)
 
     async def analyze(
         self,

--- a/backend/src/hiresense/preference/api/routes.py
+++ b/backend/src/hiresense/preference/api/routes.py
@@ -4,7 +4,11 @@ from fastapi import APIRouter, Depends, Response
 
 from hiresense.identity.api.dependencies import require_auth
 from hiresense.preference.api.dependencies import get_preference_service
-from hiresense.preference.api.schemas import FeedbackRequest, FeedbackSignalResponse
+from hiresense.preference.api.schemas import (
+    DimensionWeightResponse,
+    FeedbackRequest,
+    FeedbackSignalResponse,
+)
 from hiresense.preference.domain import PreferenceService
 from hiresense.preference.domain.explanation import PreferenceExplanation
 
@@ -32,6 +36,13 @@ async def explain(
     service: PreferenceService = Depends(get_preference_service),
 ) -> PreferenceExplanation:
     return await service.explain()
+
+
+@router.get("/weights", response_model=list[DimensionWeightResponse])
+def weights(
+    service: PreferenceService = Depends(get_preference_service),
+) -> list[DimensionWeightResponse]:
+    return [DimensionWeightResponse.model_validate(w) for w in service.weights_view()]
 
 
 @router.post("/reset", status_code=204)

--- a/backend/src/hiresense/preference/api/schemas.py
+++ b/backend/src/hiresense/preference/api/schemas.py
@@ -22,3 +22,10 @@ class FeedbackSignalResponse(BaseModel):
     created_at: datetime | None = None
 
     model_config = {"from_attributes": True}
+
+
+class DimensionWeightResponse(BaseModel):
+    dimension: str
+    base_weight: int
+    override: int
+    effective_weight: int

--- a/backend/src/hiresense/preference/domain/__init__.py
+++ b/backend/src/hiresense/preference/domain/__init__.py
@@ -3,20 +3,24 @@ from hiresense.preference.domain.feedback_kind import FeedbackKind
 from hiresense.preference.domain.feedback_signal import FeedbackSignal
 from hiresense.preference.domain.feedback_source import FeedbackSource
 from hiresense.preference.domain.implicit_signal_mapping import status_to_feedback_kind
+from hiresense.preference.domain.outcome_observation import OutcomeObservation
 from hiresense.preference.domain.preference_model import PreferenceModel
 from hiresense.preference.domain.services import PreferenceService
 from hiresense.preference.domain.signal_contribution import SignalContribution
 from hiresense.preference.domain.taste_calculator import TasteVectorCalculator
+from hiresense.preference.domain.weight_nudge_calculator import WeightNudgeCalculator
 
 __all__ = [
     "build_explanation",
     "FeedbackKind",
     "FeedbackSignal",
     "FeedbackSource",
+    "OutcomeObservation",
     "PreferenceExplanation",
     "PreferenceModel",
     "PreferenceService",
     "SignalContribution",
     "status_to_feedback_kind",
     "TasteVectorCalculator",
+    "WeightNudgeCalculator",
 ]

--- a/backend/src/hiresense/preference/domain/explanation.py
+++ b/backend/src/hiresense/preference/domain/explanation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from collections import Counter
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from hiresense.preference.domain.feedback_signal import FeedbackSignal
 
@@ -15,11 +15,16 @@ class PreferenceExplanation(BaseModel):
     negative_count: int
     counts_by_kind: dict[str, int]
     drift_magnitude: float
+    # Phase 2: learned per-dimension weight deltas applied to matching scoring.
+    weight_overrides: dict[str, int] = Field(default_factory=dict)
     summary: str | None = None
 
 
 def build_explanation(
-    signals: list[FeedbackSignal], *, delta_vector: list[float] | None
+    signals: list[FeedbackSignal],
+    *,
+    delta_vector: list[float] | None,
+    weight_overrides: dict[str, int] | None = None,
 ) -> PreferenceExplanation:
     counts = Counter(s.kind.value for s in signals)
     positive = sum(1 for s in signals if s.kind.polarity > 0)
@@ -34,4 +39,5 @@ def build_explanation(
         negative_count=negative,
         counts_by_kind=dict(counts),
         drift_magnitude=magnitude,
+        weight_overrides=dict(weight_overrides or {}),
     )

--- a/backend/src/hiresense/preference/domain/outcome_observation.py
+++ b/backend/src/hiresense/preference/domain/outcome_observation.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class OutcomeObservation:
+    """One outcome-bearing signal's view of a single dimension.
+
+    ``dimension_score`` is that dimension scorer's [0, 1] score for the job the
+    signal was about; ``polarity`` is the signal's outcome polarity (+1 for a
+    positive outcome such as an offer, -1 for a negative one such as a
+    rejection). The :class:`WeightNudgeCalculator` correlates the two across all
+    observations for a dimension to decide whether to nudge that dimension's
+    weight.
+    """
+
+    dimension: str
+    dimension_score: float
+    polarity: int

--- a/backend/src/hiresense/preference/domain/preference_model.py
+++ b/backend/src/hiresense/preference/domain/preference_model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class PreferenceModel(BaseModel):
@@ -15,6 +15,10 @@ class PreferenceModel(BaseModel):
     """
 
     delta_vector: list[float]
+    # Phase 2: per-dimension integer weight deltas applied on top of each
+    # scorer's base weight in the matching composite. Empty == no nudging
+    # (cold-start / gate unmet), which reproduces today's scoring exactly.
+    weight_overrides: dict[str, int] = Field(default_factory=dict)
     version: int = 1
     updated_at: datetime | None = None
 

--- a/backend/src/hiresense/preference/domain/services.py
+++ b/backend/src/hiresense/preference/domain/services.py
@@ -10,8 +10,10 @@ from hiresense.preference.domain.feedback_kind import FeedbackKind
 from hiresense.preference.domain.feedback_signal import FeedbackSignal
 from hiresense.preference.domain.feedback_source import FeedbackSource
 from hiresense.preference.domain.preference_model import PreferenceModel
+from hiresense.preference.domain.outcome_observation import OutcomeObservation
 from hiresense.preference.domain.signal_contribution import SignalContribution
 from hiresense.preference.domain.taste_calculator import TasteVectorCalculator
+from hiresense.preference.domain.weight_nudge_calculator import WeightNudgeCalculator
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +27,8 @@ class PreferenceService:
         calculator: TasteVectorCalculator,
         weights: dict[FeedbackKind, float],
         enabled: bool,
+        nudge_calculator: WeightNudgeCalculator | None = None,
+        base_weights: dict[str, int] | None = None,
         llm: Any | None = None,
         explanation_enabled: bool = False,
     ) -> None:
@@ -33,15 +37,28 @@ class PreferenceService:
         self._calc = calculator
         self._weights = weights
         self._enabled = enabled
+        self._nudge_calc = nudge_calculator
+        self._base_weights = dict(base_weights or {})
         self._llm = llm
         self._explanation_enabled = explanation_enabled
         self._job_lookup: Any | None = None
+        self._dimension_lookup: Any | None = None
 
     def attach_job_lookup(self, job_lookup: Any) -> None:
         """Late-bind the job-title lookup used by the LLM explanation summary.
         Two-phase wiring: the ingestion orchestrator is built after the
         preference service, so it is attached once available."""
         self._job_lookup = job_lookup
+
+    def attach_dimension_lookup(self, dimension_lookup: Any) -> None:
+        """Late-bind the per-job dimension-score lookup used to nudge weights.
+
+        Two-phase wiring (mirrors ``attach_job_lookup``): the matching layer is
+        built after the preference service, so the lookup — ``get_dimension_scores(job_id)
+        -> dict[str, float] | None`` over cached match scoring — is attached
+        once available. When absent (or it returns nothing), no observations are
+        produced and ``weight_overrides`` stays empty, so matching is unchanged."""
+        self._dimension_lookup = dimension_lookup
 
     async def _record(
         self, job_id: uuid_mod.UUID, kind: FeedbackKind, source: FeedbackSource
@@ -89,14 +106,54 @@ class PreferenceService:
             return baseline
         return self._calc.blend(baseline, model.delta_vector)
 
+    def weight_overrides(self) -> dict[str, int]:
+        """Per-dimension integer weight deltas for the matching composite.
+
+        Empty when disabled, when no model exists, or when the nudge gate is
+        unmet — making matching byte-identical to today in all those cases."""
+        if not self._enabled:
+            return {}
+        model = self._repo.get_model()
+        if model is None:
+            return {}
+        return dict(model.weight_overrides)
+
+    def weights_view(self) -> list[dict[str, Any]]:
+        """Base + override + effective integer weight per known dimension.
+
+        ``effective = max(0, base + override)`` mirrors the matching composite.
+        Dimensions appearing only in overrides (no configured base) are reported
+        with a base of 0 so the view never silently drops a learned nudge."""
+        overrides = self.weight_overrides()
+        names = list(self._base_weights.keys())
+        for name in overrides:
+            if name not in self._base_weights:
+                names.append(name)
+        view: list[dict[str, Any]] = []
+        for name in names:
+            base = int(self._base_weights.get(name, 0))
+            delta = int(overrides.get(name, 0))
+            view.append(
+                {
+                    "dimension": name,
+                    "base_weight": base,
+                    "override": delta,
+                    "effective_weight": max(0, base + delta),
+                }
+            )
+        return view
+
     def list_signals(self) -> list[FeedbackSignal]:
         return self._repo.list_signals()
 
     async def explain(self) -> PreferenceExplanation:
         model = self._repo.get_model()
         delta = model.delta_vector if model is not None else None
+        overrides = dict(model.weight_overrides) if model is not None else {}
         signals = self._repo.list_signals()
-        explanation = build_explanation(signals, delta_vector=delta)
+        explanation = build_explanation(
+            signals, delta_vector=delta, weight_overrides=overrides
+        )
         if self._explanation_enabled and self._llm is not None:
             summary = await self._build_summary(signals, explanation)
             if summary:
@@ -150,8 +207,17 @@ class PreferenceService:
         self._repo.clear()
 
     def _recompute(self) -> None:
-        signals = [s for s in self._repo.list_signals() if s.job_embedding]
+        all_signals = self._repo.list_signals()
+        signals = [s for s in all_signals if s.job_embedding]
+        overrides = self._compute_overrides(all_signals)
         if not signals:
+            # No embedding-bearing signals -> no taste delta. Still persist the
+            # overrides if any exist (an outcome signal whose job is unindexed
+            # contributes to nudging via its dimension scores, not its vector).
+            if overrides:
+                self._repo.save_model(
+                    PreferenceModel(delta_vector=[], weight_overrides=overrides)
+                )
             return
         # Dimension is taken from the first signal's embedding. If the embedding
         # model's width ever changes mid-corpus, compute_delta skips off-width
@@ -161,7 +227,37 @@ class PreferenceService:
         now = datetime.now(timezone.utc)
         contributions = [self._to_contribution(s, now) for s in signals]
         delta = self._calc.compute_delta(contributions, dim=dim)
-        self._repo.save_model(PreferenceModel(delta_vector=delta))
+        self._repo.save_model(
+            PreferenceModel(delta_vector=delta, weight_overrides=overrides)
+        )
+
+    def _compute_overrides(self, signals: list[FeedbackSignal]) -> dict[str, int]:
+        # Nudging needs both a calculator and a way to recover per-job dimension
+        # scores. Absent either, return no overrides -> matching unchanged.
+        if self._nudge_calc is None or self._dimension_lookup is None:
+            return {}
+        observations: list[OutcomeObservation] = []
+        for signal in signals:
+            scores = self._dimension_scores_for(signal.job_id)
+            if not scores:
+                continue
+            polarity = signal.kind.polarity
+            for dimension, score in scores.items():
+                observations.append(
+                    OutcomeObservation(
+                        dimension=dimension,
+                        dimension_score=float(score),
+                        polarity=polarity,
+                    )
+                )
+        return self._nudge_calc.compute_overrides(observations)
+
+    def _dimension_scores_for(self, job_id: uuid_mod.UUID) -> dict[str, float] | None:
+        try:
+            return self._dimension_lookup.get_dimension_scores(str(job_id))
+        except Exception:
+            logger.exception("preference: dimension-score lookup failed for %s", job_id)
+            return None
 
     def _to_contribution(self, signal: FeedbackSignal, now: datetime) -> SignalContribution:
         created = signal.created_at or now

--- a/backend/src/hiresense/preference/domain/weight_nudge_calculator.py
+++ b/backend/src/hiresense/preference/domain/weight_nudge_calculator.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from collections import defaultdict
+
+from hiresense.preference.domain.outcome_observation import OutcomeObservation
+
+
+class WeightNudgeCalculator:
+    """Pure, deterministic dimension-weight nudging (Phase 2 secondary loop).
+
+    Per dimension, it correlates the dimension scorer's score against the
+    outcome polarity across accumulated outcome-bearing signals and turns that
+    correlation into a small **clamped integer** weight delta. The intent: if a
+    dimension consistently scored *high* on jobs that led to positive outcomes
+    (and low on negative ones), nudge that dimension's weight up; the reverse
+    nudges it down.
+
+    Two safety properties, both config-driven (no literals):
+
+    - **Cold-start gate** — returns an empty override map until at least
+      ``min_outcomes`` outcome observations exist, so a couple of clicks can
+      never move scoring. Below the gate, callers see no overrides and matching
+      is byte-identical to today.
+    - **Hard clamp** — every delta is clamped to ``[-clamp, +clamp]`` so the
+      mechanism can only ever bend weights, never dominate them.
+
+    The correlation uses a sign-aligned mean: each dimension's score is centered
+    at 0.5 (the neutral score) and multiplied by the signal polarity, then
+    averaged. A positive mean means the dimension's score tracked positive
+    outcomes; a negative mean means it tracked negative ones. The mean lies in
+    [-0.5, 0.5]; ``scale`` maps it onto the integer delta range before clamping.
+    """
+
+    def __init__(self, *, min_outcomes: int, clamp: int, scale: float) -> None:
+        self._min_outcomes = min_outcomes
+        self._clamp = abs(clamp)
+        self._scale = scale
+
+    def compute_overrides(
+        self, observations: list[OutcomeObservation]
+    ) -> dict[str, int]:
+        # Cold-start gate: count distinct outcome signals. Observations are
+        # per-(signal, dimension); a single signal contributes one observation
+        # per dimension, so gate on the max per-dimension observation count
+        # (== number of outcome signals when every signal scores every dim).
+        if not observations:
+            return {}
+        by_dim: dict[str, list[OutcomeObservation]] = defaultdict(list)
+        for obs in observations:
+            by_dim[obs.dimension].append(obs)
+        outcome_count = max(len(v) for v in by_dim.values())
+        if outcome_count < self._min_outcomes:
+            return {}
+
+        overrides: dict[str, int] = {}
+        for dimension, obs_list in by_dim.items():
+            # Center each score at the neutral 0.5 and align with polarity, then
+            # average. Positive => dimension high-scored positive outcomes.
+            correlation = sum((o.dimension_score - 0.5) * o.polarity for o in obs_list) / len(
+                obs_list
+            )
+            delta = round(correlation * self._scale)
+            delta = max(-self._clamp, min(self._clamp, delta))
+            if delta != 0:
+                overrides[dimension] = delta
+        return overrides

--- a/backend/src/hiresense/preference/infrastructure/orm.py
+++ b/backend/src/hiresense/preference/infrastructure/orm.py
@@ -34,6 +34,9 @@ class PreferenceModelOrm(Base):
     # Singleton: one row, fixed id. (Multi-profile is a future extension.)
     id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
     delta_vector: Mapped[list] = mapped_column(JSON)
+    # Phase 2: dimension name -> integer weight delta for the matching composite.
+    # Defaults to {} so pre-Phase-2 rows (NULL) read back as "no overrides".
+    weight_overrides: Mapped[dict | None] = mapped_column(JSON, nullable=True, default=dict)
     version: Mapped[int] = mapped_column(Integer, default=1)
     updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/src/hiresense/preference/infrastructure/repository.py
+++ b/backend/src/hiresense/preference/infrastructure/repository.py
@@ -35,7 +35,7 @@ class PreferenceRepository:
     def get_model(self) -> PreferenceModel | None:
         with self._session_factory() as session:
             row = session.get(PreferenceModelOrm, _MODEL_ID)
-            return PreferenceModel.model_validate(row) if row is not None else None
+            return self._to_domain(row) if row is not None else None
 
     def save_model(self, model: PreferenceModel) -> PreferenceModel:
         with self._session_factory() as session:
@@ -44,15 +44,27 @@ class PreferenceRepository:
                 row = PreferenceModelOrm(
                     id=_MODEL_ID,
                     delta_vector=model.delta_vector,
+                    weight_overrides=dict(model.weight_overrides),
                     version=model.version,
                 )
                 session.add(row)
             else:
                 row.delta_vector = model.delta_vector
+                row.weight_overrides = dict(model.weight_overrides)
                 row.version = model.version
             session.commit()
             session.refresh(row)
-            return PreferenceModel.model_validate(row)
+            return self._to_domain(row)
+
+    @staticmethod
+    def _to_domain(row: PreferenceModelOrm) -> PreferenceModel:
+        # A pre-Phase-2 row (or any NULL column) reads back as no overrides.
+        return PreferenceModel(
+            delta_vector=row.delta_vector,
+            weight_overrides=row.weight_overrides or {},
+            version=row.version,
+            updated_at=row.updated_at,
+        )
 
     def clear(self) -> None:
         with self._session_factory() as session:

--- a/backend/tests/integration/test_preference_weight_nudge_flow.py
+++ b/backend/tests/integration/test_preference_weight_nudge_flow.py
@@ -1,0 +1,182 @@
+"""Integration: Phase 2 dimension-weight nudging end to end.
+
+Builds a real FastAPI app over an in-memory SQLite DB (no Postgres), wires the
+preference service exactly as bootstrap does (nudge calculator + a fake
+dimension-score lookup standing in for cached match scoring), and verifies:
+
+- below the gate, /preference/weights shows zero overrides and a matching
+  composite equals the base-weight composite (backward compatible);
+- once enough outcome signals exist, an override appears on /weights and the
+  same MatchingOrchestrator (sharing the preference port) produces a shifted
+  composite;
+- POST /preference/reset clears both the taste delta and the weight overrides.
+"""
+from __future__ import annotations
+
+import uuid as uuid_mod
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from hiresense.identity.api.dependencies import require_auth
+from hiresense.infrastructure.database import Base
+from hiresense.matching.domain.scorers.base import DimensionResult
+from hiresense.matching.domain.services import MatchingOrchestrator
+from hiresense.preference.api import router as preference_router
+from hiresense.preference.api.dependencies import get_preference_service
+from hiresense.preference.domain import (
+    FeedbackKind,
+    PreferenceService,
+    TasteVectorCalculator,
+    WeightNudgeCalculator,
+)
+from hiresense.preference.infrastructure import PreferenceRepository
+from hiresense.preference.infrastructure.orm import (  # noqa: F401  registers tables
+    FeedbackSignalOrm,
+    PreferenceModelOrm,
+)
+
+_BASE_COMP_WEIGHT = 10
+_BASE_CULTURE_WEIGHT = 10
+
+
+class _FakeVectorStore:
+    async def get_vector(self, id: str) -> list[float] | None:  # noqa: ARG002
+        return None  # no embedding needed for the weight-nudge path
+
+
+class _FakeDimLookup:
+    """compensation always scored 1.0 on the outcome jobs -> positive nudge."""
+
+    def get_dimension_scores(self, job_id: str):  # noqa: ARG002
+        return {"compensation": 1.0, "culture_fit": 0.5}
+
+
+class _FakeScorer:
+    def __init__(self, dimension, score, weight):
+        self._dimension, self._score, self._weight = dimension, score, weight
+
+    @property
+    def dimension_name(self):
+        return self._dimension
+
+    @property
+    def weight(self):
+        return self._weight
+
+    async def score(self, job, profile=None):  # noqa: ARG002
+        return DimensionResult(
+            dimension=self._dimension, score=self._score, rationale="", weight=self._weight
+        )
+
+
+class _FakeEventBus:
+    async def publish(self, event):  # noqa: ARG002
+        pass
+
+
+def _build_service(session_factory) -> PreferenceService:
+    return PreferenceService(
+        repository=PreferenceRepository(session_factory=session_factory),
+        vector_store=_FakeVectorStore(),
+        calculator=TasteVectorCalculator(alpha=1.0, beta=1.0, gamma=1.0, tau_days=90.0),
+        weights={k: 1.0 for k in FeedbackKind},
+        enabled=True,
+        nudge_calculator=WeightNudgeCalculator(min_outcomes=3, clamp=3, scale=10.0),
+        base_weights={
+            "compensation": _BASE_COMP_WEIGHT,
+            "culture_fit": _BASE_CULTURE_WEIGHT,
+        },
+    )
+
+
+def _build_app(service: PreferenceService) -> FastAPI:
+    app = FastAPI()
+    app.dependency_overrides[require_auth] = lambda: "test-user"
+    app.dependency_overrides[get_preference_service] = lambda: service
+    app.include_router(preference_router)
+    return app
+
+
+async def _composite(orchestrator: MatchingOrchestrator) -> float:
+    scorers = [
+        _FakeScorer("compensation", 1.0, _BASE_COMP_WEIGHT),
+        _FakeScorer("culture_fit", 0.0, _BASE_CULTURE_WEIGHT),
+    ]
+    result = await orchestrator.evaluate(
+        job={"title": "SWE", "company": "Acme", "description": ""},
+        dimension_scorers=scorers,
+    )
+    return result.composite_score
+
+
+@pytest.mark.asyncio
+async def test_weight_nudge_flow() -> None:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+
+    service = _build_service(session_factory)
+    service.attach_dimension_lookup(_FakeDimLookup())
+
+    # A matching orchestrator sharing the same preference port (as in the app).
+    orchestrator = MatchingOrchestrator(
+        llm=None, event_bus=_FakeEventBus(), preference=service
+    )
+
+    app = _build_app(service)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # --- Below the gate: no overrides, composite == base-weight composite ---
+        r = await client.get("/preference/weights")
+        assert r.status_code == 200, r.text
+        rows = {row["dimension"]: row for row in r.json()}
+        assert rows["compensation"]["override"] == 0
+        assert rows["compensation"]["effective_weight"] == _BASE_COMP_WEIGHT
+
+        base_composite = await _composite(orchestrator)
+        # 1.0*10 + 0.0*10 = 10 / 20 = 0.5
+        assert abs(base_composite - 0.5) < 1e-9
+
+        # --- Cross the gate with 3 implicit OFFERED outcomes ---
+        for _ in range(3):
+            await service.record_implicit_signal(uuid_mod.uuid4(), FeedbackKind.OFFERED)
+
+        r = await client.get("/preference/weights")
+        rows = {row["dimension"]: row for row in r.json()}
+        assert rows["compensation"]["override"] > 0
+        boosted_weight = rows["compensation"]["effective_weight"]
+        assert boosted_weight > _BASE_COMP_WEIGHT
+
+        # The composite now weights compensation more heavily -> rises above 0.5.
+        nudged_composite = await _composite(orchestrator)
+        expected = (1.0 * boosted_weight + 0.0 * _BASE_CULTURE_WEIGHT) / (
+            boosted_weight + _BASE_CULTURE_WEIGHT
+        )
+        # Composite is rounded to 4 dp by the orchestrator.
+        assert abs(nudged_composite - expected) < 1e-4
+        assert nudged_composite > base_composite
+
+        # --- Reset clears overrides; composite returns to baseline ---
+        r = await client.post("/preference/reset")
+        assert r.status_code == 204, r.text
+
+        r = await client.get("/preference/weights")
+        rows = {row["dimension"]: row for row in r.json()}
+        assert rows["compensation"]["override"] == 0
+
+        assert abs(await _composite(orchestrator) - 0.5) < 1e-9
+
+        # Explain no longer reports overrides either.
+        r = await client.get("/preference/explain")
+        assert r.status_code == 200, r.text
+        assert r.json()["weight_overrides"] == {}
+
+    Base.metadata.drop_all(engine)

--- a/backend/tests/unit/matching/test_evaluate_weight_overrides.py
+++ b/backend/tests/unit/matching/test_evaluate_weight_overrides.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import pytest
+
+from hiresense.matching.domain.scorers.base import DimensionResult
+from hiresense.matching.domain.services import MatchingOrchestrator
+
+
+class FakeScorer:
+    def __init__(self, dimension, score, weight):
+        self._dimension = dimension
+        self._score = score
+        self._weight = weight
+
+    @property
+    def dimension_name(self):
+        return self._dimension
+
+    @property
+    def weight(self):
+        return self._weight
+
+    async def score(self, job, profile=None):
+        return DimensionResult(
+            dimension=self._dimension,
+            score=self._score,
+            rationale="",
+            weight=self._weight,
+        )
+
+
+class FakeEventBus:
+    async def publish(self, event):
+        pass
+
+
+class FakePreference:
+    def __init__(self, overrides):
+        self._overrides = overrides
+
+    def weight_overrides(self):
+        return self._overrides
+
+
+_JOB = {"title": "SWE", "company": "Acme", "description": ""}
+
+
+@pytest.mark.asyncio
+async def test_no_preference_port_is_unchanged():
+    scorers = [FakeScorer("a", 0.8, 60), FakeScorer("b", 0.4, 40)]
+    o = MatchingOrchestrator(llm=None, event_bus=FakeEventBus())
+    result = await o.evaluate(job=_JOB, dimension_scorers=scorers)
+    # 0.8*60 + 0.4*40 = 64 / 100 = 0.64
+    assert abs(result.composite_score - 0.64) < 1e-9
+
+
+@pytest.mark.asyncio
+async def test_empty_overrides_is_byte_identical():
+    scorers = [FakeScorer("a", 0.8, 60), FakeScorer("b", 0.4, 40)]
+    baseline = await MatchingOrchestrator(llm=None, event_bus=FakeEventBus()).evaluate(
+        job=_JOB, dimension_scorers=scorers
+    )
+    with_pref = await MatchingOrchestrator(
+        llm=None, event_bus=FakeEventBus(), preference=FakePreference({})
+    ).evaluate(job=_JOB, dimension_scorers=scorers)
+    assert with_pref.composite_score == baseline.composite_score
+
+
+@pytest.mark.asyncio
+async def test_override_shifts_composite():
+    # Boost the high-scoring dimension's weight; composite should rise.
+    scorers = [FakeScorer("a", 0.8, 60), FakeScorer("b", 0.4, 40)]
+    o = MatchingOrchestrator(
+        llm=None, event_bus=FakeEventBus(), preference=FakePreference({"a": 20})
+    )
+    result = await o.evaluate(job=_JOB, dimension_scorers=scorers)
+    # 0.8*80 + 0.4*40 = 80 / 120 = 0.6667 (composite is rounded to 4 dp)
+    assert abs(result.composite_score - (80.0 / 120.0)) < 1e-4
+    assert result.composite_score > 0.64
+
+
+@pytest.mark.asyncio
+async def test_negative_override_lowers_composite():
+    scorers = [FakeScorer("a", 0.8, 60), FakeScorer("b", 0.4, 40)]
+    o = MatchingOrchestrator(
+        llm=None, event_bus=FakeEventBus(), preference=FakePreference({"a": -30})
+    )
+    result = await o.evaluate(job=_JOB, dimension_scorers=scorers)
+    # 0.8*30 + 0.4*40 = 40 / 70 = 0.5714 (composite is rounded to 4 dp)
+    assert abs(result.composite_score - (40.0 / 70.0)) < 1e-4
+    assert result.composite_score < 0.64
+
+
+@pytest.mark.asyncio
+async def test_override_floors_effective_weight_at_zero():
+    scorers = [FakeScorer("a", 0.8, 10), FakeScorer("b", 0.4, 40)]
+    # delta -30 would make 'a' negative; floored to 0 so it drops out entirely.
+    o = MatchingOrchestrator(
+        llm=None, event_bus=FakeEventBus(), preference=FakePreference({"a": -30})
+    )
+    result = await o.evaluate(job=_JOB, dimension_scorers=scorers)
+    # only 'b' contributes: 0.4*40 / 40 = 0.4
+    assert abs(result.composite_score - 0.4) < 1e-9
+
+
+@pytest.mark.asyncio
+async def test_preference_lookup_failure_falls_back_to_base():
+    class Boom:
+        def weight_overrides(self):
+            raise RuntimeError("boom")
+
+    scorers = [FakeScorer("a", 0.8, 60), FakeScorer("b", 0.4, 40)]
+    o = MatchingOrchestrator(llm=None, event_bus=FakeEventBus(), preference=Boom())
+    result = await o.evaluate(job=_JOB, dimension_scorers=scorers)
+    assert abs(result.composite_score - 0.64) < 1e-9

--- a/backend/tests/unit/preference/test_preference_service.py
+++ b/backend/tests/unit/preference/test_preference_service.py
@@ -10,6 +10,7 @@ from hiresense.preference.domain import (
     PreferenceModel,
     PreferenceService,
     TasteVectorCalculator,
+    WeightNudgeCalculator,
 )
 
 
@@ -206,6 +207,112 @@ async def test_explain_layers_llm_summary() -> None:
     assert exp.summary == "You prefer backend roles."
     assert len(llm.calls) == 1
     assert exp.total_signals == 1
+
+
+class _FakeDimLookup:
+    """Returns fixed dimension scores for any job id."""
+
+    def __init__(self, scores: dict[str, float]) -> None:
+        self._scores = scores
+
+    def get_dimension_scores(self, job_id: str):  # noqa: ARG002
+        return dict(self._scores)
+
+
+def _service_with_nudge(
+    repo, vectors, *, min_outcomes=3, clamp=3, scale=10.0, base_weights=None
+) -> PreferenceService:
+    calc = TasteVectorCalculator(alpha=1.0, beta=1.0, gamma=1.0, tau_days=90.0)
+    nudge = WeightNudgeCalculator(min_outcomes=min_outcomes, clamp=clamp, scale=scale)
+    return PreferenceService(
+        repository=repo,
+        vector_store=FakeVectorStore(vectors),
+        calculator=calc,
+        weights={k: 1.0 for k in FeedbackKind},
+        enabled=True,
+        nudge_calculator=nudge,
+        base_weights=base_weights or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_weight_overrides_empty_without_dimension_lookup() -> None:
+    repo = FakeRepo()
+    jid = uuid.uuid4()
+    svc = _service_with_nudge(repo, {str(jid): [0.0, 1.0]}, min_outcomes=1)
+    # No dimension lookup attached -> no observations -> no overrides.
+    await svc.record_implicit_signal(jid, FeedbackKind.OFFERED)
+    assert svc.weight_overrides() == {}
+
+
+@pytest.mark.asyncio
+async def test_weight_overrides_gated_below_min_outcomes() -> None:
+    repo = FakeRepo()
+    svc = _service_with_nudge(repo, {}, min_outcomes=5)
+    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    for _ in range(3):
+        await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
+    assert svc.weight_overrides() == {}
+
+
+@pytest.mark.asyncio
+async def test_weight_overrides_computed_once_gate_met() -> None:
+    repo = FakeRepo()
+    svc = _service_with_nudge(repo, {}, min_outcomes=3, clamp=3, scale=10.0)
+    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    for _ in range(3):
+        await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
+    overrides = svc.weight_overrides()
+    assert overrides.get("comp", 0) > 0
+
+
+@pytest.mark.asyncio
+async def test_weight_overrides_empty_when_disabled() -> None:
+    repo = FakeRepo()
+    svc = _service_with_nudge(repo, {}, min_outcomes=1)
+    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    svc._enabled = False  # disabled service exposes no overrides
+    await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
+    assert svc.weight_overrides() == {}
+
+
+@pytest.mark.asyncio
+async def test_explain_includes_weight_overrides() -> None:
+    repo = FakeRepo()
+    svc = _service_with_nudge(repo, {}, min_outcomes=3, clamp=3, scale=10.0)
+    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    for _ in range(3):
+        await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
+    exp = await svc.explain()
+    assert exp.weight_overrides.get("comp", 0) > 0
+
+
+@pytest.mark.asyncio
+async def test_reset_clears_weight_overrides() -> None:
+    repo = FakeRepo()
+    svc = _service_with_nudge(repo, {}, min_outcomes=3, clamp=3, scale=10.0)
+    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    for _ in range(3):
+        await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
+    assert svc.weight_overrides() != {}
+    svc.reset()
+    assert svc.weight_overrides() == {}
+
+
+def test_weights_view_reports_base_override_effective() -> None:
+    repo = FakeRepo()
+    svc = _service_with_nudge(
+        repo, {}, base_weights={"comp": 10, "culture": 5}
+    )
+    # Inject a model with an override directly via the repo.
+    repo.save_model(PreferenceModel(delta_vector=[], weight_overrides={"comp": 2}))
+    view = {row["dimension"]: row for row in svc.weights_view()}
+    assert view["comp"]["base_weight"] == 10
+    assert view["comp"]["override"] == 2
+    assert view["comp"]["effective_weight"] == 12
+    assert view["culture"]["base_weight"] == 5
+    assert view["culture"]["override"] == 0
+    assert view["culture"]["effective_weight"] == 5
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/preference/test_weight_nudge_calculator.py
+++ b/backend/tests/unit/preference/test_weight_nudge_calculator.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from hiresense.preference.domain import OutcomeObservation, WeightNudgeCalculator
+
+
+def _obs(dimension: str, score: float, polarity: int) -> OutcomeObservation:
+    return OutcomeObservation(dimension=dimension, dimension_score=score, polarity=polarity)
+
+
+def test_below_gate_returns_no_overrides():
+    calc = WeightNudgeCalculator(min_outcomes=5, clamp=3, scale=5.0)
+    # Only 3 outcome observations for the dimension -> gate (5) unmet.
+    obs = [_obs("comp", 1.0, 1) for _ in range(3)]
+    assert calc.compute_overrides(obs) == {}
+
+
+def test_empty_returns_no_overrides():
+    calc = WeightNudgeCalculator(min_outcomes=1, clamp=3, scale=5.0)
+    assert calc.compute_overrides([]) == {}
+
+
+def test_positive_correlation_nudges_up():
+    calc = WeightNudgeCalculator(min_outcomes=5, clamp=3, scale=5.0)
+    # Dimension scored high (1.0) on positive outcomes -> positive correlation.
+    obs = [_obs("comp", 1.0, 1) for _ in range(5)]
+    overrides = calc.compute_overrides(obs)
+    assert overrides["comp"] > 0
+
+
+def test_negative_correlation_nudges_down():
+    calc = WeightNudgeCalculator(min_outcomes=5, clamp=3, scale=5.0)
+    # Dimension scored high on NEGATIVE outcomes -> negative correlation.
+    obs = [_obs("comp", 1.0, -1) for _ in range(5)]
+    overrides = calc.compute_overrides(obs)
+    assert overrides["comp"] < 0
+
+
+def test_low_score_on_positive_outcome_nudges_down():
+    calc = WeightNudgeCalculator(min_outcomes=5, clamp=3, scale=5.0)
+    # Dimension scored LOW (0.0) on positive outcomes -> it failed to predict
+    # the good outcomes -> nudge down.
+    obs = [_obs("comp", 0.0, 1) for _ in range(5)]
+    overrides = calc.compute_overrides(obs)
+    assert overrides["comp"] < 0
+
+
+def test_neutral_score_yields_no_delta():
+    calc = WeightNudgeCalculator(min_outcomes=5, clamp=3, scale=5.0)
+    # Score exactly at the neutral 0.5 -> zero correlation -> no entry.
+    obs = [_obs("comp", 0.5, 1) for _ in range(5)]
+    assert calc.compute_overrides(obs) == {}
+
+
+def test_delta_is_clamped():
+    # Huge scale would blow past the clamp; clamp must hold the bound.
+    calc = WeightNudgeCalculator(min_outcomes=5, clamp=3, scale=1000.0)
+    obs = [_obs("comp", 1.0, 1) for _ in range(5)]
+    overrides = calc.compute_overrides(obs)
+    assert overrides["comp"] == 3  # clamped to +clamp
+
+    calc_neg = WeightNudgeCalculator(min_outcomes=5, clamp=3, scale=1000.0)
+    obs_neg = [_obs("comp", 1.0, -1) for _ in range(5)]
+    assert calc_neg.compute_overrides(obs_neg)["comp"] == -3
+
+
+def test_gate_counts_per_dimension_observations():
+    # 5 signals, each scoring two dimensions -> 5 observations per dimension,
+    # which meets a gate of 5 (the gate is per outcome signal, not per row).
+    calc = WeightNudgeCalculator(min_outcomes=5, clamp=3, scale=5.0)
+    obs: list[OutcomeObservation] = []
+    for _ in range(5):
+        obs.append(_obs("comp", 1.0, 1))
+        obs.append(_obs("culture", 0.0, 1))
+    overrides = calc.compute_overrides(obs)
+    assert overrides["comp"] > 0
+    assert overrides["culture"] < 0
+
+
+def test_independent_dimensions_get_independent_deltas():
+    calc = WeightNudgeCalculator(min_outcomes=4, clamp=5, scale=10.0)
+    obs: list[OutcomeObservation] = []
+    for _ in range(4):
+        obs.append(_obs("comp", 1.0, 1))      # strong positive
+        obs.append(_obs("growth", 0.5, 1))    # neutral
+    overrides = calc.compute_overrides(obs)
+    assert overrides["comp"] == 5  # 0.5 * 10 = 5, clamped at 5
+    assert "growth" not in overrides  # neutral -> zero -> omitted


### PR DESCRIPTION
Implements the **dimension-weight nudging** machinery from the [Phase 2 design](docs/superpowers/specs/2026-05-31-preference-learning-loop-phase2-design.md). (#35 implicit signals and #37 explanation v2 were already implemented + tested in `main` — closing those issues separately.)

### What's included
- Pure `WeightNudgeCalculator` — sign-aligned correlation → `round(corr·scale)` → hard clamp `±clamp`; returns `{}` until `≥ PREFERENCE_NUDGE_MIN_OUTCOMES` outcome signals (cold-start gate).
- `weight_overrides: dict[str,int]` on `PreferenceModel` + JSON column (migration `020`, nullable, no backfill).
- Recomputed alongside the taste delta; applied in `MatchingOrchestrator.evaluate` via `clamp(base_weight + delta)`.
- `GET /preference/weights` (base/override/effective), overrides in `/explain`, cleared by `/reset`.
- Config: `PREFERENCE_NUDGE_MIN_OUTCOMES` / `_CLAMP` / `_SCALE`.

### ⚠️ Not yet live — read before merging
The per-job dimension-score **lookup is intentionally unattached**. The only persisted dimension scores are the sparse deep-analysis breakdowns in `job_match_cache.deep_payload` (present only for jobs the user deep-analyzed), so there's no reliable source of dimension scores for arbitrary outcome-bearing applications. That's a real design gap the Phase 2 doc glossed over. Until it's resolved, `weight_overrides` stays empty and **scoring is byte-identical to today** (proven by tests). This PR lands the complete, tested mechanism as a foundation; **#36 stays open** for the activation/design follow-up.

### Verification
- Backend `uv run python -m pytest` → **802 passed** (+23); `ruff check` clean on all changed files.
- Backward-compat covered by `test_no_preference_port_is_unchanged`, `test_empty_overrides_is_byte_identical`, `test_preference_lookup_failure_falls_back_to_base`.

Part of #34
Part of #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)