### PR TITLE
feat(identity): real admin role + account settings UI (#38)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,9 @@ CORS_ORIGINS=http://localhost:4200
 AUTH_USERNAME=admin
 AUTH_PASSWORD=changeme
 JWT_SECRET_KEY=change-this-to-a-random-secret
+# Role embedded in issued tokens. Single-user instance is admin by default;
+# set to a non-admin value to exercise the admin-only route gate.
+AUTH_ROLE=admin
 
 # === Database ===
 DATABASE_URL=postgresql+asyncpg://hiresense:hiresense@localhost:5432/hiresense

--- a/backend/src/hiresense/admin/api/dependencies.py
+++ b/backend/src/hiresense/admin/api/dependencies.py
@@ -5,7 +5,7 @@ from fastapi import Depends, Request
 from hiresense.admin.api.provider import AdminProvider
 from hiresense.admin.domain.llm_settings_service import LLMSettingsService
 from hiresense.admin.domain.usage_aggregator import UsageAggregator
-from hiresense.identity.api.dependencies import require_auth
+from hiresense.identity.api.dependencies import require_admin
 
 
 def _get_provider(request: Request) -> AdminProvider:
@@ -27,7 +27,11 @@ def get_usage_aggregator(
     return provider.get_usage_aggregator()
 
 
-# Single-user system: the only authenticated principal IS the admin.
-# When proper RBAC lands, swap this for a role check; the rest of the
-# admin routes already depend on this name.
-require_admin = require_auth
+# Admin gate (#38): re-exported from identity so the admin routers keep
+# depending on this stable name, now enforcing the token's "role" claim
+# (403 for non-admin, 401 for an invalid token).
+__all__ = [
+    "get_llm_settings_service",
+    "get_usage_aggregator",
+    "require_admin",
+]

--- a/backend/src/hiresense/bootstrap/identity.py
+++ b/backend/src/hiresense/bootstrap/identity.py
@@ -9,4 +9,5 @@ def build_identity(settings: Settings) -> IdentityProvider:
         username=settings.auth_username,
         password=settings.auth_password,
         jwt_secret=settings.jwt_secret_key,
+        role=settings.auth_role,
     )

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -73,6 +73,9 @@ class Settings(BaseSettings):
     auth_username: str
     auth_password: str
     jwt_secret_key: str
+    # Role embedded in issued tokens. A single-user instance is admin by default;
+    # set to a non-admin value to genuinely exercise the admin gate.
+    auth_role: str = "admin"
 
     # Database
     database_url: str

--- a/backend/src/hiresense/identity/api/__init__.py
+++ b/backend/src/hiresense/identity/api/__init__.py
@@ -1,4 +1,15 @@
-from hiresense.identity.api.dependencies import get_auth_service
+from hiresense.identity.api.dependencies import (
+    get_auth_service,
+    get_current_user,
+    require_admin,
+    require_auth,
+)
 from hiresense.identity.api.routes import router
 
-__all__ = ["get_auth_service", "router"]
+__all__ = [
+    "get_auth_service",
+    "get_current_user",
+    "require_admin",
+    "require_auth",
+    "router",
+]

--- a/backend/src/hiresense/identity/api/dependencies.py
+++ b/backend/src/hiresense/identity/api/dependencies.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -22,3 +22,25 @@ def require_auth(
     if payload is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
     return payload["sub"]
+
+
+def get_current_user(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
+) -> dict[str, Any]:
+    payload = auth_service.validate_token(credentials.credentials)
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    return payload
+
+
+def require_admin(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
+    auth_service: Annotated[AuthService, Depends(get_auth_service)],
+) -> dict[str, Any]:
+    payload = auth_service.validate_token(credentials.credentials)
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+    if payload.get("role") != "admin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
+    return payload

--- a/backend/src/hiresense/identity/api/provider.py
+++ b/backend/src/hiresense/identity/api/provider.py
@@ -4,11 +4,12 @@ from hiresense.identity.domain import AuthService
 
 
 class IdentityProvider:
-    def __init__(self, username: str, password: str, jwt_secret: str) -> None:
+    def __init__(self, username: str, password: str, jwt_secret: str, role: str = "admin") -> None:
         self._auth_service = AuthService(
             username=username,
             password=password,
             jwt_secret=jwt_secret,
+            role=role,
         )
 
     def get_auth_service(self) -> AuthService:

--- a/backend/src/hiresense/identity/api/routes.py
+++ b/backend/src/hiresense/identity/api/routes.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from typing import Annotated
+from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, status
 
-from hiresense.identity.api.dependencies import get_auth_service
-from hiresense.identity.api.schemas import LoginRequest, TokenResponse
+from hiresense.identity.api.dependencies import get_auth_service, get_current_user
+from hiresense.identity.api.schemas import LoginRequest, MeResponse, TokenResponse
 from hiresense.identity.domain import AuthService
 
 router = APIRouter(prefix="/auth", tags=["auth"])
@@ -20,3 +20,10 @@ async def login(
     if token is None:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
     return TokenResponse(access_token=token)
+
+
+@router.get("/me", response_model=MeResponse)
+async def me(
+    current_user: Annotated[dict[str, Any], Depends(get_current_user)],
+) -> MeResponse:
+    return MeResponse(username=current_user["sub"], role=current_user.get("role", "admin"))

--- a/backend/src/hiresense/identity/api/schemas.py
+++ b/backend/src/hiresense/identity/api/schemas.py
@@ -11,3 +11,8 @@ class LoginRequest(BaseModel):
 class TokenResponse(BaseModel):
     access_token: str
     token_type: str = "bearer"
+
+
+class MeResponse(BaseModel):
+    username: str
+    role: str

--- a/backend/src/hiresense/identity/domain/services.py
+++ b/backend/src/hiresense/identity/domain/services.py
@@ -7,10 +7,11 @@ from jose import JWTError, jwt
 
 
 class AuthService:
-    def __init__(self, username: str, password: str, jwt_secret: str) -> None:
+    def __init__(self, username: str, password: str, jwt_secret: str, role: str = "admin") -> None:
         self._username = username
         self._password = password
         self._jwt_secret = jwt_secret
+        self._role = role
 
     def login(self, username: str, password: str) -> str | None:
         if username == self._username and password == self._password:
@@ -25,4 +26,8 @@ class AuthService:
 
     def _create_token(self, subject: str) -> str:
         expire = datetime.now(timezone.utc) + timedelta(hours=24)
-        return jwt.encode({"sub": subject, "exp": expire}, self._jwt_secret, algorithm="HS256")
+        return jwt.encode(
+            {"sub": subject, "role": self._role, "exp": expire},
+            self._jwt_secret,
+            algorithm="HS256",
+        )

--- a/backend/tests/integration/test_identity_admin_role.py
+++ b/backend/tests/integration/test_identity_admin_role.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import Annotated
+
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from hiresense.identity.api import router as identity_router
+from hiresense.identity.api.dependencies import require_admin
+from hiresense.identity.api.provider import IdentityProvider
+
+_USERNAME = "admin"
+_PASSWORD = "secret"
+_SECRET = "test-secret"
+
+
+def _build_app(role: str) -> FastAPI:
+    app = FastAPI()
+    app.state.identity = IdentityProvider(
+        username=_USERNAME,
+        password=_PASSWORD,
+        jwt_secret=_SECRET,
+        role=role,
+    )
+    app.include_router(identity_router)
+
+    # Stand-in for the real admin routers, which already Depends(require_admin).
+    @app.get("/admin/probe")
+    def _probe(_: Annotated[dict, Depends(require_admin)]) -> dict[str, str]:
+        return {"ok": "yes"}
+
+    return app
+
+
+async def _login(client: AsyncClient) -> str:
+    resp = await client.post("/auth/login", json={"username": _USERNAME, "password": _PASSWORD})
+    assert resp.status_code == 200
+    return resp.json()["access_token"]
+
+
+@pytest.mark.asyncio
+async def test_login_token_carries_role_and_me_returns_it() -> None:
+    app = _build_app(role="admin")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        token = await _login(c)
+        me = await c.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+        assert me.status_code == 200
+        assert me.json() == {"username": _USERNAME, "role": "admin"}
+
+
+@pytest.mark.asyncio
+async def test_admin_route_allows_admin_token() -> None:
+    app = _build_app(role="admin")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        token = await _login(c)
+        resp = await c.get("/admin/probe", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": "yes"}
+
+
+@pytest.mark.asyncio
+async def test_admin_route_forbids_valid_non_admin_token() -> None:
+    app = _build_app(role="member")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        token = await _login(c)
+        # A valid token for an authenticated non-admin user.
+        me = await c.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+        assert me.status_code == 200 and me.json()["role"] == "member"
+
+        resp = await c.get("/admin/probe", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 403

--- a/backend/tests/unit/identity/test_auth.py
+++ b/backend/tests/unit/identity/test_auth.py
@@ -27,3 +27,21 @@ def test_validate_invalid_token() -> None:
     service = AuthService(username="admin", password="secret", jwt_secret="key")
     payload = service.validate_token("garbage.token.here")
     assert payload is None
+
+
+def test_token_carries_default_admin_role() -> None:
+    service = AuthService(username="admin", password="secret", jwt_secret="key")
+    token = service.login("admin", "secret")
+    assert token is not None
+    payload = service.validate_token(token)
+    assert payload is not None
+    assert payload["role"] == "admin"
+
+
+def test_token_carries_configured_role() -> None:
+    service = AuthService(username="bob", password="secret", jwt_secret="key", role="member")
+    token = service.login("bob", "secret")
+    assert token is not None
+    payload = service.validate_token(token)
+    assert payload is not None
+    assert payload["role"] == "member"

--- a/backend/tests/unit/identity/test_require_admin.py
+++ b/backend/tests/unit/identity/test_require_admin.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi import HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+
+from hiresense.identity.api.dependencies import require_admin
+
+
+class _FakeAuthService:
+    def __init__(self, payload: dict[str, Any] | None) -> None:
+        self._payload = payload
+
+    def validate_token(self, token: str) -> dict[str, Any] | None:
+        return self._payload
+
+
+def _creds() -> HTTPAuthorizationCredentials:
+    return HTTPAuthorizationCredentials(scheme="Bearer", credentials="token")
+
+
+def test_require_admin_accepts_admin_payload() -> None:
+    service = _FakeAuthService({"sub": "admin", "role": "admin"})
+    payload = require_admin(credentials=_creds(), auth_service=service)
+    assert payload["role"] == "admin"
+
+
+def test_require_admin_rejects_non_admin_with_403() -> None:
+    service = _FakeAuthService({"sub": "bob", "role": "member"})
+    with pytest.raises(HTTPException) as exc:
+        require_admin(credentials=_creds(), auth_service=service)
+    assert exc.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_require_admin_rejects_invalid_token_with_401() -> None:
+    service = _FakeAuthService(None)
+    with pytest.raises(HTTPException) as exc:
+        require_admin(credentials=_creds(), auth_service=service)
+    assert exc.value.status_code == status.HTTP_401_UNAUTHORIZED

--- a/docs/superpowers/specs/2026-06-07-identity-admin-role-design.md
+++ b/docs/superpowers/specs/2026-06-07-identity-admin-role-design.md
@@ -1,0 +1,57 @@
+# Identity — Real Admin Role + Account Settings — Design
+
+**Issue:** #38 · **Replaces** the dangling `TODO(#19)` in `admin.guard.ts`.
+
+## Context
+
+Auth today is a single configured user (`AUTH_USERNAME`/`AUTH_PASSWORD`) with an HS256 JWT carrying
+only `sub`. The backend admin seam already exists — `admin/api/dependencies.py` has
+`require_admin = require_auth` (a placeholder) and both admin routers (`routes_llm_settings`,
+`routes_usage`) already `Depends(require_admin)`. The frontend `adminGuard` likewise just delegates
+to `isAuthenticated()` with a `TODO(#19)`. This issue makes the role real on both ends and adds a
+minimal account page. The system stays single-user; the role is config-driven so a non-admin
+instance is possible and the gate is genuinely exercised.
+
+## Backend
+
+- **Config:** `auth_role: str = "admin"` (+ `.env.example` `AUTH_ROLE=admin` with a comment: the role
+  embedded in issued tokens; a single-user instance is admin by default).
+- **Token:** `AuthService` gains a `role`; `_create_token` adds a `"role"` claim. `IdentityProvider`
+  + `bootstrap` pass `role=settings.auth_role`. `login`/`validate_token` signatures unchanged.
+- **Dependencies (`identity/api/dependencies.py`):**
+  - `get_current_user` → returns the validated payload `{sub, role, ...}` (401 on invalid).
+  - `require_admin` → real dependency: validates the token and raises **403** when
+    `payload.get("role") != "admin"`. Export it from identity.
+  - `admin/api/dependencies.py`: replace `require_admin = require_auth` with
+    `from hiresense.identity.api.dependencies import require_admin` (the admin routers keep depending
+    on it, now enforcing the role).
+- **Endpoint:** `GET /auth/me` (auth-gated) → `MeResponse { username: str, role: str }` from the
+  current-user payload.
+- **Tests (integration, real app + SQLite):** issued login token contains `role`; `/auth/me` returns
+  `{username, role}`; an admin-gated endpoint (e.g. `GET /admin/usage/...` or `/admin/llm-settings`)
+  returns **403** with a valid non-admin token and **200/normal** with an admin token. Unit: token
+  carries role; `require_admin` rejects non-admin, accepts admin.
+
+## Frontend
+
+- **`core/utils/role-from-token.ts`** — decode the JWT `role` claim locally (mirror
+  `is-token-expired.ts`; returns `null` on missing/malformed). Client-side hint only; backend remains
+  authority.
+- **`AuthService`:** `role = computed(() => roleFromToken(token))`, `isAdmin = computed(() => role() === 'admin')`,
+  and `me(): Observable<{ username: string; role: string }>` → `GET /auth/me`.
+- **`adminGuard`:** admit only when `isAuthenticated() && isAdmin()`; an authenticated non-admin →
+  redirect to `/dashboard` (not login); unauthenticated → `/login`. Remove the `TODO(#19)`; replace
+  with a comment referencing this issue (#38) and the role check.
+- **Account page** `pages/account/account.component.ts` (+html/scss), route `dashboard/account`,
+  sidebar nav link: on init `auth.me()` → show username + a role badge + account/session info and a
+  logout button; loading + error states. Read-only (password lives in env; note that inline).
+- **Tests:** `role-from-token` decode; `auth.service` `isAdmin`/`role` from token; `adminGuard` admits
+  admin / blocks non-admin (UrlTree to `/dashboard`); account component renders `me()` + handles error.
+
+## Acceptance (from #38)
+- Admin routes blocked for non-admin users end-to-end (backend 403 + frontend guard redirect). ✓
+- TODO comment updated to reference #38. ✓
+- Minimal account settings page. ✓
+
+## Out of scope
+Multi-user accounts, registration, password change at runtime, RBAC beyond admin/non-admin.

--- a/frontend/src/app/app.routes.ts
+++ b/frontend/src/app/app.routes.ts
@@ -24,6 +24,7 @@ export const routes: Routes = [
       { path: 'interview', loadComponent: () => import('./pages/interview/interview.component').then(m => m.InterviewComponent) },
       { path: 'admin/llm-settings', canActivate: [adminGuard], loadComponent: () => import('./pages/admin/admin-llm-settings.component').then(m => m.AdminLLMSettingsComponent) },
       { path: 'admin/usage', canActivate: [adminGuard], loadComponent: () => import('./pages/admin/admin-usage.component').then(m => m.AdminUsageComponent) },
+      { path: 'account', loadComponent: () => import('./pages/account/account.component').then(m => m.AccountComponent) },
     ],
   },
   { path: '**', redirectTo: 'login' },

--- a/frontend/src/app/core/guards/admin.guard.spec.ts
+++ b/frontend/src/app/core/guards/admin.guard.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  ActivatedRouteSnapshot,
+  Router,
+  RouterStateSnapshot,
+  UrlTree,
+} from '@angular/router';
+import { describe, expect, it } from 'vitest';
+import { adminGuard } from './admin.guard';
+import { AuthService } from '../services/auth.service';
+
+function run(auth: Partial<AuthService>) {
+  const router = {
+    createUrlTree: (commands: unknown[]) => ({ __tree: commands } as unknown as UrlTree),
+  };
+  TestBed.configureTestingModule({
+    providers: [
+      { provide: AuthService, useValue: auth },
+      { provide: Router, useValue: router },
+    ],
+  });
+  return TestBed.runInInjectionContext(() =>
+    adminGuard(
+      {} as ActivatedRouteSnapshot,
+      {} as RouterStateSnapshot,
+    ),
+  );
+}
+
+describe('adminGuard', () => {
+  it('admits an authenticated admin', () => {
+    const result = run({ isAuthenticated: () => true, isAdmin: () => true } as Partial<AuthService>);
+    expect(result).toBe(true);
+  });
+
+  it('redirects an authenticated non-admin to /dashboard', () => {
+    const result = run({ isAuthenticated: () => true, isAdmin: () => false } as Partial<AuthService>);
+    expect(result).toEqual({ __tree: ['/dashboard'] });
+  });
+
+  it('redirects an unauthenticated user to /login', () => {
+    const result = run({ isAuthenticated: () => false, isAdmin: () => false } as Partial<AuthService>);
+    expect(result).toEqual({ __tree: ['/login'] });
+  });
+});

--- a/frontend/src/app/core/guards/admin.guard.ts
+++ b/frontend/src/app/core/guards/admin.guard.ts
@@ -2,14 +2,18 @@ import { inject } from '@angular/core';
 import { CanActivateFn, Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
-// TODO(#19): gate on real admin role once the backend exposes one.
-// Currently delegates to the same authentication check as authGuard so the
-// seam exists and admin routes can be tightened without touching app.routes.ts.
+// #38: gate on the real admin role. The role is read from the JWT's `role`
+// claim (client-side hint); the backend enforces it for real by returning 403
+// on the admin routes. An authenticated non-admin is sent to the dashboard
+// (they're logged in, just not authorized); anyone unauthenticated goes to login.
 export const adminGuard: CanActivateFn = () => {
   const auth = inject(AuthService);
   const router = inject(Router);
-  if (auth.isAuthenticated()) {
-    return true;
+  if (!auth.isAuthenticated()) {
+    return router.createUrlTree(['/login']);
   }
-  return router.createUrlTree(['/login']);
+  if (!auth.isAdmin()) {
+    return router.createUrlTree(['/dashboard']);
+  }
+  return true;
 };

--- a/frontend/src/app/core/services/auth.service.spec.ts
+++ b/frontend/src/app/core/services/auth.service.spec.ts
@@ -1,0 +1,68 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { Router } from '@angular/router';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { AuthService } from './auth.service';
+import { environment } from '../../../environments/environment';
+
+function makeToken(claims: Record<string, unknown>): string {
+  const future = Math.floor(Date.now() / 1000) + 3600;
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify({ exp: future, ...claims }));
+  return `${header}.${payload}.signature`;
+}
+
+function makeService(): { service: AuthService; httpMock: HttpTestingController } {
+  TestBed.configureTestingModule({
+    providers: [
+      AuthService,
+      provideHttpClient(),
+      provideHttpClientTesting(),
+      { provide: Router, useValue: { navigate: () => {} } },
+    ],
+  });
+  return {
+    service: TestBed.inject(AuthService),
+    httpMock: TestBed.inject(HttpTestingController),
+  };
+}
+
+describe('AuthService', () => {
+  afterEach(() => {
+    localStorage.clear();
+    TestBed.resetTestingModule();
+  });
+
+  it('exposes role and isAdmin from an admin token', () => {
+    localStorage.setItem('access_token', makeToken({ sub: 'admin', role: 'admin' }));
+    const { service, httpMock } = makeService();
+    expect(service.role()).toBe('admin');
+    expect(service.isAdmin()).toBe(true);
+    httpMock.verify();
+  });
+
+  it('reports a non-admin token as not admin', () => {
+    localStorage.setItem('access_token', makeToken({ sub: 'bob', role: 'member' }));
+    const { service, httpMock } = makeService();
+    expect(service.role()).toBe('member');
+    expect(service.isAdmin()).toBe(false);
+    httpMock.verify();
+  });
+
+  it('has a null role when no token is stored', () => {
+    const { service, httpMock } = makeService();
+    expect(service.role()).toBeNull();
+    expect(service.isAdmin()).toBe(false);
+    httpMock.verify();
+  });
+
+  it('me() GETs /auth/me', () => {
+    const { service, httpMock } = makeService();
+    service.me().subscribe();
+    const req = httpMock.expectOne(`${environment.apiUrl}/auth/me`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ username: 'admin', role: 'admin' });
+    httpMock.verify();
+  });
+});

--- a/frontend/src/app/core/services/auth.service.ts
+++ b/frontend/src/app/core/services/auth.service.ts
@@ -2,18 +2,26 @@ import { Injectable, signal, computed } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Router } from '@angular/router';
 import { environment } from '../../../environments/environment';
+import { Observable } from 'rxjs';
 import { LoginResponse } from '../models/login-response.model';
 import { isTokenExpired } from '../utils/is-token-expired';
+import { roleFromToken } from '../utils/role-from-token';
 
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private readonly tokenSignal = signal<string | null>(this.getStoredToken());
   readonly isAuthenticated = computed(() => !isTokenExpired(this.tokenSignal()));
+  readonly role = computed(() => roleFromToken(this.tokenSignal()));
+  readonly isAdmin = computed(() => this.role() === 'admin');
 
   constructor(private http: HttpClient, private router: Router) {}
 
   login(username: string, password: string) {
     return this.http.post<LoginResponse>(`${environment.apiUrl}/auth/login`, { username, password });
+  }
+
+  me(): Observable<{ username: string; role: string }> {
+    return this.http.get<{ username: string; role: string }>(`${environment.apiUrl}/auth/me`);
   }
 
   setToken(token: string): void {

--- a/frontend/src/app/core/utils/role-from-token.spec.ts
+++ b/frontend/src/app/core/utils/role-from-token.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { roleFromToken } from './role-from-token';
+
+function makeToken(claims: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const payload = btoa(JSON.stringify(claims));
+  return `${header}.${payload}.signature`;
+}
+
+describe('roleFromToken', () => {
+  it('returns null for a null token', () => {
+    expect(roleFromToken(null)).toBeNull();
+  });
+
+  it('returns null for a malformed (non-JWT) token', () => {
+    expect(roleFromToken('not-a-jwt')).toBeNull();
+  });
+
+  it('returns null when the role claim is missing', () => {
+    expect(roleFromToken(makeToken({ sub: 'admin' }))).toBeNull();
+  });
+
+  it('returns null when the role claim is not a string', () => {
+    expect(roleFromToken(makeToken({ sub: 'admin', role: 123 }))).toBeNull();
+  });
+
+  it('decodes the admin role claim', () => {
+    expect(roleFromToken(makeToken({ sub: 'admin', role: 'admin' }))).toBe('admin');
+  });
+
+  it('decodes a non-admin role claim', () => {
+    expect(roleFromToken(makeToken({ sub: 'bob', role: 'member' }))).toBe('member');
+  });
+});

--- a/frontend/src/app/core/utils/role-from-token.ts
+++ b/frontend/src/app/core/utils/role-from-token.ts
@@ -1,0 +1,22 @@
+/**
+ * Returns the `role` claim from a JWT, or `null` when the token is missing,
+ * malformed, or has no string `role`. The payload is decoded locally for
+ * client-side UI hints only (e.g. showing/hiding admin nav) — the backend
+ * remains the authority on the role via the 403-gated admin routes.
+ */
+export function roleFromToken(token: string | null): string | null {
+  if (!token) {
+    return null;
+  }
+  const segments = token.split('.');
+  if (segments.length !== 3) {
+    return null;
+  }
+  try {
+    const json = atob(segments[1].replace(/-/g, '+').replace(/_/g, '/'));
+    const payload = JSON.parse(json) as { role?: unknown };
+    return typeof payload.role === 'string' ? payload.role : null;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/app/pages/account/account.component.html
+++ b/frontend/src/app/pages/account/account.component.html
@@ -1,0 +1,34 @@
+<section class="account">
+  <header class="account-header">
+    <h1>Account</h1>
+    <p class="account-sub">Your session and instance settings</p>
+  </header>
+
+  @if (loading()) {
+    <p class="account-loading">Loading account…</p>
+  } @else if (error()) {
+    <p class="account-error" role="alert">{{ error() }}</p>
+  } @else {
+    <div class="account-card">
+      <dl class="account-fields">
+        <div class="account-field">
+          <dt>Username</dt>
+          <dd>{{ username() }}</dd>
+        </div>
+        <div class="account-field">
+          <dt>Role</dt>
+          <dd>
+            <span class="role-badge" [class.role-badge--admin]="role() === 'admin'">{{ role() }}</span>
+          </dd>
+        </div>
+      </dl>
+
+      <p class="account-note">
+        This is a single-user instance. The username and password are managed
+        via environment configuration and are read-only here.
+      </p>
+
+      <button type="button" class="logout-btn" (click)="logout()">Sign Out</button>
+    </div>
+  }
+</section>

--- a/frontend/src/app/pages/account/account.component.scss
+++ b/frontend/src/app/pages/account/account.component.scss
@@ -1,0 +1,91 @@
+.account {
+  max-width: 520px;
+  padding: 1.5rem;
+}
+
+.account-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.account-sub {
+  margin: 0.25rem 0 1.5rem;
+  color: var(--text-muted, #6b7280);
+}
+
+.account-loading,
+.account-error {
+  padding: 1rem 0;
+}
+
+.account-error {
+  color: var(--danger, #dc2626);
+}
+
+.account-card {
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 8px;
+  padding: 1.25rem 1.5rem;
+}
+
+.account-fields {
+  margin: 0;
+}
+
+.account-field {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid var(--border, #f0f0f0);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  dt {
+    font-weight: 600;
+    color: var(--text-muted, #6b7280);
+  }
+
+  dd {
+    margin: 0;
+  }
+}
+
+.role-badge {
+  display: inline-block;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  background: var(--surface-muted, #f3f4f6);
+  color: var(--text, #374151);
+  text-transform: capitalize;
+
+  &--admin {
+    background: var(--accent-soft, #ede9fe);
+    color: var(--accent, #6d28d9);
+  }
+}
+
+.account-note {
+  margin: 1rem 0 1.25rem;
+  font-size: 0.85rem;
+  color: var(--text-muted, #6b7280);
+}
+
+.logout-btn {
+  width: 100%;
+  padding: 0.6rem 1rem;
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 6px;
+  background: var(--surface, #fff);
+  color: var(--text, #374151);
+  font-weight: 600;
+  cursor: pointer;
+
+  &:hover {
+    background: var(--surface-muted, #f9fafb);
+  }
+}

--- a/frontend/src/app/pages/account/account.component.spec.ts
+++ b/frontend/src/app/pages/account/account.component.spec.ts
@@ -1,0 +1,50 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+import { AccountComponent } from './account.component';
+import { AuthService } from '../../core/services/auth.service';
+
+describe('AccountComponent', () => {
+  function mount(auth: Partial<AuthService>) {
+    TestBed.configureTestingModule({
+      imports: [AccountComponent],
+      providers: [{ provide: AuthService, useValue: auth }],
+    });
+    const fixture = TestBed.createComponent(AccountComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('renders username and role from me() on init', () => {
+    const fixture = mount({
+      me: () => of({ username: 'admin', role: 'admin' }),
+    } as Partial<AuthService>);
+    const cmp = fixture.componentInstance;
+
+    expect(cmp.username()).toBe('admin');
+    expect(cmp.role()).toBe('admin');
+    expect(cmp.loading()).toBe(false);
+    expect(cmp.error()).toBe('');
+  });
+
+  it('surfaces an error and clears loading when me() fails', () => {
+    const fixture = mount({
+      me: () => throwError(() => ({ error: { detail: 'nope' } })),
+    } as Partial<AuthService>);
+    const cmp = fixture.componentInstance;
+
+    expect(cmp.error()).toBe('nope');
+    expect(cmp.loading()).toBe(false);
+    expect(cmp.username()).toBe('');
+  });
+
+  it('delegates logout to AuthService', () => {
+    const logout = vi.fn();
+    const fixture = mount({
+      me: () => of({ username: 'admin', role: 'admin' }),
+      logout,
+    } as Partial<AuthService>);
+    fixture.componentInstance.logout();
+    expect(logout).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/pages/account/account.component.ts
+++ b/frontend/src/app/pages/account/account.component.ts
@@ -1,0 +1,43 @@
+import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { AuthService } from '../../core/services/auth.service';
+
+@Component({
+  selector: 'app-account',
+  standalone: true,
+  imports: [],
+  templateUrl: './account.component.html',
+  styleUrl: './account.component.scss',
+})
+export class AccountComponent implements OnInit {
+  readonly username = signal('');
+  readonly role = signal('');
+  readonly loading = signal(false);
+  readonly error = signal('');
+
+  private auth = inject(AuthService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  ngOnInit(): void {
+    this.loading.set(true);
+    this.error.set('');
+    this.auth
+      .me()
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (me) => {
+          this.username.set(me.username);
+          this.role.set(me.role);
+          this.loading.set(false);
+        },
+        error: (err) => {
+          this.error.set(err.error?.detail ?? 'Failed to load account');
+          this.loading.set(false);
+        },
+      });
+  }
+
+  logout(): void {
+    this.auth.logout();
+  }
+}

--- a/frontend/src/app/pages/dashboard/dashboard.component.html
+++ b/frontend/src/app/pages/dashboard/dashboard.component.html
@@ -127,6 +127,16 @@
         </span>
         <span>LLM Usage</span>
       </a>
+      <div class="nav-section-label">Settings</div>
+      <a routerLink="account" routerLinkActive="active">
+        <span class="nav-icon" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
+            <circle cx="12" cy="7" r="4"/>
+          </svg>
+        </span>
+        <span>Account</span>
+      </a>
     </nav>
     <div class="sidebar-footer">
       <button (click)="logout()" class="logout-btn">Sign Out</button>


### PR DESCRIPTION
Makes the placeholder admin seam real and adds a minimal account page. Design: `docs/superpowers/specs/2026-06-07-identity-admin-role-design.md`.

### Backend
- `AUTH_ROLE` config (default `admin`) → embedded as a `role` claim in the JWT.
- `require_admin` is now a real dependency: validates the token and returns **403** for non-admins (the admin LLM-settings + usage routers already depend on it, so they're now genuinely gated).
- `GET /auth/me` → `{ username, role }`.

### Frontend
- `role-from-token` decoder + `AuthService.role`/`isAdmin` signals + `me()`.
- `adminGuard` admits only `isAuthenticated() && isAdmin()` (authenticated non-admin → `/dashboard`, unauth → `/login`); the dangling `TODO(#19)` is replaced with a #38 reference.
- Account page at `/dashboard/account` (username + role badge + logout, loading/error states) with a sidebar link.

Backward compatible: the configured single user is admin by default, so all current behavior is preserved.

### Verification
- Backend `uv run python -m pytest` → **810 passed**; ruff clean on changed files.
- Frontend full Vitest → **236 passed (39 files)**; `tsc --noEmit` clean for app + spec projects.

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)