### PR TITLE
perf(ingestion): sort-only fast path to skip full rescore pipeline (#76)

### DIFF
--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -160,6 +160,7 @@ async def list_jobs(
     seniority: Annotated[list[SeniorityLevel] | None, Query()] = None,
     max_years_experience: int | None = None,
     include_closed: bool = False,
+    rescore: bool = True,
 ) -> PaginatedResult:
     # Default min_score from settings when the client doesn't specify one
     # (pass min_score=0 explicitly to disable the filter). Tests mount the
@@ -183,36 +184,46 @@ async def list_jobs(
     if effective_sort not in _ALLOWED_SORTS:
         effective_sort = "match_desc"
 
-    # Pre-compute skill-overlap per job (cheap) and fold in any *persisted*
-    # semantic score so the sort key matches the displayed value. Keep the
-    # raw skill score in a side dict so we can re-combine after page-level
-    # semantic scoring without recomputing the overlap.
+    # Raw skill-overlap per job, kept so the page-level semantic re-combine can
+    # reuse it without recomputing. Populated only on the rescore path.
     skill_by_id: dict[str, float | None] = {}
-    if candidate_skills:
-        skill_set = {s.lower() for s in candidate_skills if s}
-        for job in all_jobs:
-            skill_by_id[job.id] = score_job_against_skills(job, skill_set)
-        all_jobs = [
-            j.model_copy(
-                update={"match_score": combine_fit_score(skill_by_id[j.id], j.semantic_score)}
+
+    # `rescore=False` is the sort-only / pagination fast path (#76): the corpus
+    # scores were already computed and persisted by a prior full request, and a
+    # reorder doesn't change them. Skip the whole global block — the expensive
+    # part — and sort/paginate directly off the persisted match_score below.
+    # Clients send rescore=False only for pure reorder/pagination; any filter,
+    # tab, feedback or fetch change keeps the default (full rescore).
+    if rescore:
+        # Pre-compute skill-overlap per job (cheap) and fold in any *persisted*
+        # semantic score so the sort key matches the displayed value.
+        if candidate_skills:
+            skill_set = {s.lower() for s in candidate_skills if s}
+            for job in all_jobs:
+                skill_by_id[job.id] = score_job_against_skills(job, skill_set)
+            all_jobs = [
+                j.model_copy(
+                    update={
+                        "match_score": combine_fit_score(skill_by_id[j.id], j.semantic_score)
+                    }
+                )
+                for j in all_jobs
+            ]
+
+        # GLOBAL pre-rank BEFORE pagination (#18 fix): use the pgvector ANN to
+        # set semantic_score + combined match_score across the WHOLE corpus, so
+        # a high-semantic / low-keyword job can reach page 1 instead of being
+        # scored only after it's already been paginated off. Passthrough (no
+        # vector store, empty profile, etc.) leaves the skill-only ordering.
+        if pre_ranker is not None:
+            all_jobs = await pre_ranker.rerank(
+                all_jobs, skill_by_id, candidate_skills, candidate_summary, bucket=tab
             )
-            for j in all_jobs
-        ]
 
-    # GLOBAL pre-rank BEFORE pagination (#18 fix): use the pgvector ANN to set
-    # semantic_score + combined match_score across the WHOLE corpus, so a
-    # high-semantic / low-keyword job can reach page 1 instead of being scored
-    # only after it's already been paginated off. Passthrough (no vector store,
-    # empty profile, etc.) leaves the skill-only ordering intact.
-    if pre_ranker is not None:
-        all_jobs = await pre_ranker.rerank(
-            all_jobs, skill_by_id, candidate_skills, candidate_summary, bucket=tab
-        )
-
-    if candidate_skills:
-        persist_scores_batch(
-            [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in all_jobs]
-        )
+        if candidate_skills:
+            persist_scores_batch(
+                [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in all_jobs]
+            )
 
     params = JobQueryParams(
         page=page,
@@ -239,7 +250,8 @@ async def list_jobs(
     # the persisted score feeds back into the sort on subsequent calls.
     needs_semantic = [j for j in result.jobs if j.semantic_score is None]
     if (
-        semantic_scoring is not None
+        rescore
+        and semantic_scoring is not None
         and (candidate_skills or candidate_summary)
         and needs_semantic
     ):

--- a/backend/tests/unit/ingestion/test_routes.py
+++ b/backend/tests/unit/ingestion/test_routes.py
@@ -365,3 +365,127 @@ async def test_pre_ranker_promotes_job_to_page_one_before_pagination() -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["jobs"][0]["id"] == "job-2"  # pre-ranked to the top, reached page 1
+
+
+# ---------------------------------------------------------------------------
+# #76 — sort-only fast path: rescore=false skips the global ANN re-rank and the
+# full-corpus persist write (scores are already persisted; a reorder is cheap).
+# ---------------------------------------------------------------------------
+
+
+class _Section:
+    content = "experienced python engineer"
+
+
+class _Profile:
+    skills = ["python"]
+    sections = [_Section()]
+
+
+class FakeProfileWithSkills:
+    async def list_profiles(self):
+        return [_Profile()]
+
+
+def _scored_jobs() -> list[NormalizedJob]:
+    """Three board jobs carrying *persisted* match scores (semantic still None)."""
+    scores = {"job-0": 0.3, "job-1": 0.9, "job-2": 0.6}
+    return [
+        NormalizedJob(
+            id=jid, title=f"T{jid}", company="Co", description="d", skills=["python"],
+            source="remotive", source_type="api", language="en",
+            url=f"https://e.com/{jid}", match_score=score,
+        )
+        for jid, score in scores.items()
+    ]
+
+
+class _RecordingPreRanker:
+    def __init__(self) -> None:
+        self.called = False
+
+    async def rerank(self, corpus, skill_by_id, skills, summary, bucket):
+        self.called = True
+        # If it ran, it would flip the order — used to prove it did NOT run.
+        return list(reversed(corpus))
+
+
+def _make_scored_app(pre_ranker, persisted: list):
+    from hiresense.ingestion.api.dependencies import get_pre_ranker
+
+    jobs = _scored_jobs()
+
+    class _Orch:
+        async def run(self, filters=None):
+            return []
+
+        def list_jobs(self):
+            return list(jobs)
+
+        def persist_scores(self, *a):
+            pass
+
+        def persist_scores_batch(self, updates):
+            persisted.append(updates)
+
+    app = FastAPI()
+    app.dependency_overrides[get_ingestion_orchestrator] = lambda: _Orch()
+    app.dependency_overrides[get_portal_scanner] = lambda: FakeScanner()
+    app.dependency_overrides[get_profile_service] = lambda: FakeProfileWithSkills()
+    app.dependency_overrides[get_semantic_scoring] = lambda: None
+    app.dependency_overrides[get_pre_ranker] = lambda: pre_ranker
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_rescore_false_skips_pre_rank_and_persist() -> None:
+    pre = _RecordingPreRanker()
+    persisted: list = []
+    app = _make_scored_app(pre, persisted)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get(
+            "/ingestion/jobs",
+            params={"tab": "boards", "rescore": "false", "min_score": 0},
+        )
+
+    assert resp.status_code == 200
+    # The global ANN re-rank must not run on a sort-only request...
+    assert pre.called is False
+    # ...nor the full-corpus score persist write.
+    assert persisted == []
+
+
+@pytest.mark.asyncio
+async def test_rescore_false_sorts_by_persisted_scores() -> None:
+    pre = _RecordingPreRanker()
+    persisted: list = []
+    app = _make_scored_app(pre, persisted)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # Default sort = match_desc; ordering must come from the persisted scores
+        # (0.9, 0.6, 0.3), NOT from the pre-ranker's reversal.
+        resp = await client.get(
+            "/ingestion/jobs",
+            params={"tab": "boards", "rescore": "false", "min_score": 0},
+        )
+
+    assert resp.status_code == 200
+    ids = [j["id"] for j in resp.json()["jobs"]]
+    assert ids == ["job-1", "job-2", "job-0"]
+
+
+@pytest.mark.asyncio
+async def test_rescore_default_still_runs_pre_rank_and_persist() -> None:
+    # Regression: omitting `rescore` keeps the full pipeline (rescore defaults True).
+    pre = _RecordingPreRanker()
+    persisted: list = []
+    app = _make_scored_app(pre, persisted)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/ingestion/jobs", params={"tab": "boards", "min_score": 0})
+
+    assert resp.status_code == 200
+    assert pre.called is True
+    assert persisted != []

--- a/docs/superpowers/specs/2026-06-07-sorting-filtering-design.md
+++ b/docs/superpowers/specs/2026-06-07-sorting-filtering-design.md
@@ -122,6 +122,33 @@ Each phase is an independent plan + PR.
   invalid→default, alias mapping) and for each touched endpoint's repository
   ordering. Suite stays Postgres-free per project convention.
 
+## Follow-up: sort-only fast path (#76)
+
+**Date:** 2026-06-08 · **Status:** Implemented
+
+After the column-sorting work landed (PRs #72–#74), every sort/filter change on
+the **ingestion** page (the one server-side-paginated list) re-ran the full
+scoring pipeline on the request path: skill-overlap across the corpus, the global
+pgvector ANN pre-rank, a full-corpus score persist write, and a blocking Tier-1
+LLM quick-scoring call for the visible page. A pure reorder doesn't change any
+score, so this was wasted work — and the LLM round-trip dominated the latency
+(#76).
+
+**Fix.** `GET /ingestion/jobs` gains a `rescore: bool = True` query param. When
+`False` (the sort-only / pagination fast path), the handler skips the three
+global ops — skill recompute, ANN re-rank, and the full-corpus persist write —
+plus the global page-level semantic-fill block, and sorts/paginates directly off
+the **already-persisted** `match_score` / `semantic_score`. Bounded, cached
+Tier-1 quick scoring of the visible page still runs (cache hits are instant; only
+newly-surfaced uncached jobs cost one batched LLM call).
+
+The frontend sends `rescore=false` only for pure reorder/pagination
+(`onSorted`, `onPageChange`, `onPageSizeChange`). Filter, tab-switch, feedback
+re-rank, and fetch keep the default full rescore, because those can change which
+jobs match or their scores. The first load (`ngOnInit`) is a full rescore, so the
+corpus is always fully scored before any fast-path request relies on persisted
+scores.
+
 ## Non-goals
 
 - No multi-column / secondary sort.

--- a/frontend/src/app/core/services/ingestion.service.spec.ts
+++ b/frontend/src/app/core/services/ingestion.service.spec.ts
@@ -1,0 +1,44 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { IngestionService } from './ingestion.service';
+import { environment } from '../../../environments/environment';
+
+describe('IngestionService', () => {
+  let service: IngestionService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [IngestionService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(IngestionService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  const empty = { jobs: [], total: 0, page: 1, page_size: 20, total_pages: 0 };
+
+  it('queryJobs omits the rescore param by default (full scoring pipeline)', () => {
+    service.queryJobs('boards', 1, 20).subscribe();
+    const req = httpMock.expectOne((r) => r.url === `${environment.apiUrl}/ingestion/jobs`);
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.has('rescore')).toBe(false);
+    req.flush(empty);
+  });
+
+  it('queryJobs sends rescore=false for the sort-only fast path (#76)', () => {
+    service.queryJobs('boards', 2, 20, {}, false, false).subscribe();
+    const req = httpMock.expectOne((r) => r.url === `${environment.apiUrl}/ingestion/jobs`);
+    expect(req.request.params.get('rescore')).toBe('false');
+    req.flush(empty);
+  });
+
+  it('queryJobs omits rescore when rescore=true is passed explicitly', () => {
+    service.queryJobs('boards', 1, 20, {}, false, true).subscribe();
+    const req = httpMock.expectOne((r) => r.url === `${environment.apiUrl}/ingestion/jobs`);
+    expect(req.request.params.has('rescore')).toBe(false);
+    req.flush(empty);
+  });
+});

--- a/frontend/src/app/core/services/ingestion.service.ts
+++ b/frontend/src/app/core/services/ingestion.service.ts
@@ -31,6 +31,10 @@ export class IngestionService {
     pageSize: number,
     filters: JobFilters = {},
     includeClosed = false,
+    // Pure reorder/pagination changes pass rescore=false so the server skips
+    // the global ANN re-rank + full-corpus persist write and just sorts the
+    // already-persisted scores (#76). Defaults to true (full scoring pipeline).
+    rescore = true,
   ): Observable<PaginatedJobsResponse> {
     let params = new HttpParams()
       .set('tab', tab)
@@ -38,6 +42,7 @@ export class IngestionService {
       .set('page_size', pageSize.toString());
 
     if (includeClosed) params = params.set('include_closed', 'true');
+    if (!rescore) params = params.set('rescore', 'false');
 
     if (filters.source) params = params.set('source', filters.source);
     if (filters.keyword) params = params.set('keyword', filters.keyword);

--- a/frontend/src/app/pages/ingestion/ingestion.component.ts
+++ b/frontend/src/app/pages/ingestion/ingestion.component.ts
@@ -135,12 +135,22 @@ export class IngestionComponent implements OnInit {
     this.loadJobs();
   }
 
-  loadJobs(): void {
+  // `rescore` defaults to true (full scoring pipeline). Pure reorder/pagination
+  // callers pass false so the server short-circuits the global re-rank + persist
+  // and just sorts the already-persisted scores (#76).
+  loadJobs(rescore = true): void {
     this.loading.set(true);
     this.error.set('');
     const filtersWithSort = { ...this.filters(), sort: this.sort.token() as JobFilters['sort'] };
     this.ingestionService
-      .queryJobs(this.activeTab(), this.page(), this.pageSize(), filtersWithSort, this.includeClosed())
+      .queryJobs(
+        this.activeTab(),
+        this.page(),
+        this.pageSize(),
+        filtersWithSort,
+        this.includeClosed(),
+        rescore,
+      )
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
         next: (res) => {
@@ -221,13 +231,13 @@ export class IngestionComponent implements OnInit {
 
   onPageChange(newPage: number): void {
     this.page.set(newPage);
-    this.loadJobs();
+    this.loadJobs(false); // pagination — scores unchanged, no rescore
   }
 
   onPageSizeChange(newSize: number): void {
     this.pageSize.set(newSize);
     this.page.set(1);
-    this.loadJobs();
+    this.loadJobs(false); // pagination — scores unchanged, no rescore
   }
 
   openDetail(job: NormalizedJob): void {
@@ -297,7 +307,7 @@ export class IngestionComponent implements OnInit {
 
   onSorted(): void {
     this.page.set(1);
-    this.loadJobs();
+    this.loadJobs(false); // reorder only — scores unchanged, no rescore
   }
 
   onFeedback(jobId: string, kind: FeedbackKind): void {


### PR DESCRIPTION
## What

On the **ingestion** page (the only server-side-paginated list), changing a sort column or page re-ran the **entire** scoring pipeline on the request path — skill-overlap across the corpus, the global pgvector ANN pre-rank, a full-corpus score persist write, and a **blocking Tier-1 LLM quick-scoring call** for the visible page. A pure reorder never changes a score, so this was wasted work, and the LLM round-trip dominated the latency.

## How

`GET /ingestion/jobs` gains a `rescore: bool = True` query param:

- **`rescore=false`** (sort-only / pagination fast path): skips the three global ops — skill recompute, ANN re-rank, full-corpus persist write — *and* the global page-level semantic-fill block, sorting/paginating directly off the **already-persisted** `match_score` / `semantic_score`. Cached Tier-1 quick scoring of the visible page still runs (cache hits are instant; only newly-surfaced uncached jobs cost one batched LLM call).
- **`rescore=true`** (default): unchanged full pipeline.

The frontend sends `rescore=false` only for pure reorder/pagination (`onSorted`, `onPageChange`, `onPageSizeChange`). Filter, tab-switch, feedback re-rank, fetch, and the first load (`ngOnInit`) keep the default full rescore — so the corpus is always fully scored before any fast-path request relies on persisted scores.

## Tests

- **Backend:** 3 new route tests — `rescore=false` skips the ANN re-rank + persist write, sorts by persisted scores, and (regression) the default still runs the full pipeline. Full ingestion unit suite: 315 passing. `ruff check` clean.
- **Frontend:** new `ingestion.service.spec.ts` (3 tests) covering the param wiring. `ng lint` clean.

Design doc updated: `docs/superpowers/specs/2026-06-07-sorting-filtering-design.md` (Follow-up: sort-only fast path).

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)