### PR TITLE
fix(alembic): ensure vector_embeddings exists (023 drift repair)

### DIFF
--- a/backend/alembic/versions/023_ensure_vector_embeddings.py
+++ b/backend/alembic/versions/023_ensure_vector_embeddings.py
@@ -1,0 +1,55 @@
+"""ensure vector_embeddings exists (drift repair)
+
+Reconciliation migration for environments whose `alembic_version` advanced past
+revision 014 without its `vector_embeddings` table ever materializing on the
+volume (observed on a long-lived dev DB stamped at a later revision; see the
+2026-05/06 alembic-drift fixes). Migration 014 is correct and creates the table
+on a fresh chain, but a drifted DB already records 014 as applied, so alembic
+never re-runs it and the PgVectorStore queries fail with
+`relation "vector_embeddings" does not exist` (the SemanticPreRanker then
+degrades to passthrough — semantic ANN pre-ranking silently disabled).
+
+This re-asserts 014's objects idempotently: a no-op on healthy databases
+(`IF NOT EXISTS`), and the missing table/index get created on drifted ones.
+Schema is kept byte-for-byte identical to migration 014.
+
+Revision ID: 023
+Revises: 022
+Create Date: 2026-06-07
+"""
+import os
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "023"
+down_revision: Union[str, None] = "022"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Vector dimension tracks EMBEDDING_DIM in config (all-mpnet-base-v2 = 768),
+# mirroring migration 014 so a repaired table matches the original schema.
+_DIM = int(os.environ.get("EMBEDDING_DIM", "768"))
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+    op.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS vector_embeddings (
+            id TEXT PRIMARY KEY,
+            embedding vector({_DIM}) NOT NULL,
+            metadata JSONB NOT NULL DEFAULT '{{}}'::jsonb
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vector_embeddings_embedding "
+        "ON vector_embeddings USING hnsw (embedding vector_cosine_ops)"
+    )
+
+
+def downgrade() -> None:
+    # No-op: the table's lifecycle is owned by migration 014's down path. This
+    # repair migration must not drop an object it may not have created.
+    pass


### PR DESCRIPTION
## Problem

On a running dev DB, the ingestion page logged repeatedly:

```
psycopg2.errors.UndefinedTable: relation "vector_embeddings" does not exist
SemanticPreRanker: vector store search failed — passthrough
```

Jobs still loaded (the pre-ranker degrades gracefully), but ANN semantic pre-ranking was silently disabled.

## Root cause

Schema drift. The DB recorded `alembic_version = 022` (head) — so alembic believed migration `014_create_vector_embeddings` had run — but its `vector_embeddings` table was never materialized on that long-lived volume (consistent with the earlier alembic-drift reconciliation). Migration 014 is correct (a fresh `upgrade head` creates the table, which is why CI/integration stay green), but a drifted DB already records 014 as applied, so alembic never re-runs it.

## Fix

A reconciliation migration `023` that re-asserts 014's objects **idempotently** (`CREATE EXTENSION/TABLE/INDEX IF NOT EXISTS`, schema byte-for-byte identical to 014, dim from `EMBEDDING_DIM`):

- **Healthy DBs:** no-op (objects already exist).
- **Drifted DBs:** the missing table + HNSW index get created on `alembic upgrade head`.

`downgrade()` is intentionally a no-op — the table's lifecycle is owned by 014's down path; a repair migration must not drop an object it may not have created.

## Verification

- `alembic heads` → single linear head `023`.
- Applied `022 -> 023` against a live `pgvector/pgvector:pg16` DB: table created, the PgVectorStore ANN query (`embedding <=> CAST(... AS vector)`) runs cleanly (0 rows on the empty table, no error).
- `ruff` clean.

No new ORM models (the table is off-ORM, queried via raw SQL), so no autogenerate/`alembic check` delta on a fresh DB.

> Note: after this lands, the table is empty until embeddings are indexed — `POST /ingestion/backfill-embeddings` populates existing jobs so ANN pre-ranking has data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
