### PR TITLE
chore(infrastructure): make alembic check clean (align ORM ↔ schema)

### DIFF
--- a/backend/alembic/versions/022_widen_profile_url_columns.py
+++ b/backend/alembic/versions/022_widen_profile_url_columns.py
@@ -1,0 +1,45 @@
+"""widen profile URL columns from VARCHAR(500) to VARCHAR(2048)
+
+The ``profiles`` table stores ``linkedin_url``, ``github_url`` and
+``portfolio_url`` as ``VARCHAR(500)`` (from an earlier migration), but the ORM
+declares them as ``String(2048)``. This resolves that model/schema drift by
+widening the DB columns to match the ORM. Widening a varchar is a metadata-only
+change in Postgres (no table rewrite) and is fully reversible.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-06-07
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "022"
+down_revision: Union[str, None] = "021"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_COLUMNS = ("linkedin_url", "github_url", "portfolio_url")
+
+
+def upgrade() -> None:
+    for column in _COLUMNS:
+        op.alter_column(
+            "profiles",
+            column,
+            existing_type=sa.String(length=500),
+            type_=sa.String(length=2048),
+            existing_nullable=True,
+        )
+
+
+def downgrade() -> None:
+    for column in _COLUMNS:
+        op.alter_column(
+            "profiles",
+            column,
+            existing_type=sa.String(length=2048),
+            type_=sa.String(length=500),
+            existing_nullable=True,
+        )

--- a/backend/src/hiresense/admin/infrastructure/llm_audit_log_model.py
+++ b/backend/src/hiresense/admin/infrastructure/llm_audit_log_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid as uuid_mod
 from datetime import datetime
 
-from sqlalchemy import DateTime, JSON, String, Uuid, func
+from sqlalchemy import DateTime, Index, JSON, String, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from hiresense.infrastructure.database import Base
@@ -17,6 +17,7 @@ class LLMAuditLog(Base):
     """
 
     __tablename__ = "llm_audit_log"
+    __table_args__ = (Index("ix_llm_audit_log_created_at", "created_at"),)
 
     id: Mapped[uuid_mod.UUID] = mapped_column(Uuid, primary_key=True, default=uuid_mod.uuid4)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/hiresense/admin/infrastructure/llm_usage_log_model.py
+++ b/backend/src/hiresense/admin/infrastructure/llm_usage_log_model.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid as uuid_mod
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Float, Integer, String, Text, Uuid, func
+from sqlalchemy import Boolean, DateTime, Float, Index, Integer, String, Text, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from hiresense.infrastructure.database import Base
@@ -11,6 +11,11 @@ from hiresense.infrastructure.database import Base
 
 class LLMUsageLog(Base):
     __tablename__ = "llm_usage_log"
+    __table_args__ = (
+        Index("ix_llm_usage_log_created_at", "created_at"),
+        Index("ix_llm_usage_log_feature_created", "feature_key", "created_at"),
+        Index("ix_llm_usage_log_provider_model", "provider", "model"),
+    )
 
     id: Mapped[uuid_mod.UUID] = mapped_column(Uuid, primary_key=True, default=uuid_mod.uuid4)
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/hiresense/applications/infrastructure/orm.py
+++ b/backend/src/hiresense/applications/infrastructure/orm.py
@@ -35,10 +35,10 @@ class ApplicationJobSnapshotOrm(Base):
     required_skills: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     source: Mapped[str] = mapped_column(String(20), nullable=False)
     created_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     updated_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
 
 
@@ -66,7 +66,7 @@ class ApplicationMatchOrm(Base):
     recommendations: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     cv_language: Mapped[str] = mapped_column(String(10), nullable=False)
     created_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
 
@@ -91,7 +91,7 @@ class ApplicationCvOptimizationOrm(Base):
     improvement_summary: Mapped[str] = mapped_column(Text, nullable=False, default="")
     changes: Mapped[list[dict]] = mapped_column(JSON, nullable=False, default=list)
     created_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
 
@@ -113,7 +113,7 @@ class ApplicationCoverLetterOrm(Base):
     body: Mapped[str] = mapped_column(Text, nullable=False)
     tone: Mapped[str] = mapped_column(String(20), nullable=False, default="professional")
     created_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
 
 
@@ -134,5 +134,5 @@ class ApplicationInterviewPrepOrm(Base):
     negotiation_points: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
     matched_stories: Mapped[list[dict]] = mapped_column(JSON, nullable=False, default=list)
     created_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/src/hiresense/autohunt/infrastructure/orm.py
+++ b/backend/src/hiresense/autohunt/infrastructure/orm.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import uuid as uuid_mod
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, Integer, JSON, Uuid, func
+from sqlalchemy import DateTime, Index, Integer, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
+from hiresense.infrastructure import JSONB_OR_JSON
 from hiresense.infrastructure.database import Base
 
 
@@ -14,6 +15,7 @@ class DigestOrm(Base):
     `entries` is a denormalized JSON snapshot of the qualifying matches."""
 
     __tablename__ = "digests"
+    __table_args__ = (Index("ix_digests_created_at", "created_at"),)
 
     id: Mapped[uuid_mod.UUID] = mapped_column(Uuid, primary_key=True, default=uuid_mod.uuid4)
     created_at: Mapped[datetime] = mapped_column(
@@ -23,5 +25,5 @@ class DigestOrm(Base):
         nullable=False,
     )
     cutoff_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
-    entries: Mapped[list] = mapped_column(JSON, default=list)
+    entries: Mapped[list] = mapped_column(JSONB_OR_JSON, default=list)
     job_count: Mapped[int] = mapped_column(Integer, default=0)

--- a/backend/src/hiresense/cover_letter_templates/infrastructure/orm.py
+++ b/backend/src/hiresense/cover_letter_templates/infrastructure/orm.py
@@ -25,8 +25,8 @@ class CoverLetterTemplateOrm(Base):
     body: Mapped[str] = mapped_column(Text, default="")
     signature: Mapped[str] = mapped_column(Text, default="")
     created_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     updated_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )

--- a/backend/src/hiresense/infrastructure/__init__.py
+++ b/backend/src/hiresense/infrastructure/__init__.py
@@ -1,0 +1,3 @@
+from hiresense.infrastructure.json_type import JSONB_OR_JSON
+
+__all__ = ["JSONB_OR_JSON"]

--- a/backend/src/hiresense/infrastructure/json_type.py
+++ b/backend/src/hiresense/infrastructure/json_type.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from sqlalchemy import JSON
+from sqlalchemy.dialects.postgresql import JSONB
+
+# Cross-dialect JSON column type: renders JSONB on PostgreSQL (matching the
+# columns created by the original migrations) while falling back to plain JSON
+# on other dialects (e.g. the SQLite-backed test harness). Use this for columns
+# whose live Postgres type is JSONB so the ORM metadata matches the DB.
+JSONB_OR_JSON = JSON().with_variant(JSONB(), "postgresql")

--- a/backend/src/hiresense/preference/infrastructure/orm.py
+++ b/backend/src/hiresense/preference/infrastructure/orm.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import uuid as uuid_mod
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, Integer, String, Uuid, func
+from sqlalchemy import DateTime, Integer, String, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
+from hiresense.infrastructure import JSONB_OR_JSON
 from hiresense.infrastructure.database import Base
 
 # Embeddings are stored as JSON float arrays (not a pgvector column): the taste
@@ -22,10 +23,10 @@ class FeedbackSignalOrm(Base):
     job_id: Mapped[uuid_mod.UUID] = mapped_column(Uuid, index=True)
     kind: Mapped[str] = mapped_column(String(32))
     source: Mapped[str] = mapped_column(String(16))
-    job_embedding: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    job_embedding: Mapped[list | None] = mapped_column(JSONB_OR_JSON, nullable=True)
     # Per-dimension matching scores snapshotted at outcome time. NULL for
     # explicit signals (or when capture failed); maps back to domain `None`.
-    dimension_scores: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    dimension_scores: Mapped[dict | None] = mapped_column(JSONB_OR_JSON, nullable=True)
     created_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now()
     )
@@ -36,10 +37,10 @@ class PreferenceModelOrm(Base):
 
     # Singleton: one row, fixed id. (Multi-profile is a future extension.)
     id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
-    delta_vector: Mapped[list] = mapped_column(JSON)
+    delta_vector: Mapped[list] = mapped_column(JSONB_OR_JSON)
     # Phase 2: dimension name -> integer weight delta for the matching composite.
     # Defaults to {} so pre-Phase-2 rows (NULL) read back as "no overrides".
-    weight_overrides: Mapped[dict | None] = mapped_column(JSON, nullable=True, default=dict)
+    weight_overrides: Mapped[dict | None] = mapped_column(JSONB_OR_JSON, nullable=True, default=dict)
     version: Mapped[int] = mapped_column(Integer, default=1)
     updated_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), onupdate=func.now()

--- a/backend/src/hiresense/profile/infrastructure/orm.py
+++ b/backend/src/hiresense/profile/infrastructure/orm.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import uuid as uuid_mod
 from datetime import datetime
 
-from sqlalchemy import JSON, DateTime, Index, String, Text, Uuid, func
+from sqlalchemy import DateTime, Index, String, Text, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
+from hiresense.infrastructure import JSONB_OR_JSON
 from hiresense.infrastructure.database import Base
 
 
@@ -22,10 +23,10 @@ class ProfileOrm(Base):
     email: Mapped[str | None] = mapped_column(String(255), nullable=True)
     phone: Mapped[str | None] = mapped_column(String(100), nullable=True)
     location: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    sections: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    sections: Mapped[list | None] = mapped_column(JSONB_OR_JSON, nullable=True)
     raw_tex: Mapped[str | None] = mapped_column(Text, nullable=True)
     language: Mapped[str] = mapped_column(String(10), default="en")
-    skills: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    skills: Mapped[list | None] = mapped_column(JSONB_OR_JSON, nullable=True)
     original_filename: Mapped[str | None] = mapped_column(String(500), nullable=True)
     linkedin_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     github_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)

--- a/backend/src/hiresense/tracking/infrastructure/orm.py
+++ b/backend/src/hiresense/tracking/infrastructure/orm.py
@@ -32,10 +32,10 @@ class TrackedApplicationOrm(Base):
         DateTime(timezone=True), nullable=True
     )
     created_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now()
+        DateTime(timezone=True), server_default=func.now(), nullable=False
     )
     updated_at: Mapped[datetime | None] = mapped_column(
-        DateTime(timezone=True), server_default=func.now(), onupdate=func.now()
+        DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
 
 


### PR DESCRIPTION
Fixes the pre-existing Alembic drift surfaced during live verification — `alembic check` failed on endemic ORM↔schema mismatches. Now clean.

- **JSONB↔JSON** (7 cols) — new cross-dialect `JSONB_OR_JSON` type (`JSON().with_variant(JSONB, "postgresql")`): Postgres renders JSONB (matching the DB), SQLite still uses JSON so tests pass. No DDL.
- **Missing indexes** (5) — re-declared in the ORM with their exact DB names (llm_audit_log, llm_usage_log ×3, digests `created_at`). No DDL.
- **Nullable** (10 timestamp cols) — `nullable=False` to match the NOT NULL columns the DB already has. No DDL.
- **Migration `022`** — widens `profiles` linkedin/github/portfolio_url `VARCHAR(500)→2048` (the one place the DB genuinely needed to change).

### Verification (against the live compose Postgres)
- `alembic upgrade head` → applied `022`; `alembic check` → **"No new upgrade operations detected."**
- `uv run python -m pytest` → **815 passed, 6 skipped**; ruff clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)