### PR TITLE
feat(autohunt): digests frontend (#33)

### DIFF
--- a/docs/superpowers/specs/2026-06-07-autohunt-frontend-design.md
+++ b/docs/superpowers/specs/2026-06-07-autohunt-frontend-design.md
@@ -1,0 +1,53 @@
+# Auto-Hunt Digests Frontend — Design
+
+**Issue:** #33 · **Builds on:** the `autohunt` backend (`2026-05-31-proactive-auto-hunt-design.md`, which deferred "a frontend view" to a later phase — this is it).
+
+## Context
+
+The backend computes and persists periodic digests of the top *new* taste-ranked matches above a
+quality floor (external cron drives `POST /autohunt/run`). The data is in-app via GET endpoints but
+has no UI. This delivers the glanceable view: "5 strong new roles since yesterday."
+
+## Backend contract (implemented, auth-gated, base `${environment.apiUrl}/autohunt`)
+
+| Method | Path | Returns |
+|---|---|---|
+| GET | `/autohunt/digests/latest` | `Digest` **or HTTP 204** (no digests yet) |
+| GET | `/autohunt/digests?limit=20` | `Digest[]` (newest first) |
+| POST | `/autohunt/run` | `Digest` (manual trigger; normally cron) |
+
+- `Digest { id, created_at: string|null, cutoff_at: string, entries: DigestEntry[], job_count: number }`
+- `DigestEntry { job_id: string, title: string, company: string, url: string|null, score: number }`
+
+## Frontend design
+
+### Service + models (`#33`)
+- `pages/autohunt/models/`: `digest-entry.model.ts` (`DigestEntry`), `digest.model.ts` (`Digest`).
+- `core/services/autohunt.service.ts` (`providedIn:'root'`, `inject(HttpClient)`,
+  `base = ${environment.apiUrl}/autohunt`): `latest(): Observable<Digest | null>` (map HTTP 204 /
+  empty body → `null`), `listRecent(limit = 20): Observable<Digest[]>`, `run(): Observable<Digest>`.
+  Mirror `OutreachService`/`InterviewService` style.
+
+### Page `pages/autohunt/autohunt.component.ts` (+ html/scss), route `dashboard/autohunt`, sidebar nav
+- **Latest digest** panel (hero): `latest()` on init. Header shows "N new matches since {cutoff_at}"
+  (relative) and the run time; entries rendered as rows — `title @ company`, score as a percentage
+  badge, an external link to `entry.url` (when present) and an **Optimize CV** deep-link to
+  `/dashboard/optimization?job_id={job_id}` (reuse the existing prefill flow). 204 → empty state
+  ("No digests yet — runs are scheduled via cron, or trigger one now").
+- **Run now** button → `run()`; on success prepend/refresh latest + history; disable while running;
+  surface errors inline. (Manual convenience; cron is the normal trigger.)
+- **History** list: `listRecent()` — each digest a collapsible row (date + `job_count`), expandable
+  to its entries. Empty + error states.
+
+### Wiring
+- Lazy route under `dashboard` children in `app.routes.ts`; sidebar nav link in
+  `dashboard.component.html` (radar/🛰️-style icon, same markup as siblings).
+- All subscriptions use `inject(DestroyRef)` + `takeUntilDestroyed` per the teardown standard.
+
+## Testing
+- `autohunt.service.spec.ts`: each method's URL/verb; `latest()` maps 204 → `null`.
+- `autohunt.component.spec.ts`: latest renders entries; 204 → empty state; `run()` refreshes;
+  history expand. Services mocked.
+
+## Out of scope
+Pre-drafting applications from digest entries (separate follow-up per the backend doc); email/push.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -19,6 +19,7 @@ export const routes: Routes = [
       { path: 'optimization', loadComponent: () => import('./pages/optimization/optimization.component').then(m => m.OptimizationComponent) },
       { path: 'tracking', loadComponent: () => import('./pages/tracking/tracking.component').then(m => m.TrackingComponent) },
       { path: 'outreach', loadComponent: () => import('./pages/outreach/outreach.component').then(m => m.OutreachComponent) },
+      { path: 'autohunt', loadComponent: () => import('./pages/autohunt/autohunt.component').then(m => m.AutohuntComponent) },
       { path: 'analytics', loadComponent: () => import('./pages/analytics/analytics.component').then(m => m.AnalyticsComponent) },
       { path: 'interview', loadComponent: () => import('./pages/interview/interview.component').then(m => m.InterviewComponent) },
       { path: 'admin/llm-settings', canActivate: [adminGuard], loadComponent: () => import('./pages/admin/admin-llm-settings.component').then(m => m.AdminLLMSettingsComponent) },

--- a/frontend/src/app/core/services/autohunt.service.spec.ts
+++ b/frontend/src/app/core/services/autohunt.service.spec.ts
@@ -1,0 +1,85 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { AutohuntService } from './autohunt.service';
+import { environment } from '../../../environments/environment';
+import { Digest } from '../../pages/autohunt/models/digest.model';
+
+function makeDigest(over: Partial<Digest> = {}): Digest {
+  return {
+    id: 'dig-1',
+    created_at: '2026-06-07T00:00:00Z',
+    cutoff_at: '2026-06-06T00:00:00Z',
+    job_count: 1,
+    entries: [
+      { job_id: 'job-1', title: 'Backend Engineer', company: 'Acme', url: null, score: 0.87 },
+    ],
+    ...over,
+  };
+}
+
+describe('AutohuntService', () => {
+  let service: AutohuntService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AutohuntService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(AutohuntService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('latest GETs /autohunt/digests/latest and returns the digest on 200', () => {
+    const digest = makeDigest();
+    let result: Digest | null | undefined;
+    service.latest().subscribe((d) => (result = d));
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/autohunt/digests/latest`);
+    expect(req.request.method).toBe('GET');
+    req.flush(digest);
+
+    expect(result).toEqual(digest);
+  });
+
+  it('latest maps a 204 No Content to null', () => {
+    let result: Digest | null | undefined;
+    service.latest().subscribe((d) => (result = d));
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/autohunt/digests/latest`);
+    expect(req.request.method).toBe('GET');
+    req.flush(null, { status: 204, statusText: 'No Content' });
+
+    expect(result).toBeNull();
+  });
+
+  it('listRecent GETs /autohunt/digests with the limit param', () => {
+    service.listRecent().subscribe();
+    const req = httpMock.expectOne((r) => r.url === `${environment.apiUrl}/autohunt/digests`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('limit')).toBe('20');
+    req.flush([]);
+  });
+
+  it('listRecent honors a custom limit', () => {
+    service.listRecent(5).subscribe();
+    const req = httpMock.expectOne((r) => r.url === `${environment.apiUrl}/autohunt/digests`);
+    expect(req.request.params.get('limit')).toBe('5');
+    req.flush([]);
+  });
+
+  it('run POSTs /autohunt/run with an empty body', () => {
+    const digest = makeDigest();
+    let result: Digest | undefined;
+    service.run().subscribe((d) => (result = d));
+
+    const req = httpMock.expectOne(`${environment.apiUrl}/autohunt/run`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual({});
+    req.flush(digest);
+
+    expect(result).toEqual(digest);
+  });
+});

--- a/frontend/src/app/core/services/autohunt.service.ts
+++ b/frontend/src/app/core/services/autohunt.service.ts
@@ -1,0 +1,30 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { environment } from '../../../environments/environment';
+import { Digest } from '../../pages/autohunt/models/digest.model';
+
+@Injectable({ providedIn: 'root' })
+export class AutohuntService {
+  private http = inject(HttpClient);
+  private base = `${environment.apiUrl}/autohunt`;
+
+  latest(): Observable<Digest | null> {
+    // The endpoint returns HTTP 204 with an empty body when no digest exists.
+    // Observe the full response so an empty body maps to null instead of
+    // throwing a JSON parse error.
+    return this.http
+      .get<Digest>(`${this.base}/digests/latest`, { observe: 'response' })
+      .pipe(map((res) => (res.status === 204 || !res.body ? null : res.body)));
+  }
+
+  listRecent(limit = 20): Observable<Digest[]> {
+    const params = new HttpParams().set('limit', limit);
+    return this.http.get<Digest[]>(`${this.base}/digests`, { params });
+  }
+
+  run(): Observable<Digest> {
+    return this.http.post<Digest>(`${this.base}/run`, {});
+  }
+}

--- a/frontend/src/app/pages/autohunt/autohunt.component.html
+++ b/frontend/src/app/pages/autohunt/autohunt.component.html
@@ -1,0 +1,125 @@
+<div class="page">
+  <h1>Auto-Hunt</h1>
+  <p class="hint">
+    Periodic digests of the strongest new taste-ranked matches. Runs are scheduled via cron — trigger
+    one manually below to see what's new right now.
+  </p>
+
+  <!-- Latest digest hero -->
+  <section class="card hero">
+    <div class="hero-head">
+      <h2>Latest digest</h2>
+      <button class="btn-primary" (click)="run()" [disabled]="running()">
+        @if (running()) { Running… } @else { Run now }
+      </button>
+    </div>
+
+    @if (runError()) {
+      <div class="alert alert-error">{{ runError() }}</div>
+    }
+
+    @if (latestError()) {
+      <div class="alert alert-error">{{ latestError() }}</div>
+    } @else if (latestLoading()) {
+      <p class="muted">Loading…</p>
+    } @else if (latestDigest(); as digest) {
+      <p class="summary">
+        <strong>{{ digest.job_count }}</strong>
+        {{ digest.job_count === 1 ? 'new match' : 'new matches' }}
+        since {{ digest.cutoff_at }}
+        @if (digest.created_at) {
+          <span class="run-time">· run {{ digest.created_at }}</span>
+        }
+      </p>
+
+      @if (digest.entries.length === 0) {
+        <p class="muted empty">This digest has no entries.</p>
+      } @else {
+        <ul class="entries">
+          @for (entry of digest.entries; track entry.job_id) {
+            <li class="entry-row">
+              <div class="entry-main">
+                <span class="entry-title">{{ entry.title }}</span>
+                <span class="entry-company">@ {{ entry.company }}</span>
+              </div>
+              <div class="entry-actions">
+                <span class="score-badge">{{ scorePercent(entry.score) }}%</span>
+                @if (entry.url) {
+                  <a class="link" [href]="entry.url" target="_blank" rel="noopener">View posting</a>
+                }
+                <a
+                  class="link"
+                  routerLink="/dashboard/optimization"
+                  [queryParams]="{ job_id: entry.job_id }"
+                >
+                  Optimize CV
+                </a>
+              </div>
+            </li>
+          }
+        </ul>
+      }
+    } @else {
+      <p class="muted empty">
+        No digests yet — runs are scheduled via cron, or trigger one now.
+      </p>
+    }
+  </section>
+
+  <!-- History -->
+  <section class="card">
+    <h2>History</h2>
+    @if (historyError()) {
+      <div class="alert alert-error">{{ historyError() }}</div>
+    } @else if (historyLoading()) {
+      <p class="muted">Loading…</p>
+    } @else if (history().length === 0) {
+      <p class="muted empty">No past digests yet.</p>
+    } @else {
+      <ul class="history">
+        @for (digest of history(); track digest.id) {
+          <li class="history-row">
+            <button class="history-head" (click)="toggleExpanded(digest.id)">
+              <span class="history-date">{{ digest.created_at ?? digest.cutoff_at }}</span>
+              <span class="history-count">
+                {{ digest.job_count }} {{ digest.job_count === 1 ? 'match' : 'matches' }}
+              </span>
+              <span class="chevron">{{ expandedId() === digest.id ? '▾' : '▸' }}</span>
+            </button>
+            @if (expandedId() === digest.id) {
+              @if (digest.entries.length === 0) {
+                <p class="muted empty">No entries in this digest.</p>
+              } @else {
+                <ul class="entries">
+                  @for (entry of digest.entries; track entry.job_id) {
+                    <li class="entry-row">
+                      <div class="entry-main">
+                        <span class="entry-title">{{ entry.title }}</span>
+                        <span class="entry-company">@ {{ entry.company }}</span>
+                      </div>
+                      <div class="entry-actions">
+                        <span class="score-badge">{{ scorePercent(entry.score) }}%</span>
+                        @if (entry.url) {
+                          <a class="link" [href]="entry.url" target="_blank" rel="noopener">
+                            View posting
+                          </a>
+                        }
+                        <a
+                          class="link"
+                          routerLink="/dashboard/optimization"
+                          [queryParams]="{ job_id: entry.job_id }"
+                        >
+                          Optimize CV
+                        </a>
+                      </div>
+                    </li>
+                  }
+                </ul>
+              }
+            }
+          </li>
+        }
+      </ul>
+    }
+  </section>
+</div>

--- a/frontend/src/app/pages/autohunt/autohunt.component.scss
+++ b/frontend/src/app/pages/autohunt/autohunt.component.scss
@@ -1,0 +1,180 @@
+.page {
+  max-width: 800px;
+}
+
+.hint {
+  color: #6b7280;
+  margin-bottom: 1.5rem;
+}
+
+.card {
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1.5rem;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+
+  h2 {
+    margin-top: 0;
+    margin-bottom: 1rem;
+    font-size: 1.1em;
+  }
+}
+
+.hero-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.summary {
+  margin: 0.5rem 0 1rem;
+  color: #374151;
+
+  strong {
+    color: #111827;
+  }
+
+  .run-time {
+    color: #9ca3af;
+    font-size: 0.9em;
+  }
+}
+
+.btn-primary {
+  background: #2563eb;
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 9px 16px;
+  font-size: 0.95em;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.muted {
+  color: #6b7280;
+}
+
+.empty {
+  font-style: italic;
+}
+
+.alert {
+  padding: 0.6rem 0.85rem;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  font-size: 0.9em;
+
+  &.alert-error {
+    background: #fef2f2;
+    color: #b91c1c;
+    border: 1px solid #fecaca;
+  }
+}
+
+.entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.entry-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 0;
+  border-top: 1px solid #f3f4f6;
+
+  &:first-child {
+    border-top: none;
+  }
+}
+
+.entry-main {
+  display: flex;
+  flex-direction: column;
+}
+
+.entry-title {
+  font-weight: 600;
+  color: #111827;
+}
+
+.entry-company {
+  color: #6b7280;
+  font-size: 0.9em;
+}
+
+.entry-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-shrink: 0;
+}
+
+.score-badge {
+  background: #ecfdf5;
+  color: #047857;
+  border: 1px solid #a7f3d0;
+  border-radius: 999px;
+  padding: 2px 10px;
+  font-size: 0.85em;
+  font-weight: 600;
+}
+
+.link {
+  color: #2563eb;
+  text-decoration: none;
+  font-size: 0.9em;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.history {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.history-row {
+  border-top: 1px solid #f3f4f6;
+
+  &:first-child {
+    border-top: none;
+  }
+}
+
+.history-head {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0.75rem 0;
+  cursor: pointer;
+  font-size: 0.95em;
+  text-align: left;
+
+  .history-date {
+    flex: 1;
+    color: #374151;
+  }
+
+  .history-count {
+    color: #6b7280;
+  }
+
+  .chevron {
+    color: #9ca3af;
+  }
+}

--- a/frontend/src/app/pages/autohunt/autohunt.component.spec.ts
+++ b/frontend/src/app/pages/autohunt/autohunt.component.spec.ts
@@ -1,0 +1,113 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AutohuntComponent } from './autohunt.component';
+import { AutohuntService } from '../../core/services/autohunt.service';
+import { Digest } from './models/digest.model';
+
+function makeDigest(over: Partial<Digest> = {}): Digest {
+  return {
+    id: 'dig-1',
+    created_at: '2026-06-07T00:00:00Z',
+    cutoff_at: '2026-06-06T00:00:00Z',
+    job_count: 2,
+    entries: [
+      { job_id: 'job-1', title: 'Backend Engineer', company: 'Acme', url: 'https://x/1', score: 0.87 },
+      { job_id: 'job-2', title: 'Platform Engineer', company: 'Globex', url: null, score: 0.71 },
+    ],
+    ...over,
+  };
+}
+
+describe('AutohuntComponent', () => {
+  function mount(opts: { autohunt?: Partial<Record<string, unknown>> } = {}) {
+    const autohunt = {
+      latest: vi.fn(() => of(makeDigest())),
+      listRecent: vi.fn(() => of([makeDigest()])),
+      run: vi.fn(() => of(makeDigest())),
+      ...opts.autohunt,
+    };
+
+    TestBed.configureTestingModule({
+      imports: [AutohuntComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AutohuntService, useValue: autohunt },
+      ],
+    });
+    const fixture = TestBed.createComponent(AutohuntComponent);
+    fixture.detectChanges();
+    return { fixture, cmp: fixture.componentInstance, autohunt };
+  }
+
+  it('loads the latest digest and renders its entries', () => {
+    const { cmp, autohunt } = mount();
+
+    expect(autohunt.latest).toHaveBeenCalled();
+    expect(cmp.latestDigest()?.id).toBe('dig-1');
+    expect(cmp.latestDigest()?.entries.length).toBe(2);
+  });
+
+  it('maps a null latest (204) to the empty state', () => {
+    const latest = vi.fn(() => of(null));
+    const { cmp } = mount({ autohunt: { latest } });
+
+    expect(cmp.latestDigest()).toBeNull();
+    expect(cmp.latestError()).toBe('');
+  });
+
+  it('loads history on init', () => {
+    const { cmp, autohunt } = mount();
+
+    expect(autohunt.listRecent).toHaveBeenCalled();
+    expect(cmp.history().length).toBe(1);
+  });
+
+  it('run() success sets the latest digest and refreshes history', () => {
+    const run = vi.fn(() => of(makeDigest({ id: 'dig-new', job_count: 5 })));
+    const listRecent = vi.fn(() => of([makeDigest({ id: 'dig-new' })]));
+    const { cmp, autohunt } = mount({ autohunt: { run, listRecent } });
+
+    const historyCallsBefore = autohunt.listRecent.mock.calls.length;
+    cmp.run();
+
+    expect(run).toHaveBeenCalled();
+    expect(cmp.latestDigest()?.id).toBe('dig-new');
+    expect(cmp.running()).toBe(false);
+    expect(autohunt.listRecent.mock.calls.length).toBe(historyCallsBefore + 1);
+  });
+
+  it('run() error surfaces an inline message and clears running', () => {
+    const run = vi.fn(() => throwError(() => ({ error: { detail: 'boom' } })));
+    const { cmp } = mount({ autohunt: { run } });
+
+    cmp.run();
+
+    expect(cmp.runError()).toBe('boom');
+    expect(cmp.running()).toBe(false);
+  });
+
+  it('latest error surfaces an inline message', () => {
+    const latest = vi.fn(() => throwError(() => ({ error: { detail: 'nope' } })));
+    const { cmp } = mount({ autohunt: { latest } });
+
+    expect(cmp.latestError()).toBe('nope');
+  });
+
+  it('toggleExpanded expands and collapses a history row', () => {
+    const { cmp } = mount();
+
+    expect(cmp.expandedId()).toBeNull();
+    cmp.toggleExpanded('dig-1');
+    expect(cmp.expandedId()).toBe('dig-1');
+    cmp.toggleExpanded('dig-1');
+    expect(cmp.expandedId()).toBeNull();
+  });
+
+  it('scorePercent renders a 0..1 score as a percentage', () => {
+    const { cmp } = mount();
+
+    expect(cmp.scorePercent(0.87)).toBe(87);
+    expect(cmp.scorePercent(1)).toBe(100);
+  });
+});

--- a/frontend/src/app/pages/autohunt/autohunt.component.ts
+++ b/frontend/src/app/pages/autohunt/autohunt.component.ts
@@ -1,0 +1,100 @@
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { AutohuntService } from '../../core/services/autohunt.service';
+import { Digest } from './models/digest.model';
+
+@Component({
+  selector: 'app-autohunt',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './autohunt.component.html',
+  styleUrl: './autohunt.component.scss',
+})
+export class AutohuntComponent implements OnInit {
+  private autohunt = inject(AutohuntService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // Latest digest (hero)
+  latestDigest = signal<Digest | null>(null);
+  latestLoading = signal(false);
+  latestError = signal('');
+
+  // Run now
+  running = signal(false);
+  runError = signal('');
+
+  // History
+  history = signal<Digest[]>([]);
+  historyLoading = signal(false);
+  historyError = signal('');
+  expandedId = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.loadLatest();
+    this.loadHistory();
+  }
+
+  private loadLatest(): void {
+    this.latestLoading.set(true);
+    this.latestError.set('');
+    this.autohunt
+      .latest()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (digest) => {
+          this.latestDigest.set(digest);
+          this.latestLoading.set(false);
+        },
+        error: (err) => {
+          this.latestLoading.set(false);
+          this.latestError.set(err?.error?.detail ?? 'Could not load the latest digest.');
+        },
+      });
+  }
+
+  private loadHistory(): void {
+    this.historyLoading.set(true);
+    this.historyError.set('');
+    this.autohunt
+      .listRecent()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (digests) => {
+          this.history.set(digests);
+          this.historyLoading.set(false);
+        },
+        error: (err) => {
+          this.historyLoading.set(false);
+          this.historyError.set(err?.error?.detail ?? 'Could not load digest history.');
+        },
+      });
+  }
+
+  run(): void {
+    this.running.set(true);
+    this.runError.set('');
+    this.autohunt
+      .run()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (digest) => {
+          this.running.set(false);
+          this.latestDigest.set(digest);
+          this.loadHistory();
+        },
+        error: (err) => {
+          this.running.set(false);
+          this.runError.set(err?.error?.detail ?? 'Could not run a digest.');
+        },
+      });
+  }
+
+  toggleExpanded(id: string): void {
+    this.expandedId.set(this.expandedId() === id ? null : id);
+  }
+
+  scorePercent(score: number): number {
+    return Math.round(score * 100);
+  }
+}

--- a/frontend/src/app/pages/autohunt/models/digest-entry.model.ts
+++ b/frontend/src/app/pages/autohunt/models/digest-entry.model.ts
@@ -1,0 +1,7 @@
+export interface DigestEntry {
+  job_id: string;
+  title: string;
+  company: string;
+  url: string | null;
+  score: number;
+}

--- a/frontend/src/app/pages/autohunt/models/digest.model.ts
+++ b/frontend/src/app/pages/autohunt/models/digest.model.ts
@@ -1,0 +1,9 @@
+import { DigestEntry } from './digest-entry.model';
+
+export interface Digest {
+  id: string;
+  created_at: string | null;
+  cutoff_at: string;
+  entries: DigestEntry[];
+  job_count: number;
+}

--- a/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -80,6 +80,21 @@
         </span>
         <span>Outreach</span>
       </a>
+      <a routerLink="autohunt" routerLinkActive="active">
+        <span class="nav-icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M19.07 4.93A10 10 0 0 0 6.99 3.34"/>
+            <path d="M4 6h.01"/>
+            <path d="M2.29 9.62A10 10 0 1 0 21.31 8.35"/>
+            <path d="M16.24 7.76A6 6 0 1 0 8.23 16.67"/>
+            <path d="M12 18h.01"/>
+            <path d="M17.99 11.66A6 6 0 0 1 15.77 16.67"/>
+            <circle cx="12" cy="12" r="2"/>
+            <path d="m13.41 10.59 5.66-5.66"/>
+          </svg>
+        </span>
+        <span>Auto-Hunt</span>
+      </a>
       <a routerLink="analytics" routerLinkActive="active">
         <span class="nav-icon" aria-hidden="true">
           <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
Delivers the auto-hunt digests UI the backend spec deferred. Design: `docs/superpowers/specs/2026-06-07-autohunt-frontend-design.md`.

- `AutohuntService` — `latest()` (maps HTTP 204 → `null`), `listRecent(limit)`, `run()` — + `Digest`/`DigestEntry` models.
- `/dashboard/autohunt` page (lazy route + sidebar nav): latest-digest hero with "N new matches since {cutoff}", entry rows (title @ company, score %, external link, **Optimize CV** deep link to the existing prefill flow), a **Run now** trigger, and a collapsible history list. Empty + error states throughout.
- All subscriptions use `takeUntilDestroyed`; no hardcoded URLs.

### Verification
- Frontend full Vitest → **220 passed (35 files)**; `tsc --noEmit` clean for app + spec projects.

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)