### PR TITLE
feat(preference): activate weight-nudging (#36, closes epic #34)

### DIFF
--- a/backend/alembic/versions/021_add_feedback_signal_dimension_scores.py
+++ b/backend/alembic/versions/021_add_feedback_signal_dimension_scores.py
@@ -1,0 +1,30 @@
+"""add dimension_scores to feedback_signals (Phase 2 nudge activation)
+
+Adds a JSONB column holding ``{dimension_name: score}`` snapshotted from the
+matching dimension scorers at outcome time. Nullable with no backfill: existing
+rows (and explicit signals) read back as NULL, which the repository maps to
+domain ``None`` so those signals contribute nothing to weight nudging and
+matching stays unchanged until enough outcome signals carry scores.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-06-07
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "021"
+down_revision: Union[str, None] = "020"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE feedback_signals ADD COLUMN IF NOT EXISTS dimension_scores JSONB"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE feedback_signals DROP COLUMN IF EXISTS dimension_scores")

--- a/backend/src/hiresense/bootstrap/__init__.py
+++ b/backend/src/hiresense/bootstrap/__init__.py
@@ -10,6 +10,7 @@ from hiresense.bootstrap.analytics import AnalyticsBuild, build_analytics
 from hiresense.bootstrap.applications import build_applications
 from hiresense.bootstrap.autohunt import AutoHuntBuild, build_autohunt
 from hiresense.bootstrap.cover_letter_templates import build_cover_letter_templates
+from hiresense.bootstrap.dimension_scorer_adapter import MatchingDimensionScorerAdapter
 from hiresense.bootstrap.identity import build_identity
 from hiresense.bootstrap.ingestion import IngestionBuild, build_ingestion
 from hiresense.bootstrap.interview import InterviewBuild, build_interview
@@ -29,6 +30,7 @@ __all__ = [
     "AutoHuntBuild",
     "IngestionBuild",
     "InterviewBuild",
+    "MatchingDimensionScorerAdapter",
     "MatchingBuild",
     "OptimizationBuild",
     "OutreachBuild",

--- a/backend/src/hiresense/bootstrap/dimension_scorer_adapter.py
+++ b/backend/src/hiresense/bootstrap/dimension_scorer_adapter.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class MatchingDimensionScorerAdapter:
+    """Bootstrap adapter implementing the preference ``DimensionScorerPort``.
+
+    Given a ``job_id``, it fetches the job (via the ingestion orchestrator, the
+    same get-job seam ``attach_job_lookup`` uses) and the current candidate
+    profile (via the profile service), then runs the *same* matching dimension
+    scorers the orchestrator uses for ``job x profile``, collecting
+    ``{result.dimension: result.score}``.
+
+    Returns ``None`` (no nudging contribution, signal still stored) when the
+    job, profile, scorers, or LLM are unavailable, or on any exception. Living
+    in ``bootstrap/`` keeps the cross-module call (matching + ingestion +
+    profile) out of the pure preference domain.
+    """
+
+    def __init__(
+        self,
+        *,
+        orchestrator: Any,
+        job_lookup: Any,
+        profile_service: Any,
+    ) -> None:
+        self._orchestrator = orchestrator
+        self._job_lookup = job_lookup
+        self._profile_service = profile_service
+
+    async def score_dimensions(self, job_id: str) -> dict[str, float] | None:
+        try:
+            scorers = getattr(self._orchestrator, "_dimension_scorers", None)
+            if not scorers:
+                return None
+            job = self._job_lookup.get_job_by_id(job_id)
+            if job is None:
+                return None
+            profile = await self._profile_service.get_current_profile()
+            # Reuse the orchestrator's own evaluate path so the scores match
+            # exactly what matching would produce for this job x profile.
+            result = await self._orchestrator.evaluate(job, profile)
+            scores = {d.dimension: float(d.score) for d in result.dimensions}
+            return scores or None
+        except Exception:
+            logger.exception(
+                "preference: dimension-score adapter failed for job %s — "
+                "no nudging contribution",
+                job_id,
+            )
+            return None

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -11,6 +11,7 @@ from hiresense.analytics.api import router as analytics_router
 from hiresense.applications.api.routes import router as applications_router
 from hiresense.autohunt.api import router as autohunt_router
 from hiresense.bootstrap import (
+    MatchingDimensionScorerAdapter,
     build_admin,
     build_analytics,
     build_applications,
@@ -113,6 +114,19 @@ def create_app() -> FastAPI:
     matching = build_matching(infra, tracked, preference=preference.service)
     app.state.matching = matching.provider
     app.include_router(matching_router)
+
+    # Two-phase wiring (mirrors attach_job_lookup): matching is built after the
+    # preference service, so attach the dimension scorer used to snapshot
+    # per-job dimension scores onto outcome signals at record time. Absent this
+    # (or when it returns None) no signal carries scores -> weight_overrides
+    # stays empty -> matching composite is byte-identical to today.
+    preference.service.attach_dimension_scorer(
+        MatchingDimensionScorerAdapter(
+            orchestrator=matching.orchestrator,
+            job_lookup=ingestion.orchestrator,
+            profile_service=profile.service,
+        )
+    )
 
     # --- Optimization ---
     optimization = build_optimization(tracked)

--- a/backend/src/hiresense/preference/domain/feedback_signal.py
+++ b/backend/src/hiresense/preference/domain/feedback_signal.py
@@ -17,6 +17,10 @@ class FeedbackSignal(BaseModel):
     kind: FeedbackKind
     source: FeedbackSource
     job_embedding: list[float] | None = None
+    # Per-dimension matching scores snapshotted at outcome time (implicit
+    # signals only). None for explicit signals or when capture failed; such
+    # signals contribute nothing to weight nudging.
+    dimension_scores: dict[str, float] | None = None
     created_at: datetime | None = None
 
     model_config = {"from_attributes": True}

--- a/backend/src/hiresense/preference/domain/services.py
+++ b/backend/src/hiresense/preference/domain/services.py
@@ -42,7 +42,7 @@ class PreferenceService:
         self._llm = llm
         self._explanation_enabled = explanation_enabled
         self._job_lookup: Any | None = None
-        self._dimension_lookup: Any | None = None
+        self._dimension_scorer: Any | None = None
 
     def attach_job_lookup(self, job_lookup: Any) -> None:
         """Late-bind the job-title lookup used by the LLM explanation summary.
@@ -50,18 +50,25 @@ class PreferenceService:
         preference service, so it is attached once available."""
         self._job_lookup = job_lookup
 
-    def attach_dimension_lookup(self, dimension_lookup: Any) -> None:
-        """Late-bind the per-job dimension-score lookup used to nudge weights.
+    def attach_dimension_scorer(self, scorer: Any) -> None:
+        """Late-bind the dimension scorer used to snapshot per-job scores.
 
         Two-phase wiring (mirrors ``attach_job_lookup``): the matching layer is
-        built after the preference service, so the lookup — ``get_dimension_scores(job_id)
-        -> dict[str, float] | None`` over cached match scoring — is attached
-        once available. When absent (or it returns nothing), no observations are
-        produced and ``weight_overrides`` stays empty, so matching is unchanged."""
-        self._dimension_lookup = dimension_lookup
+        built after the preference service, so the scorer — a
+        ``DimensionScorerPort`` whose ``score_dimensions(job_id) ->
+        dict[str, float] | None`` runs the matching dimension scorers for the
+        job times the current profile — is attached once available. When absent
+        (or it returns ``None``), recorded signals carry no dimension scores, so
+        no observations are produced and ``weight_overrides`` stays empty,
+        leaving matching byte-identical to today."""
+        self._dimension_scorer = scorer
 
     async def _record(
-        self, job_id: uuid_mod.UUID, kind: FeedbackKind, source: FeedbackSource
+        self,
+        job_id: uuid_mod.UUID,
+        kind: FeedbackKind,
+        source: FeedbackSource,
+        capture_dimensions: bool = False,
     ) -> FeedbackSignal:
         embedding: list[float] | None = None
         if self._vector_store is not None:
@@ -75,12 +82,27 @@ class PreferenceService:
                 "signal stored, no contribution",
                 job_id,
             )
+        # Outcome (implicit) signals snapshot the matching dimension scores once,
+        # at outcome time, off the request path. Failure degrades gracefully:
+        # the signal is still stored, simply with no nudging contribution.
+        dimension_scores: dict[str, float] | None = None
+        if capture_dimensions and self._dimension_scorer is not None:
+            try:
+                dimension_scores = await self._dimension_scorer.score_dimensions(str(job_id))
+            except Exception:
+                logger.exception(
+                    "preference: dimension-score capture failed for %s — "
+                    "signal stored, no nudging contribution",
+                    job_id,
+                )
+                dimension_scores = None
         signal = self._repo.add_signal(
             FeedbackSignal(
                 job_id=job_id,
                 kind=kind,
                 source=source,
                 job_embedding=embedding,
+                dimension_scores=dimension_scores,
             )
         )
         self._recompute()
@@ -89,12 +111,16 @@ class PreferenceService:
     async def record_signal(
         self, job_id: uuid_mod.UUID, kind: FeedbackKind
     ) -> FeedbackSignal:
-        return await self._record(job_id, kind, FeedbackSource.EXPLICIT)
+        return await self._record(
+            job_id, kind, FeedbackSource.EXPLICIT, capture_dimensions=False
+        )
 
     async def record_implicit_signal(
         self, job_id: uuid_mod.UUID, kind: FeedbackKind
     ) -> FeedbackSignal:
-        return await self._record(job_id, kind, FeedbackSource.IMPLICIT)
+        return await self._record(
+            job_id, kind, FeedbackSource.IMPLICIT, capture_dimensions=True
+        )
 
     def query_vector(self, baseline: list[float]) -> list[float]:
         if not self._enabled:
@@ -232,13 +258,16 @@ class PreferenceService:
         )
 
     def _compute_overrides(self, signals: list[FeedbackSignal]) -> dict[str, int]:
-        # Nudging needs both a calculator and a way to recover per-job dimension
-        # scores. Absent either, return no overrides -> matching unchanged.
-        if self._nudge_calc is None or self._dimension_lookup is None:
+        # Nudging needs a calculator. Each signal contributes only via the
+        # dimension scores snapshotted onto it at record time; signals without
+        # them (explicit, or capture-failed) contribute nothing. Absent the
+        # calculator, or no signal carries scores, return no overrides ->
+        # matching byte-identical to today.
+        if self._nudge_calc is None:
             return {}
         observations: list[OutcomeObservation] = []
         for signal in signals:
-            scores = self._dimension_scores_for(signal.job_id)
+            scores = signal.dimension_scores
             if not scores:
                 continue
             polarity = signal.kind.polarity
@@ -251,13 +280,6 @@ class PreferenceService:
                     )
                 )
         return self._nudge_calc.compute_overrides(observations)
-
-    def _dimension_scores_for(self, job_id: uuid_mod.UUID) -> dict[str, float] | None:
-        try:
-            return self._dimension_lookup.get_dimension_scores(str(job_id))
-        except Exception:
-            logger.exception("preference: dimension-score lookup failed for %s", job_id)
-            return None
 
     def _to_contribution(self, signal: FeedbackSignal, now: datetime) -> SignalContribution:
         created = signal.created_at or now

--- a/backend/src/hiresense/preference/infrastructure/orm.py
+++ b/backend/src/hiresense/preference/infrastructure/orm.py
@@ -23,6 +23,9 @@ class FeedbackSignalOrm(Base):
     kind: Mapped[str] = mapped_column(String(32))
     source: Mapped[str] = mapped_column(String(16))
     job_embedding: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    # Per-dimension matching scores snapshotted at outcome time. NULL for
+    # explicit signals (or when capture failed); maps back to domain `None`.
+    dimension_scores: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )

--- a/backend/src/hiresense/preference/infrastructure/repository.py
+++ b/backend/src/hiresense/preference/infrastructure/repository.py
@@ -21,6 +21,7 @@ class PreferenceRepository:
                 kind=signal.kind.value,
                 source=signal.source.value,
                 job_embedding=signal.job_embedding,
+                dimension_scores=signal.dimension_scores,
             )
             session.add(row)
             session.commit()

--- a/backend/src/hiresense/preference/ports/__init__.py
+++ b/backend/src/hiresense/preference/ports/__init__.py
@@ -1,3 +1,4 @@
+from hiresense.preference.ports.dimension_scorer import DimensionScorerPort
 from hiresense.preference.ports.repository import PreferenceRepositoryPort
 
-__all__ = ["PreferenceRepositoryPort"]
+__all__ = ["DimensionScorerPort", "PreferenceRepositoryPort"]

--- a/backend/src/hiresense/preference/ports/dimension_scorer.py
+++ b/backend/src/hiresense/preference/ports/dimension_scorer.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class DimensionScorerPort(Protocol):
+    """Snapshots a job's per-dimension matching scores at outcome time.
+
+    Implemented by a bootstrap adapter that runs the configured matching
+    dimension scorers for the job (by id) against the current profile and
+    returns ``{dimension_name: score}``. Returns ``None`` when the job,
+    profile, scorers, or LLM are unavailable, or on any failure — in which
+    case the signal is still recorded but carries no dimension scores and so
+    contributes nothing to weight nudging.
+    """
+
+    async def score_dimensions(self, job_id: str) -> dict[str, float] | None: ...

--- a/backend/tests/integration/test_preference_weight_nudge_flow.py
+++ b/backend/tests/integration/test_preference_weight_nudge_flow.py
@@ -2,7 +2,8 @@
 
 Builds a real FastAPI app over an in-memory SQLite DB (no Postgres), wires the
 preference service exactly as bootstrap does (nudge calculator + a fake
-dimension-score lookup standing in for cached match scoring), and verifies:
+dimension scorer standing in for the matching dimension scorers, snapshotted
+onto each outcome signal at record time), and verifies:
 
 - below the gate, /preference/weights shows zero overrides and a matching
   composite equals the base-weight composite (backward compatible);
@@ -49,10 +50,10 @@ class _FakeVectorStore:
         return None  # no embedding needed for the weight-nudge path
 
 
-class _FakeDimLookup:
+class _FakeDimScorer:
     """compensation always scored 1.0 on the outcome jobs -> positive nudge."""
 
-    def get_dimension_scores(self, job_id: str):  # noqa: ARG002
+    async def score_dimensions(self, job_id: str):  # noqa: ARG002
         return {"compensation": 1.0, "culture_fit": 0.5}
 
 
@@ -125,7 +126,7 @@ async def test_weight_nudge_flow() -> None:
     session_factory = sessionmaker(bind=engine, expire_on_commit=False)
 
     service = _build_service(session_factory)
-    service.attach_dimension_lookup(_FakeDimLookup())
+    service.attach_dimension_scorer(_FakeDimScorer())
 
     # A matching orchestrator sharing the same preference port (as in the app).
     orchestrator = MatchingOrchestrator(

--- a/backend/tests/unit/preference/test_preference_service.py
+++ b/backend/tests/unit/preference/test_preference_service.py
@@ -209,14 +209,34 @@ async def test_explain_layers_llm_summary() -> None:
     assert exp.total_signals == 1
 
 
-class _FakeDimLookup:
-    """Returns fixed dimension scores for any job id."""
+class _FakeDimScorer:
+    """Async scorer that returns fixed dimension scores for any job id."""
 
     def __init__(self, scores: dict[str, float]) -> None:
         self._scores = scores
+        self.calls: list[str] = []
 
-    def get_dimension_scores(self, job_id: str):  # noqa: ARG002
+    async def score_dimensions(self, job_id: str) -> dict[str, float] | None:
+        self.calls.append(job_id)
         return dict(self._scores)
+
+
+class _NoneDimScorer:
+    """Scorer that always returns None (job/profile/LLM unavailable)."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def score_dimensions(self, job_id: str) -> dict[str, float] | None:
+        self.calls.append(job_id)
+        return None
+
+
+class _RaisingDimScorer:
+    """Scorer that raises — capture must degrade gracefully."""
+
+    async def score_dimensions(self, job_id: str) -> dict[str, float] | None:  # noqa: ARG002
+        raise RuntimeError("scorer down")
 
 
 def _service_with_nudge(
@@ -236,12 +256,62 @@ def _service_with_nudge(
 
 
 @pytest.mark.asyncio
-async def test_weight_overrides_empty_without_dimension_lookup() -> None:
+async def test_weight_overrides_empty_without_dimension_scorer() -> None:
     repo = FakeRepo()
     jid = uuid.uuid4()
     svc = _service_with_nudge(repo, {str(jid): [0.0, 1.0]}, min_outcomes=1)
-    # No dimension lookup attached -> no observations -> no overrides.
+    # No dimension scorer attached -> signal carries no scores -> no overrides.
     await svc.record_implicit_signal(jid, FeedbackKind.OFFERED)
+    assert svc.weight_overrides() == {}
+
+
+@pytest.mark.asyncio
+async def test_implicit_signal_captures_dimensions_at_record_time() -> None:
+    repo = FakeRepo()
+    jid = uuid.uuid4()
+    scorer = _FakeDimScorer({"comp": 1.0})
+    svc = _service_with_nudge(repo, {}, min_outcomes=1)
+    svc.attach_dimension_scorer(scorer)
+    await svc.record_implicit_signal(jid, FeedbackKind.OFFERED)
+    # The scorer was called for the job id and the scores were snapshotted.
+    assert scorer.calls == [str(jid)]
+    assert repo.signals[0].dimension_scores == {"comp": 1.0}
+
+
+@pytest.mark.asyncio
+async def test_explicit_signal_does_not_capture_dimensions() -> None:
+    repo = FakeRepo()
+    jid = uuid.uuid4()
+    scorer = _FakeDimScorer({"comp": 1.0})
+    svc = _service_with_nudge(repo, {}, min_outcomes=1)
+    svc.attach_dimension_scorer(scorer)
+    await svc.record_signal(jid, FeedbackKind.THUMBS_UP)
+    # Explicit thumbs signals never trigger dimension capture.
+    assert scorer.calls == []
+    assert repo.signals[0].dimension_scores is None
+
+
+@pytest.mark.asyncio
+async def test_capture_returns_none_stores_signal_without_scores() -> None:
+    repo = FakeRepo()
+    jid = uuid.uuid4()
+    svc = _service_with_nudge(repo, {}, min_outcomes=1)
+    svc.attach_dimension_scorer(_NoneDimScorer())
+    await svc.record_implicit_signal(jid, FeedbackKind.OFFERED)
+    assert repo.signals[0].dimension_scores is None
+    assert svc.weight_overrides() == {}
+
+
+@pytest.mark.asyncio
+async def test_capture_raises_degrades_gracefully() -> None:
+    repo = FakeRepo()
+    jid = uuid.uuid4()
+    svc = _service_with_nudge(repo, {}, min_outcomes=1)
+    svc.attach_dimension_scorer(_RaisingDimScorer())
+    # No crash; signal still stored, just without dimension scores.
+    signal = await svc.record_implicit_signal(jid, FeedbackKind.OFFERED)
+    assert signal.dimension_scores is None
+    assert repo.signals[0].dimension_scores is None
     assert svc.weight_overrides() == {}
 
 
@@ -249,7 +319,7 @@ async def test_weight_overrides_empty_without_dimension_lookup() -> None:
 async def test_weight_overrides_gated_below_min_outcomes() -> None:
     repo = FakeRepo()
     svc = _service_with_nudge(repo, {}, min_outcomes=5)
-    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    svc.attach_dimension_scorer(_FakeDimScorer({"comp": 1.0}))
     for _ in range(3):
         await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
     assert svc.weight_overrides() == {}
@@ -259,7 +329,7 @@ async def test_weight_overrides_gated_below_min_outcomes() -> None:
 async def test_weight_overrides_computed_once_gate_met() -> None:
     repo = FakeRepo()
     svc = _service_with_nudge(repo, {}, min_outcomes=3, clamp=3, scale=10.0)
-    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    svc.attach_dimension_scorer(_FakeDimScorer({"comp": 1.0}))
     for _ in range(3):
         await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
     overrides = svc.weight_overrides()
@@ -267,10 +337,27 @@ async def test_weight_overrides_computed_once_gate_met() -> None:
 
 
 @pytest.mark.asyncio
+async def test_compute_overrides_ignores_signals_without_scores() -> None:
+    # Signals captured before a scorer was attached carry no scores and must
+    # not contribute; only the score-bearing signals count toward the gate.
+    repo = FakeRepo()
+    svc = _service_with_nudge(repo, {}, min_outcomes=3, clamp=3, scale=10.0)
+    # Two outcomes without a scorer -> no scores.
+    for _ in range(2):
+        await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
+    assert svc.weight_overrides() == {}
+    # Attach a scorer and add three more -> only those three meet the gate.
+    svc.attach_dimension_scorer(_FakeDimScorer({"comp": 1.0}))
+    for _ in range(3):
+        await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
+    assert svc.weight_overrides().get("comp", 0) > 0
+
+
+@pytest.mark.asyncio
 async def test_weight_overrides_empty_when_disabled() -> None:
     repo = FakeRepo()
     svc = _service_with_nudge(repo, {}, min_outcomes=1)
-    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    svc.attach_dimension_scorer(_FakeDimScorer({"comp": 1.0}))
     svc._enabled = False  # disabled service exposes no overrides
     await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
     assert svc.weight_overrides() == {}
@@ -280,7 +367,7 @@ async def test_weight_overrides_empty_when_disabled() -> None:
 async def test_explain_includes_weight_overrides() -> None:
     repo = FakeRepo()
     svc = _service_with_nudge(repo, {}, min_outcomes=3, clamp=3, scale=10.0)
-    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    svc.attach_dimension_scorer(_FakeDimScorer({"comp": 1.0}))
     for _ in range(3):
         await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
     exp = await svc.explain()
@@ -291,7 +378,7 @@ async def test_explain_includes_weight_overrides() -> None:
 async def test_reset_clears_weight_overrides() -> None:
     repo = FakeRepo()
     svc = _service_with_nudge(repo, {}, min_outcomes=3, clamp=3, scale=10.0)
-    svc.attach_dimension_lookup(_FakeDimLookup({"comp": 1.0}))
+    svc.attach_dimension_scorer(_FakeDimScorer({"comp": 1.0}))
     for _ in range(3):
         await svc.record_implicit_signal(uuid.uuid4(), FeedbackKind.OFFERED)
     assert svc.weight_overrides() != {}

--- a/docs/superpowers/specs/2026-06-07-preference-nudge-activation-design.md
+++ b/docs/superpowers/specs/2026-06-07-preference-nudge-activation-design.md
@@ -1,0 +1,68 @@
+# Preference Weight-Nudging — Activation (dimension-score source) — Design
+
+**Issues:** #36 (activation) → closes epic **#34**. Builds on the merged nudging mechanism (PR #64).
+
+## The blocker this resolves
+
+`WeightNudgeCalculator` correlates each matching dimension's score on outcome-bearing jobs with the
+outcome polarity to produce clamped weight deltas. The mechanism (calculator, `weight_overrides`
+storage, `MatchingOrchestrator` application, `/preference/weights`) is merged but **inert**: there was
+no source of per-job dimension scores. We evaluated the candidates:
+
+- **Stored application match** (`ApplicationMatchOrm`) — only persists semantic/skill/experience/
+  language, *not* the 6 LLM dimension scorers (compensation/culture/growth/seniority/
+  application_strength/interview_readiness). Incomplete.
+- **Deep-analysis cache** (`job_match_cache.deep_payload`) — has a full breakdown but only for jobs
+  the user explicitly deep-analyzed. Too sparse.
+- **Live recompute at override-compute time** (the current unattached seam) — would re-run LLM
+  scorers every recompute and fails once the job is pruned.
+
+## Decision (chosen): snapshot at outcome time onto the signal
+
+When an **outcome** (implicit) signal is recorded — `applied` / `interviewing` / `offered` /
+`accepted` / `rejected` — run the matching dimension scorers for that job × current profile **once**,
+and store the resulting `{dimension: score}` map on the `FeedbackSignal`. Rationale:
+
+- **Complete** — all configured dimensions, straight from the real scorers.
+- **Ground-truth & durable** — captures the scores as they were at the outcome moment and survives
+  later job pruning / embedding cleanup (the scores live on the signal, not the job).
+- **Bounded cost** — outcomes are rare (you apply to / hear back on a small number of jobs), and the
+  capture runs in the async event-bus subscriber, off the request path. LLM/profile/job unavailable →
+  `None` → signal still stored, simply no nudging contribution (graceful, mirrors the embedding path).
+- Explicit thumbs signals do **not** capture dimensions — nudging is outcome-driven only.
+
+## Changes
+
+### Domain
+- `FeedbackSignal`: add `dimension_scores: dict[str, float] | None = None`.
+- New port `preference/ports` `DimensionScorerPort` (Protocol): `async score_dimensions(job_id: str) -> dict[str, float] | None`.
+- `PreferenceService._record(... , capture_dimensions: bool)`: for outcome (implicit) signals, when a
+  dimension scorer is attached, `await scorer.score_dimensions(job_id)` and set it on the signal
+  before persisting. `record_signal` (explicit) passes `capture_dimensions=False`;
+  `record_implicit_signal` passes `True`.
+- `_compute_overrides`: build `OutcomeObservation`s from each signal's **stored** `dimension_scores`
+  (signals without them — explicit, or capture-failed — contribute nothing) + `signal.kind.polarity`.
+  Remove the live `_dimension_lookup` / `attach_dimension_lookup` / `_dimension_scores_for` seam;
+  replace with `attach_dimension_scorer(scorer)` used at record time.
+
+### Infrastructure
+- `FeedbackSignalOrm`: add `dimension_scores` JSON column; repository maps it ↔ domain. Migration `021`.
+
+### Bootstrap (the cross-module wiring, allowed only here)
+- A `DimensionScorerPort` adapter that, given `job_id`, fetches the job (ingestion orchestrator) +
+  current profile (profile service) and runs the matching dimension scorers (collect
+  `{result.dimension: result.score}`), returning `None` on any miss. Attached to the preference
+  service post-build (matching is built after preference — same two-phase pattern as the existing
+  `attach_job_lookup`).
+
+## Backward compatibility
+No scorer attached, scorer returns `None`, or the cold-start gate unmet → no signals carry dimension
+scores → `weight_overrides` empty → `MatchingOrchestrator` composite **byte-identical** to today.
+
+## Testing
+- Unit: `_record` captures dimensions for implicit signals (scorer attached) and skips for explicit;
+  `_compute_overrides` builds observations from stored `dimension_scores` and ignores signals without
+  them; backward-compat (no scorer → empty).
+- Integration: enough outcome events (status changes) → signals stored with dimension scores → gate
+  met → `weight_overrides` populated → a matching composite changes; `/reset` clears delta + overrides;
+  a capture failure degrades gracefully.


### PR DESCRIPTION
Activates the dimension-weight-nudging loop that PR #64 left as a tested-but-inert mechanism. Design: `docs/superpowers/specs/2026-06-07-preference-nudge-activation-design.md`.

**The fix** — there was no source of per-job dimension scores. Now an **outcome** (implicit) signal snapshots the matching dimension scorers' breakdown onto the `FeedbackSignal` at record time:
- New `DimensionScorerPort` + a bootstrap adapter that reuses the matching orchestrator's own scorers for the job × current profile (job via ingestion, profile via profile service), attached post-build like `attach_job_lookup`.
- `FeedbackSignal.dimension_scores` JSON column (migration `021`); `_compute_overrides` builds observations from the stored scores + signal polarity.
- Chosen over live-recompute (loses pruned jobs) and stored application-match/deep-analysis (incomplete/sparse). Outcomes are rare so the LLM cost is bounded; capture runs in the async subscriber and degrades gracefully.

**Backward compatible:** no scorer / `None` / cold-start gate unmet → no stored scores → empty overrides → `MatchingOrchestrator` composite byte-identical (asserted in the integration test).

### Verification
- Backend default `uv run python -m pytest` → **815 passed, 6 skipped** (pgvector opt-in); ruff clean on changed files.

Closes #36
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)