### PR TITLE
feat: client-side sorting & filtering for Applications, Tracking, Interview Stories (Phase 2)

### DIFF
--- a/docs/superpowers/plans/2026-06-07-list-sorting-filtering-phase2.md
+++ b/docs/superpowers/plans/2026-06-07-list-sorting-filtering-phase2.md
@@ -1,0 +1,73 @@
+# List Sorting & Filtering — Phase 2 (Client-side bare lists) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Add client-side sorting + filtering to the Applications, Tracking, and Interview Stories list views, reusing the Phase 1 foundation (`createSortState`, `sortItems`, `SortableHeaderComponent`).
+
+**Architecture:** Each page already loads its full collection into a signal. We add (a) a `createSortState` instance, (b) optional text/select filter signals, and (c) a `visibleX = computed(...)` that filters then sorts via `sortItems`. The template iterates the computed and uses `SortableHeaderComponent` headers — no `(sorted)` handler and no extra network call, because the computed re-derives from the sort signals automatically. Builds on `feat/list-sorting-filtering` (Phase 1).
+
+**Tech Stack:** Angular 21 standalone + signals, Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-sorting-filtering-design.md` (Phase 2 section).
+
+---
+
+### Task 1: Applications — sortable headers + status filter + text search
+
+**Files:**
+- Modify: `frontend/src/app/pages/applications/applications.component.ts`
+- Modify: `frontend/src/app/pages/applications/applications.component.html`
+- Test: `frontend/src/app/pages/applications/applications.component.spec.ts` (create)
+
+**Design:**
+- `sort = createSortState<'title'|'company'|'status'|'match'|'created'>('created','desc',['title','company','status'])`.
+- `query = signal('')` (title/company text search), `statusFilter = signal('')`.
+- Accessor map: title→`title`, company→`company`, status→`status`, match→`latest_match_score`, created→`created_at`.
+- `visibleApplications = computed(...)`: filter by `query` (title/company substring, case-insensitive) and `statusFilter` (exact), then `sortItems`.
+- Template: iterate `visibleApplications()`; headers Title/Company/Status/Match/Created use `appSortHeader`; Artifacts + actions stay plain. Add a filter bar (text input + status `select`) in the page header. Status options derived from the data: a `statuses = computed(() => [...new Set(applications().map(a => a.status))].sort())`.
+- Spec: load 3 rows, assert default order by created desc; set `query`, assert filtered; toggle the status header twice, assert reorder.
+
+### Task 2: Tracking — sortable headers + text search (keep existing status filter)
+
+**Files:**
+- Modify: `frontend/src/app/pages/tracking/tracking.component.ts`
+- Modify: `frontend/src/app/pages/tracking/tracking.component.html`
+- Test: `frontend/src/app/pages/tracking/tracking.component.spec.ts` (create)
+
+**Design:**
+- Keep the existing server-side `statusFilter`/`onStatusFilterChange` (re-queries) untouched.
+- `sort = createSortState<'company'|'title'|'status'|'posted'|'applied'>('company','asc',['company','title','status'])`.
+- `query = signal('')` (company/title search).
+- Accessor map: company→`company`, title→`title`, status→`status`, posted→`posted_date`, applied→`applied_at`.
+- `visibleApplications = computed(...)`: filter by `query`, then `sortItems` over `applications()`.
+- Template: iterate `visibleApplications()`; headers Company/Title/Status/Posted/Applied use `appSortHeader`; Location/Salary/Source/Notes/Actions stay plain. Add a company/title text input next to the existing status `select` in the header actions.
+- Spec: load 3 rows; assert company asc default; toggle posted header, assert order by posted_date; set query, assert filter.
+
+### Task 3: Interview Stories — sortable headers + competency filter
+
+**Files:**
+- Modify: `frontend/src/app/pages/interview/interview.component.ts`
+- Modify: `frontend/src/app/pages/interview/interview.component.html`
+- Test: `frontend/src/app/pages/interview/interview.component.spec.ts` (create, scoped to the story bank)
+
+**Design:**
+- `storySort = createSortState<'title'|'competency'|'created'>('created','desc',['title','competency'])`.
+- `competencyFilter = signal<Competency | ''>('')`.
+- Accessor map: title→`title`, competency→`competency`, created→`created_at`.
+- `visibleStories = computed(...)`: filter by `competencyFilter` (exact), then `sortItems` over `stories()`.
+- Template (story bank table only): iterate `visibleStories()`; headers Title/Competency/Created use `appSortHeader`; Situation/Actions stay plain. Add a competency `select` (reuse `competencyOptions`) above the table. Note: the table currently has no Created column header — add a "Created" `<th>`/`<td>` (value `created_at | date:'mediumDate'`) so the created sort is visible.
+- Spec: load 3 stories; assert created desc default; set competencyFilter, assert filtered; toggle title header, assert order.
+
+### Task 4: Verification
+
+- [ ] `cd frontend && npm run build` — succeeds.
+- [ ] `cd frontend && npm test` — all specs pass (including 3 new).
+- [ ] Commit per task; final verification commit if needed.
+
+---
+
+## Self-review notes
+
+- All three pages keep their existing create/delete/research/evaluate logic untouched — only display derivation changes (iterate the computed instead of the raw signal).
+- No backend changes (bare lists). No new network calls from sorting.
+- Reuses Phase 1 foundation verbatim; `(sorted)` output intentionally unused for client-side pages.

--- a/frontend/src/app/pages/applications/applications.component.html
+++ b/frontend/src/app/pages/applications/applications.component.html
@@ -1,7 +1,25 @@
 <div class="page">
   <div class="page-header">
     <h1>Applications</h1>
-    <button class="btn-primary" (click)="openCreate()">+ New application</button>
+    <div class="header-actions">
+      @if (applications().length > 0) {
+        <input
+          type="search"
+          class="filter-control"
+          placeholder="Search title or company…"
+          [value]="query()"
+          (input)="onQueryInput($event)"
+          aria-label="Search applications"
+        />
+        <select class="filter-control" [value]="statusFilter()" (change)="onStatusFilterChange($event)" aria-label="Filter by status">
+          <option value="">All statuses</option>
+          @for (s of statuses(); track s) {
+            <option [value]="s">{{ s | titlecase }}</option>
+          }
+        </select>
+      }
+      <button class="btn-primary" (click)="openCreate()">+ New application</button>
+    </div>
   </div>
 
   @if (loading()) {
@@ -17,17 +35,17 @@
     <table class="apps-table">
       <thead>
         <tr>
-          <th>Title</th>
-          <th>Company</th>
-          <th>Status</th>
-          <th>Match</th>
+          <th appSortHeader [state]="sort" field="title">Title</th>
+          <th appSortHeader [state]="sort" field="company">Company</th>
+          <th appSortHeader [state]="sort" field="status">Status</th>
+          <th appSortHeader [state]="sort" field="match">Match</th>
           <th>Artifacts</th>
-          <th>Created</th>
+          <th appSortHeader [state]="sort" field="created">Created</th>
           <th class="col-actions" aria-label="Actions"></th>
         </tr>
       </thead>
       <tbody>
-        @for (app of applications(); track app.id) {
+        @for (app of visibleApplications(); track app.id) {
           <tr (click)="open(app.id)" class="row">
             <td>{{ app.title }}</td>
             <td>{{ app.company }}</td>

--- a/frontend/src/app/pages/applications/applications.component.spec.ts
+++ b/frontend/src/app/pages/applications/applications.component.spec.ts
@@ -129,3 +129,45 @@ describe('ApplicationsComponent', () => {
     expect(fixture.componentInstance.deletingId()).toBeNull();
   });
 });
+
+describe('ApplicationsComponent sorting/filtering', () => {
+  function mountWith(rows: ApplicationListItem[]): ApplicationsComponent {
+    TestBed.configureTestingModule({
+      imports: [ApplicationsComponent],
+      providers: [
+        provideRouter([]),
+        { provide: ApplicationsService, useValue: { list: () => of(rows), remove: () => of(undefined) } },
+      ],
+    });
+    const fixture = TestBed.createComponent(ApplicationsComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  it('defaults to created descending', () => {
+    const comp = mountWith([
+      makeItem({ id: 'a', created_at: '2026-01-01T00:00:00Z' }),
+      makeItem({ id: 'b', created_at: '2026-05-01T00:00:00Z' }),
+      makeItem({ id: 'c', created_at: '2026-03-01T00:00:00Z' }),
+    ]);
+    expect(comp.visibleApplications().map((a) => a.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('filters by query across title and company', () => {
+    const comp = mountWith([
+      makeItem({ id: 'a', title: 'Engineer', company: 'Globex' }),
+      makeItem({ id: 'b', title: 'Designer', company: 'Acme' }),
+    ]);
+    comp.query.set('acme');
+    expect(comp.visibleApplications().map((a) => a.id)).toEqual(['b']);
+  });
+
+  it('sorts by status ascending when toggled', () => {
+    const comp = mountWith([
+      makeItem({ id: 'a', status: 'saved' }),
+      makeItem({ id: 'b', status: 'applied' }),
+    ]);
+    comp.sort.toggle('status'); // text field default asc; "applied" < "saved"
+    expect(comp.visibleApplications().map((a) => a.id)).toEqual(['b', 'a']);
+  });
+});

--- a/frontend/src/app/pages/applications/applications.component.ts
+++ b/frontend/src/app/pages/applications/applications.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
 import { DatePipe, TitleCasePipe } from '@angular/common';
@@ -7,11 +7,16 @@ import { ApplicationListItem } from './models/application-list-item.model';
 import { ApplicationCreateDialogComponent } from './components/application-create-dialog.component';
 import { scoreColor as toScoreColor } from '../../core/utils/score-color';
 import { formatScorePercent } from '../../core/utils/format-score-percent';
+import { SortableHeaderComponent } from '../../core/components/sortable-header';
+import { createSortState } from '../../core/utils/sort-state';
+import { sortItems } from '../../core/utils/sort-items';
+
+type AppSortField = 'title' | 'company' | 'status' | 'match' | 'created';
 
 @Component({
   selector: 'app-applications',
   standalone: true,
-  imports: [DatePipe, TitleCasePipe, RouterLink, ApplicationCreateDialogComponent],
+  imports: [DatePipe, TitleCasePipe, RouterLink, ApplicationCreateDialogComponent, SortableHeaderComponent],
   templateUrl: './applications.component.html',
   styleUrl: './applications.component.scss',
 })
@@ -25,6 +30,45 @@ export class ApplicationsComponent implements OnInit {
   error = signal('');
   showCreateDialog = signal(false);
   deletingId = signal<string | null>(null);
+
+  // Client-side sort + filter over the fully-loaded list.
+  sort = createSortState<AppSortField>('created', 'desc', ['title', 'company', 'status']);
+  query = signal('');
+  statusFilter = signal('');
+
+  statuses = computed(() => [...new Set(this.applications().map((a) => a.status))].sort());
+
+  visibleApplications = computed(() => {
+    let rows = this.applications();
+    const q = this.query().trim().toLowerCase();
+    if (q) {
+      rows = rows.filter(
+        (a) => a.title.toLowerCase().includes(q) || a.company.toLowerCase().includes(q),
+      );
+    }
+    const status = this.statusFilter();
+    if (status) rows = rows.filter((a) => a.status === status);
+    const field = this.sort.field();
+    return sortItems(rows, (a) => this.sortValue(a, field), this.sort.dir());
+  });
+
+  private sortValue(a: ApplicationListItem, field: AppSortField): string | number | null {
+    switch (field) {
+      case 'title': return a.title;
+      case 'company': return a.company;
+      case 'status': return a.status;
+      case 'match': return a.latest_match_score;
+      case 'created': return a.created_at;
+    }
+  }
+
+  onQueryInput(event: Event): void {
+    this.query.set((event.target as HTMLInputElement).value);
+  }
+
+  onStatusFilterChange(event: Event): void {
+    this.statusFilter.set((event.target as HTMLSelectElement).value);
+  }
 
   ngOnInit(): void {
     this.load();

--- a/frontend/src/app/pages/interview/interview.component.html
+++ b/frontend/src/app/pages/interview/interview.component.html
@@ -121,19 +121,26 @@
       @if (stories().length > 0) {
         <div class="stats">
           <span class="stat">{{ stories().length }} story(s) in bank</span>
+          <select class="filter-control" [value]="competencyFilter()" (change)="onCompetencyFilterChange($event)" aria-label="Filter by competency">
+            <option value="">All competencies</option>
+            @for (c of competencyOptions; track c) {
+              <option [value]="c">{{ c | titlecase }}</option>
+            }
+          </select>
         </div>
         <div class="table-container">
           <table>
             <thead>
               <tr>
-                <th>Title</th>
-                <th>Competency</th>
+                <th appSortHeader [state]="storySort" field="title">Title</th>
+                <th appSortHeader [state]="storySort" field="competency">Competency</th>
                 <th>Situation</th>
+                <th appSortHeader [state]="storySort" field="created">Created</th>
                 <th>Actions</th>
               </tr>
             </thead>
             <tbody>
-              @for (story of stories(); track story.id) {
+              @for (story of visibleStories(); track story.id) {
                 <tr>
                   <td class="story-title">{{ story.title }}</td>
                   <td>
@@ -142,6 +149,7 @@
                     </span>
                   </td>
                   <td class="situation-preview">{{ story.situation }}</td>
+                  <td>{{ story.created_at | date:'mediumDate' }}</td>
                   <td>
                     <button (click)="deleteStory(story.id)" class="btn-danger">Delete</button>
                   </td>

--- a/frontend/src/app/pages/interview/interview.component.spec.ts
+++ b/frontend/src/app/pages/interview/interview.component.spec.ts
@@ -140,3 +140,54 @@ describe('InterviewComponent', () => {
     expect(cmp.prepError()).toBe('prep failed');
   });
 });
+
+describe('InterviewComponent story sorting/filtering', () => {
+  function mountWith(stories: ReturnType<typeof makeStory>[]): InterviewComponent {
+    const interview = {
+      listStories: () => of(stories),
+      createStory: () => of(makeStory()),
+      deleteStory: () => of(undefined),
+      prepare: () => of(makePrep()),
+    };
+    TestBed.configureTestingModule({
+      imports: [InterviewComponent],
+      providers: [
+        { provide: InterviewService, useValue: interview },
+        { provide: IngestionService, useValue: { getJob: () => of({ title: '', company: '', description: '' }) } },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParamMap: { get: () => null } } } },
+        { provide: ApplicationsService, useValue: { list: () => of([]) } },
+        { provide: Router, useValue: { navigate: () => {} } },
+      ],
+    });
+    const fixture = TestBed.createComponent(InterviewComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  it('defaults to created descending', () => {
+    const comp = mountWith([
+      makeStory({ id: 'a', created_at: '2026-01-01' }),
+      makeStory({ id: 'b', created_at: '2026-05-01' }),
+      makeStory({ id: 'c', created_at: '2026-03-01' }),
+    ]);
+    expect(comp.visibleStories().map((s) => s.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('filters by competency', () => {
+    const comp = mountWith([
+      makeStory({ id: 'a', competency: 'leadership' }),
+      makeStory({ id: 'b', competency: 'technical' }),
+    ]);
+    comp.competencyFilter.set('technical');
+    expect(comp.visibleStories().map((s) => s.id)).toEqual(['b']);
+  });
+
+  it('sorts by title ascending when toggled', () => {
+    const comp = mountWith([
+      makeStory({ id: 'a', title: 'Zeta' }),
+      makeStory({ id: 'b', title: 'Alpha' }),
+    ]);
+    comp.storySort.toggle('title'); // text default asc
+    expect(comp.visibleStories().map((s) => s.id)).toEqual(['b', 'a']);
+  });
+});

--- a/frontend/src/app/pages/interview/interview.component.ts
+++ b/frontend/src/app/pages/interview/interview.component.ts
@@ -1,19 +1,24 @@
-import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
 import { FormsModule } from '@angular/forms';
-import { TitleCasePipe } from '@angular/common';
+import { TitleCasePipe, DatePipe } from '@angular/common';
 import { InterviewService } from '../../core/services/interview.service';
 import { IngestionService } from '../../core/services/ingestion.service';
 import { Competency } from './models/competency.model';
 import { InterviewPrep } from './models/interview-prep.model';
 import { Story } from './models/story.model';
 import { ApplicationsPrepListComponent } from './components/applications-prep-list.component';
+import { SortableHeaderComponent } from '../../core/components/sortable-header';
+import { createSortState } from '../../core/utils/sort-state';
+import { sortItems } from '../../core/utils/sort-items';
+
+type StorySortField = 'title' | 'competency' | 'created';
 
 @Component({
   selector: 'app-interview',
   standalone: true,
-  imports: [FormsModule, TitleCasePipe, ApplicationsPrepListComponent],
+  imports: [FormsModule, TitleCasePipe, DatePipe, ApplicationsPrepListComponent, SortableHeaderComponent],
   templateUrl: './interview.component.html',
   styleUrl: './interview.component.scss',
 })
@@ -24,6 +29,30 @@ export class InterviewComponent implements OnInit {
   storiesError = signal('');
   showAddStoryForm = signal(false);
   addingStory = signal(false);
+
+  // Client-side sort + competency filter over the loaded story bank.
+  storySort = createSortState<StorySortField>('created', 'desc', ['title', 'competency']);
+  competencyFilter = signal<Competency | ''>('');
+
+  visibleStories = computed(() => {
+    let rows = this.stories();
+    const competency = this.competencyFilter();
+    if (competency) rows = rows.filter((s) => s.competency === competency);
+    const field = this.storySort.field();
+    return sortItems(rows, (s) => this.storySortValue(s, field), this.storySort.dir());
+  });
+
+  private storySortValue(s: Story, field: StorySortField): string {
+    switch (field) {
+      case 'title': return s.title;
+      case 'competency': return s.competency;
+      case 'created': return s.created_at;
+    }
+  }
+
+  onCompetencyFilterChange(event: Event): void {
+    this.competencyFilter.set((event.target as HTMLSelectElement).value as Competency | '');
+  }
 
   // New story form fields
   newTitle = signal('');

--- a/frontend/src/app/pages/tracking/tracking.component.html
+++ b/frontend/src/app/pages/tracking/tracking.component.html
@@ -2,6 +2,14 @@
   <div class="page-header">
     <h1>Pipeline</h1>
     <div class="header-actions">
+      <input
+        type="search"
+        class="filter-select"
+        placeholder="Search company or title…"
+        [value]="query()"
+        (input)="onQueryInput($event)"
+        aria-label="Search applications"
+      />
       <select (change)="onStatusFilterChange($event)" class="filter-select">
         <option value="">All Statuses</option>
         @for (s of statusOptions; track s) {
@@ -101,20 +109,20 @@
         <table>
           <thead>
             <tr>
-              <th>Company</th>
-              <th>Title</th>
+              <th appSortHeader [state]="sort" field="company">Company</th>
+              <th appSortHeader [state]="sort" field="title">Title</th>
               <th>Location</th>
               <th>Salary</th>
               <th>Source</th>
-              <th>Posted</th>
-              <th>Status</th>
-              <th>Applied</th>
+              <th appSortHeader [state]="sort" field="posted">Posted</th>
+              <th appSortHeader [state]="sort" field="status">Status</th>
+              <th appSortHeader [state]="sort" field="applied">Applied</th>
               <th>Notes</th>
               <th>Actions</th>
             </tr>
           </thead>
           <tbody>
-            @for (app of applications(); track app.id) {
+            @for (app of visibleApplications(); track app.id) {
               <tr>
                 <td class="company">{{ app.company }}</td>
                 <td class="title">

--- a/frontend/src/app/pages/tracking/tracking.component.spec.ts
+++ b/frontend/src/app/pages/tracking/tracking.component.spec.ts
@@ -242,3 +242,44 @@ describe('TrackingComponent', () => {
     expect(fixture.componentInstance.expandedResearchId()).toBeNull();
   });
 });
+
+describe('TrackingComponent sorting/filtering', () => {
+  function mountWith(rows: TrackedApplication[]): TrackingComponent {
+    TestBed.configureTestingModule({
+      imports: [TrackingComponent],
+      providers: [
+        { provide: TrackingService, useValue: { list: () => of(rows), create: () => of(rows[0]), update: () => of(rows[0]), delete: () => of(undefined), batchEvaluate: () => of({ results: [] }) } },
+        { provide: ResearchService, useValue: { research: () => of(makeResearch()), refresh: () => of(makeResearch()) } },
+      ],
+    });
+    const fixture = TestBed.createComponent(TrackingComponent);
+    fixture.detectChanges();
+    return fixture.componentInstance;
+  }
+
+  it('defaults to company ascending', () => {
+    const comp = mountWith([
+      makeApp({ id: 'a', company: 'Zebra' }),
+      makeApp({ id: 'b', company: 'Acme' }),
+    ]);
+    expect(comp.visibleApplications().map((a) => a.id)).toEqual(['b', 'a']);
+  });
+
+  it('sorts by posted date when the posted header is toggled', () => {
+    const comp = mountWith([
+      makeApp({ id: 'old', posted_date: '2026-01-01T00:00:00Z' }),
+      makeApp({ id: 'new', posted_date: '2026-05-01T00:00:00Z' }),
+    ]);
+    comp.sort.toggle('posted'); // non-text default desc
+    expect(comp.visibleApplications().map((a) => a.id)).toEqual(['new', 'old']);
+  });
+
+  it('filters by company/title query', () => {
+    const comp = mountWith([
+      makeApp({ id: 'a', company: 'Globex', title: 'Engineer' }),
+      makeApp({ id: 'b', company: 'Acme', title: 'Designer' }),
+    ]);
+    comp.query.set('designer');
+    expect(comp.visibleApplications().map((a) => a.id)).toEqual(['b']);
+  });
+});

--- a/frontend/src/app/pages/tracking/tracking.component.ts
+++ b/frontend/src/app/pages/tracking/tracking.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, OnInit, inject, signal } from '@angular/core';
+import { Component, DestroyRef, OnInit, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -12,11 +12,16 @@ import { CompanyResearch } from './models/company-research.model';
 import { TrackedApplication } from './models/tracked-application.model';
 import { UpdateApplicationRequest } from './models/update-application-request.model';
 import { scoreColor as toScoreColor } from '../../core/utils/score-color';
+import { SortableHeaderComponent } from '../../core/components/sortable-header';
+import { createSortState } from '../../core/utils/sort-state';
+import { sortItems } from '../../core/utils/sort-items';
+
+type TrackSortField = 'company' | 'title' | 'status' | 'posted' | 'applied';
 
 @Component({
   selector: 'app-tracking',
   standalone: true,
-  imports: [FormsModule, TitleCasePipe, DatePipe, RouterLink],
+  imports: [FormsModule, TitleCasePipe, DatePipe, RouterLink, SortableHeaderComponent],
   templateUrl: './tracking.component.html',
   styleUrl: './tracking.component.scss',
 })
@@ -26,6 +31,37 @@ export class TrackingComponent implements OnInit {
   error = signal('');
   statusFilter = signal<ApplicationStatus | ''>('');
   showAddForm = signal(false);
+
+  // Client-side sort + text search over the loaded list. The status filter
+  // above stays server-side (re-queries); these compose on top of its result.
+  sort = createSortState<TrackSortField>('company', 'asc', ['company', 'title', 'status']);
+  query = signal('');
+
+  visibleApplications = computed(() => {
+    let rows = this.applications();
+    const q = this.query().trim().toLowerCase();
+    if (q) {
+      rows = rows.filter(
+        (a) => a.company.toLowerCase().includes(q) || a.title.toLowerCase().includes(q),
+      );
+    }
+    const field = this.sort.field();
+    return sortItems(rows, (a) => this.sortValue(a, field), this.sort.dir());
+  });
+
+  private sortValue(a: TrackedApplication, field: TrackSortField): string | null {
+    switch (field) {
+      case 'company': return a.company;
+      case 'title': return a.title;
+      case 'status': return a.status;
+      case 'posted': return a.posted_date;
+      case 'applied': return a.applied_at;
+    }
+  }
+
+  onQueryInput(event: Event): void {
+    this.query.set((event.target as HTMLInputElement).value);
+  }
 
   newTitle = signal('');
   newCompany = signal('');


### PR DESCRIPTION
@
## Summary

Phase 2 of the sorting & filtering initiative. Stacked on #72 (Phase 1) — **merge #72 first**, then this retargets to `main`.

Adds **client-side** column sorting + filtering to three bare lists (fully loaded into the browser, so zero backend change), reusing the Phase 1 foundation (`createSortState`, `sortItems`, `SortableHeaderComponent`).

- **Applications** — sortable Title/Company/Status/Match/Created headers; status `select` + title/company search.
- **Tracking** — sortable Company/Title/Status/Posted/Applied headers; company/title search (existing server-side status filter kept).
- **Interview Stories** — sortable Title/Competency/Created headers (new Created column) + competency filter.

Each page derives a `visibleX()` computed (filter → `sortItems`) that the template iterates; the sortable headers drive the sort signals, so no extra network calls.

## Testing

Frontend: 261 passed (45 files), production build clean.

## Design docs

- Spec: `docs/superpowers/specs/2026-06-07-sorting-filtering-design.md`
- Phase 2 plan: `docs/superpowers/plans/2026-06-07-list-sorting-filtering-phase2.md`

Follow-up: Phase 3 (Cover Letters, Admin tables, Autohunt, Outreach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@