### PR TITLE
fix(ingestion): consistent cross-source match ranking + defer LLM on re-sort (#76)

### DIFF
--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -184,46 +184,60 @@ async def list_jobs(
     if effective_sort not in _ALLOWED_SORTS:
         effective_sort = "match_desc"
 
-    # Raw skill-overlap per job, kept so the page-level semantic re-combine can
-    # reuse it without recomputing. Populated only on the rescore path.
+    # Pre-compute skill-overlap per job (cheap) and fold in any *persisted*
+    # semantic score so the sort key matches the displayed value. Keep the
+    # raw skill score in a side dict so we can re-combine after page-level
+    # semantic scoring without recomputing the overlap.
     skill_by_id: dict[str, float | None] = {}
-
-    # `rescore=False` is the sort-only / pagination fast path (#76): the corpus
-    # scores were already computed and persisted by a prior full request, and a
-    # reorder doesn't change them. Skip the whole global block — the expensive
-    # part — and sort/paginate directly off the persisted match_score below.
-    # Clients send rescore=False only for pure reorder/pagination; any filter,
-    # tab, feedback or fetch change keeps the default (full rescore).
-    if rescore:
-        # Pre-compute skill-overlap per job (cheap) and fold in any *persisted*
-        # semantic score so the sort key matches the displayed value.
-        if candidate_skills:
-            skill_set = {s.lower() for s in candidate_skills if s}
-            for job in all_jobs:
-                skill_by_id[job.id] = score_job_against_skills(job, skill_set)
-            all_jobs = [
-                j.model_copy(
-                    update={
-                        "match_score": combine_fit_score(skill_by_id[j.id], j.semantic_score)
-                    }
-                )
-                for j in all_jobs
-            ]
-
-        # GLOBAL pre-rank BEFORE pagination (#18 fix): use the pgvector ANN to
-        # set semantic_score + combined match_score across the WHOLE corpus, so
-        # a high-semantic / low-keyword job can reach page 1 instead of being
-        # scored only after it's already been paginated off. Passthrough (no
-        # vector store, empty profile, etc.) leaves the skill-only ordering.
-        if pre_ranker is not None:
-            all_jobs = await pre_ranker.rerank(
-                all_jobs, skill_by_id, candidate_skills, candidate_summary, bucket=tab
+    if candidate_skills:
+        skill_set = {s.lower() for s in candidate_skills if s}
+        for job in all_jobs:
+            skill_by_id[job.id] = score_job_against_skills(job, skill_set)
+        all_jobs = [
+            j.model_copy(
+                update={"match_score": combine_fit_score(skill_by_id[j.id], j.semantic_score)}
             )
+            for j in all_jobs
+        ]
 
-        if candidate_skills:
-            persist_scores_batch(
-                [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in all_jobs]
-            )
+    # GLOBAL pre-rank BEFORE pagination (#18 fix): use the pgvector ANN to set
+    # semantic_score + combined match_score across the WHOLE corpus, so a
+    # high-semantic / low-keyword job can reach page 1 instead of being scored
+    # only after it's already been paginated off. Passthrough (no vector store,
+    # empty profile, etc.) leaves the skill-only ordering intact.
+    if pre_ranker is not None:
+        all_jobs = await pre_ranker.rerank(
+            all_jobs, skill_by_id, candidate_skills, candidate_summary, bucket=tab
+        )
+
+    if candidate_skills:
+        persist_scores_batch(
+            [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in all_jobs]
+        )
+
+    # GLOBAL apply of already-cached Tier-1 LLM scores BEFORE pagination. The
+    # LLM quick score is the accurate, displayed match value, but it was only
+    # ever applied to the visible page — so the global sort ranked by the
+    # heuristic blend, which is source-biased (hn_hiring scores via verbose
+    # text-mention and saturates; getonboard's structured tags get dilution-
+    # capped low). A genuinely strong job from a "weak-heuristic" source was
+    # buried off page 1 and never LLM-scored in the all-sources view, even
+    # though it ranked highly once its source was filtered.
+    #
+    # Reading the LLM cache (keyed by job_id+profile_hash, source-agnostic) for
+    # the WHOLE corpus and overriding match_score where we have a score makes
+    # the global ranking consistent with the displayed value across every
+    # filter. This is cache-only (`llm_on_miss=False`) — no LLM calls, one bulk
+    # read — so it's safe on the sort-only fast path too. Visible-page cache
+    # misses are filled by the page-level pass below and improve later rankings.
+    # Applied AFTER persist so the persisted row score stays the heuristic blend
+    # (the LLM score lives in its own cache); this override is request-scoped.
+    if quick_scoring is not None and (candidate_skills or candidate_summary):
+        cached_quick = await quick_scoring.score_page(
+            all_jobs, candidate_skills, candidate_summary, llm_on_miss=False
+        )
+        if cached_quick:
+            all_jobs = [_apply_quick(j, cached_quick.get(j.id)) for j in all_jobs]
 
     params = JobQueryParams(
         page=page,
@@ -250,8 +264,7 @@ async def list_jobs(
     # the persisted score feeds back into the sort on subsequent calls.
     needs_semantic = [j for j in result.jobs if j.semantic_score is None]
     if (
-        rescore
-        and semantic_scoring is not None
+        semantic_scoring is not None
         and (candidate_skills or candidate_summary)
         and needs_semantic
     ):
@@ -294,9 +307,18 @@ async def list_jobs(
     # min_score gate never culls a job on a not-yet-computed LLM score. The LLM
     # score replaces the displayed match_score when available; jobs without one
     # keep the heuristic blend. Cache hits make repeat views instant.
+    #
+    # `rescore=False` is the sort-only / pagination fast path (#76): the result
+    # set and order are already determined by the (cheap) skill + ANN + min_score
+    # steps above, which still ran. We only DEFER the blocking LLM round-trip —
+    # quick scoring runs cache-only (`llm_on_miss=False`), so a reorder reuses
+    # already-computed scores instantly and newly-surfaced jobs show their
+    # heuristic blend until the next full rescore fills the cache. Clients send
+    # rescore=False only for pure reorder/pagination; any filter, tab, feedback
+    # or fetch change keeps the default (full LLM scoring of the page).
     if quick_scoring is not None and (candidate_skills or candidate_summary):
         quick_results = await quick_scoring.score_page(
-            result.jobs, candidate_skills, candidate_summary
+            result.jobs, candidate_skills, candidate_summary, llm_on_miss=rescore
         )
         if quick_results:
             result.jobs = [_apply_quick(j, quick_results.get(j.id)) for j in result.jobs]

--- a/backend/src/hiresense/ingestion/domain/quick_scoring_service.py
+++ b/backend/src/hiresense/ingestion/domain/quick_scoring_service.py
@@ -106,18 +106,30 @@ class QuickScoringService:
         jobs: list[NormalizedJob],
         candidate_skills: list[str],
         candidate_summary: str,
+        *,
+        llm_on_miss: bool = True,
     ) -> dict[str, QuickMatchResult]:
         """Return quick results keyed by job_id for the jobs we could score.
 
         Jobs absent from the returned dict have no LLM score (cache miss + no
         LLM, or a failed batch) — the caller falls back to the heuristic score.
+
+        When ``llm_on_miss`` is False, cache misses are NOT sent to the LLM:
+        only already-cached scores are returned. This is the #76 sort-only fast
+        path — a pure reorder reuses cached scores instantly and never pays the
+        blocking LLM round-trip; newly-surfaced jobs keep their heuristic score
+        until a full rescore fills the cache.
         """
         if not jobs:
             return {}
         profile_hash = score_profile_hash(candidate_skills, candidate_summary)
         hits = self._cache_repo.get_quick_bulk([j.id for j in jobs], profile_hash)
 
-        if self._llm is None or (not candidate_skills and not candidate_summary):
+        if (
+            not llm_on_miss
+            or self._llm is None
+            or (not candidate_skills and not candidate_summary)
+        ):
             return hits
 
         misses = [j for j in jobs if j.id not in hits]

--- a/backend/tests/unit/ingestion/test_quick_scoring_service.py
+++ b/backend/tests/unit/ingestion/test_quick_scoring_service.py
@@ -94,6 +94,25 @@ async def test_no_llm_returns_only_cache_hits():
 
 
 @pytest.mark.asyncio
+async def test_llm_on_miss_false_returns_only_cache_hits_without_calling_llm():
+    # #76 sort-only fast path: on a pure reorder we apply already-cached quick
+    # scores instantly and never fire the blocking LLM call for cache misses.
+    cached = QuickMatchResult(job_id="a", score=0.9, verdict=QuickMatchVerdict.STRONG)
+    cache = StubCache({"a": cached})
+    llm = StubLLM(json.dumps([{"ref": 1, "score": 0.3, "verdict": "weak"}]))
+    svc = QuickScoringService(llm=llm, cache_repo=cache)
+
+    results = await svc.score_page(
+        [_job("a"), _job("b")], ["python"], "summary", llm_on_miss=False
+    )
+
+    assert set(results) == {"a"}  # only the cache hit; the miss is left unscored
+    assert results["a"].score == 0.9
+    assert llm.calls == []  # blocking LLM round-trip skipped
+    assert cache.upserts == []  # nothing newly persisted
+
+
+@pytest.mark.asyncio
 async def test_no_profile_skips_llm():
     llm = StubLLM("[]")
     svc = QuickScoringService(llm=llm, cache_repo=StubCache())

--- a/backend/tests/unit/ingestion/test_routes.py
+++ b/backend/tests/unit/ingestion/test_routes.py
@@ -368,8 +368,9 @@ async def test_pre_ranker_promotes_job_to_page_one_before_pagination() -> None:
 
 
 # ---------------------------------------------------------------------------
-# #76 — sort-only fast path: rescore=false skips the global ANN re-rank and the
-# full-corpus persist write (scores are already persisted; a reorder is cheap).
+# #76 — sort-only fast path: a pure reorder (rescore=false) must KEEP the full
+# skill+ANN+min_score pipeline (so the result set/order is unchanged) but defer
+# the blocking Tier-1 LLM call — quick scoring runs cache-only (llm_on_miss=False).
 # ---------------------------------------------------------------------------
 
 
@@ -387,33 +388,35 @@ class FakeProfileWithSkills:
         return [_Profile()]
 
 
-def _scored_jobs() -> list[NormalizedJob]:
-    """Three board jobs carrying *persisted* match scores (semantic still None)."""
-    scores = {"job-0": 0.3, "job-1": 0.9, "job-2": 0.6}
-    return [
-        NormalizedJob(
-            id=jid, title=f"T{jid}", company="Co", description="d", skills=["python"],
-            source="remotive", source_type="api", language="en",
-            url=f"https://e.com/{jid}", match_score=score,
-        )
-        for jid, score in scores.items()
-    ]
-
-
 class _RecordingPreRanker:
     def __init__(self) -> None:
         self.called = False
 
     async def rerank(self, corpus, skill_by_id, skills, summary, bucket):
         self.called = True
-        # If it ran, it would flip the order — used to prove it did NOT run.
-        return list(reversed(corpus))
+        return list(corpus)
 
 
-def _make_scored_app(pre_ranker, persisted: list):
-    from hiresense.ingestion.api.dependencies import get_pre_ranker
+class _RecordingQuickScoring:
+    def __init__(self) -> None:
+        self.llm_on_miss_calls: list[bool] = []
 
-    jobs = _scored_jobs()
+    async def score_page(self, jobs, skills, summary, *, llm_on_miss=True):
+        self.llm_on_miss_calls.append(llm_on_miss)
+        return {}
+
+
+def _make_rescore_app(pre_ranker, quick_scoring):
+    from hiresense.ingestion.api.dependencies import get_pre_ranker, get_quick_scoring
+
+    jobs = [
+        NormalizedJob(
+            id=f"job-{i}", title=f"T{i}", company="Co", description="d", skills=["python"],
+            source="remotive", source_type="api", language="en",
+            url=f"https://e.com/{i}", match_score=0.5,
+        )
+        for i in range(3)
+    ]
 
     class _Orch:
         async def run(self, filters=None):
@@ -426,7 +429,7 @@ def _make_scored_app(pre_ranker, persisted: list):
             pass
 
         def persist_scores_batch(self, updates):
-            persisted.append(updates)
+            pass
 
     app = FastAPI()
     app.dependency_overrides[get_ingestion_orchestrator] = lambda: _Orch()
@@ -434,15 +437,16 @@ def _make_scored_app(pre_ranker, persisted: list):
     app.dependency_overrides[get_profile_service] = lambda: FakeProfileWithSkills()
     app.dependency_overrides[get_semantic_scoring] = lambda: None
     app.dependency_overrides[get_pre_ranker] = lambda: pre_ranker
+    app.dependency_overrides[get_quick_scoring] = lambda: quick_scoring
     app.include_router(router)
     return app
 
 
 @pytest.mark.asyncio
-async def test_rescore_false_skips_pre_rank_and_persist() -> None:
+async def test_rescore_false_defers_llm_but_keeps_pipeline() -> None:
     pre = _RecordingPreRanker()
-    persisted: list = []
-    app = _make_scored_app(pre, persisted)
+    quick = _RecordingQuickScoring()
+    app = _make_rescore_app(pre, quick)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get(
@@ -451,41 +455,127 @@ async def test_rescore_false_skips_pre_rank_and_persist() -> None:
         )
 
     assert resp.status_code == 200
-    # The global ANN re-rank must not run on a sort-only request...
-    assert pre.called is False
-    # ...nor the full-corpus score persist write.
-    assert persisted == []
+    # The scoring pipeline that determines the result set/order is preserved...
+    assert pre.called is True
+    # ...both score_page passes are cache-only on a pure reorder: the global
+    # pre-pagination apply (always cache-only) and the page-level pass (deferred
+    # because rescore=False). Neither fires the blocking LLM round-trip.
+    assert quick.llm_on_miss_calls == [False, False]
 
 
 @pytest.mark.asyncio
-async def test_rescore_false_sorts_by_persisted_scores() -> None:
+async def test_rescore_default_runs_llm_on_miss() -> None:
+    # Omitting `rescore` (full load / filter change) keeps the LLM round-trip.
     pre = _RecordingPreRanker()
-    persisted: list = []
-    app = _make_scored_app(pre, persisted)
-
-    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-        # Default sort = match_desc; ordering must come from the persisted scores
-        # (0.9, 0.6, 0.3), NOT from the pre-ranker's reversal.
-        resp = await client.get(
-            "/ingestion/jobs",
-            params={"tab": "boards", "rescore": "false", "min_score": 0},
-        )
-
-    assert resp.status_code == 200
-    ids = [j["id"] for j in resp.json()["jobs"]]
-    assert ids == ["job-1", "job-2", "job-0"]
-
-
-@pytest.mark.asyncio
-async def test_rescore_default_still_runs_pre_rank_and_persist() -> None:
-    # Regression: omitting `rescore` keeps the full pipeline (rescore defaults True).
-    pre = _RecordingPreRanker()
-    persisted: list = []
-    app = _make_scored_app(pre, persisted)
+    quick = _RecordingQuickScoring()
+    app = _make_rescore_app(pre, quick)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/ingestion/jobs", params={"tab": "boards", "min_score": 0})
 
     assert resp.status_code == 200
     assert pre.called is True
-    assert persisted != []
+    # Global pre-pagination apply is always cache-only; the page-level pass does
+    # the LLM round-trip on a full load / filter change (rescore defaults True).
+    assert quick.llm_on_miss_calls == [False, True]
+
+
+# ---------------------------------------------------------------------------
+# #76 follow-up — cross-source ranking consistency: a job with a low heuristic
+# score but a HIGH already-cached LLM score must rank to the top GLOBALLY (before
+# pagination), so it isn't buried off page 1 in the all-sources view while
+# surfacing only when its source is filtered. The cached LLM score is the sort
+# authority wherever available.
+# ---------------------------------------------------------------------------
+
+
+class _SummarySection:
+    content = "backend python engineer"
+
+
+class _SummaryProfile:
+    skills: list[str] = []
+    sections = [_SummarySection()]
+
+
+class FakeProfileSummaryOnly:
+    async def list_profiles(self):
+        return [_SummaryProfile()]
+
+
+class _CachedQuickScoring:
+    """Simulates 'job-gob' already LLM-scored (cached) at 0.82; 'job-hn' uncached.
+
+    Returns the cached hit regardless of ``llm_on_miss`` — a cache hit needs no
+    LLM. 'job-hn' is never returned (no cached score), so it keeps its heuristic.
+    """
+
+    def __init__(self) -> None:
+        self.llm_on_miss_calls: list[bool] = []
+
+    async def score_page(self, jobs, skills, summary, *, llm_on_miss=True):
+        from hiresense.ingestion.domain.quick_match_result import QuickMatchResult
+        from hiresense.ingestion.domain.quick_match_verdict import QuickMatchVerdict
+
+        self.llm_on_miss_calls.append(llm_on_miss)
+        ids = {j.id for j in jobs}
+        out = {}
+        if "job-gob" in ids:
+            out["job-gob"] = QuickMatchResult(
+                job_id="job-gob", score=0.82, verdict=QuickMatchVerdict.STRONG
+            )
+        return out
+
+
+@pytest.mark.asyncio
+async def test_cached_llm_score_ranks_globally_before_pagination() -> None:
+    from hiresense.ingestion.api.dependencies import get_quick_scoring
+
+    # job-hn: high heuristic (0.78), no cached LLM score.
+    # job-gob: low heuristic (0.30), but a cached LLM score of 0.82.
+    # Heuristic order would bury job-gob on page 2; the cached LLM score must
+    # pull it to page 1.
+    job_hn = NormalizedJob(
+        id="job-hn", title="HN Engineer", company="Co", description="d", skills=[],
+        source="hn_hiring", source_type="api", language="en",
+        url="https://e.com/hn", match_score=0.78,
+    )
+    job_gob = NormalizedJob(
+        id="job-gob", title="Programador Back-end Python", company="Co", description="d",
+        skills=[], source="getonboard", source_type="api", language="en",
+        url="https://e.com/gob", match_score=0.30,
+    )
+
+    class _Orch:
+        async def run(self, filters=None):
+            return []
+
+        def list_jobs(self):
+            return [job_hn, job_gob]  # heuristic order: hn first
+
+        def persist_scores(self, *a):
+            pass
+
+        def persist_scores_batch(self, updates):
+            pass
+
+    app = FastAPI()
+    app.dependency_overrides[get_ingestion_orchestrator] = lambda: _Orch()
+    app.dependency_overrides[get_portal_scanner] = lambda: FakeScanner()
+    app.dependency_overrides[get_profile_service] = lambda: FakeProfileSummaryOnly()
+    app.dependency_overrides[get_semantic_scoring] = lambda: None
+    app.dependency_overrides[get_quick_scoring] = lambda: _CachedQuickScoring()
+    app.include_router(router)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        # page_size=1: only the global #1 reaches page 1. Without the cached-LLM
+        # global apply, that would be job-hn (heuristic 0.78). With it, job-gob.
+        resp = await client.get(
+            "/ingestion/jobs", params={"tab": "boards", "page_size": 1, "min_score": 0}
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 2
+    assert body["jobs"][0]["id"] == "job-gob"  # cached LLM 0.82 outranks heuristic 0.78
+    assert body["jobs"][0]["match_score"] == 0.82

--- a/docs/superpowers/specs/2026-06-07-sorting-filtering-design.md
+++ b/docs/superpowers/specs/2026-06-07-sorting-filtering-design.md
@@ -128,26 +128,61 @@ Each phase is an independent plan + PR.
 
 After the column-sorting work landed (PRs #72–#74), every sort/filter change on
 the **ingestion** page (the one server-side-paginated list) re-ran the full
-scoring pipeline on the request path: skill-overlap across the corpus, the global
-pgvector ANN pre-rank, a full-corpus score persist write, and a blocking Tier-1
-LLM quick-scoring call for the visible page. A pure reorder doesn't change any
-score, so this was wasted work — and the LLM round-trip dominated the latency
-(#76).
+scoring pipeline on the request path. The dominant cost is the **blocking Tier-1
+LLM quick-scoring call** for the visible page (~seconds); the skill-overlap
+recompute, pgvector ANN pre-rank, and `min_score` gate are comparatively cheap
+(in-memory + one ANN query).
 
-**Fix.** `GET /ingestion/jobs` gains a `rescore: bool = True` query param. When
-`False` (the sort-only / pagination fast path), the handler skips the three
-global ops — skill recompute, ANN re-rank, and the full-corpus persist write —
-plus the global page-level semantic-fill block, and sorts/paginates directly off
-the **already-persisted** `match_score` / `semantic_score`. Bounded, cached
-Tier-1 quick scoring of the visible page still runs (cache hits are instant; only
-newly-surfaced uncached jobs cost one batched LLM call).
+**Why a naïve "skip the global rescore" approach is wrong.** The displayed match
+% is the LLM quick score, which is *not* persisted to the job row; the persisted
+heuristic `match_score` is only written when the profile has structured skills,
+and only ANN-returned jobs get a `semantic_score`. So persisted scores are an
+incomplete, divergent stand-in for the live computation — sorting/filtering off
+them changes *which* jobs appear and their order (jobs with a null persisted
+score get dumped to the tail by `sort_jobs`), not just the row order.
+
+**Fix.** `GET /ingestion/jobs` gains `rescore: bool = True`. The set/order
+-determining steps (skill recompute, ANN pre-rank, `min_score`) **always run**, so
+results are provably identical to before. When `rescore=False` (the sort-only /
+pagination fast path), only the **blocking LLM round-trip is deferred**: quick
+scoring runs cache-only (`QuickScoringService.score_page(..., llm_on_miss=False)`)
+— already-cached scores apply instantly and newly-surfaced jobs keep their
+heuristic blend until the next full rescore fills the cache.
 
 The frontend sends `rescore=false` only for pure reorder/pagination
 (`onSorted`, `onPageChange`, `onPageSizeChange`). Filter, tab-switch, feedback
-re-rank, and fetch keep the default full rescore, because those can change which
-jobs match or their scores. The first load (`ngOnInit`) is a full rescore, so the
-corpus is always fully scored before any fast-path request relies on persisted
-scores.
+re-rank, fetch, and the initial load keep the default full LLM scoring.
+
+### Cross-source ranking consistency (same follow-up)
+
+A second, deeper bug surfaced: sorting by **match** in the *all-sources* view
+showed only `hn_hiring` at the top, yet filtering to `getonboard` alone revealed
+an 82% job that outranked everything on the all-sources page 1. The match
+ranking was **inconsistent across source filters**.
+
+Cause: the displayed match % is the **Tier-1 LLM quick score**, but the global
+sort + pagination ranked by the **heuristic blend**, and the LLM score was
+applied **only after pagination** (to the visible page). The heuristic is
+source-biased — `hn_hiring` jobs (no structured `skills`) score via
+`_text_mention_score` over verbose prose and saturate near 1.0, while
+`getonboard`'s structured tags get dilution-capped low — so strong jobs from
+"weak-heuristic" sources were buried off page 1 and never LLM-scored in the
+all-sources view, only surfacing once their source was filtered.
+
+Fix: in `GET /ingestion/jobs`, after the heuristic/ANN pre-rank and before
+pagination, **apply already-cached LLM scores across the whole corpus**
+(`QuickScoringService.score_page(all_jobs, …, llm_on_miss=False)` — one bulk
+cache read, no LLM calls) and override `match_score` where a cached score
+exists. The LLM cache is keyed by `(job_id, profile_hash)` (source-agnostic), so
+a job scored under any filter ranks correctly everywhere. The persisted row
+score stays the heuristic blend (the override is request-scoped); visible-page
+cache misses are still filled by the page-level pass and improve later rankings.
+
+**Known residual (cold start):** a job that has *never* been LLM-scored in any
+view still ranks by its (biased) heuristic until it first lands on a visible
+page. Fully closing this needs either a less source-biased heuristic pre-rank or
+proactively LLM-scoring a wider candidate window / background backfill — tracked
+separately to avoid unbounded LLM cost.
 
 ## Non-goals
 

--- a/frontend/src/app/core/services/ingestion.service.ts
+++ b/frontend/src/app/core/services/ingestion.service.ts
@@ -31,9 +31,9 @@ export class IngestionService {
     pageSize: number,
     filters: JobFilters = {},
     includeClosed = false,
-    // Pure reorder/pagination changes pass rescore=false so the server skips
-    // the global ANN re-rank + full-corpus persist write and just sorts the
-    // already-persisted scores (#76). Defaults to true (full scoring pipeline).
+    // Pure reorder/pagination passes rescore=false so the server keeps the full
+    // skill+ANN+min_score pipeline (set/order unchanged) but defers the blocking
+    // LLM call, reusing cached scores (#76). Defaults to true (full scoring).
     rescore = true,
   ): Observable<PaginatedJobsResponse> {
     let params = new HttpParams()

--- a/frontend/src/app/pages/ingestion/ingestion.component.ts
+++ b/frontend/src/app/pages/ingestion/ingestion.component.ts
@@ -136,8 +136,8 @@ export class IngestionComponent implements OnInit {
   }
 
   // `rescore` defaults to true (full scoring pipeline). Pure reorder/pagination
-  // callers pass false so the server short-circuits the global re-rank + persist
-  // and just sorts the already-persisted scores (#76).
+  // callers pass false so the server defers the blocking LLM call and reuses
+  // cached scores, while the set/order-determining steps still run (#76).
   loadJobs(rescore = true): void {
     this.loading.set(true);
     this.error.set('');
@@ -231,13 +231,13 @@ export class IngestionComponent implements OnInit {
 
   onPageChange(newPage: number): void {
     this.page.set(newPage);
-    this.loadJobs(false); // pagination — scores unchanged, no rescore
+    this.loadJobs(false); // pagination — scores unchanged, defer LLM rescore
   }
 
   onPageSizeChange(newSize: number): void {
     this.pageSize.set(newSize);
     this.page.set(1);
-    this.loadJobs(false); // pagination — scores unchanged, no rescore
+    this.loadJobs(false); // pagination — scores unchanged, defer LLM rescore
   }
 
   openDetail(job: NormalizedJob): void {
@@ -307,7 +307,7 @@ export class IngestionComponent implements OnInit {
 
   onSorted(): void {
     this.page.set(1);
-    this.loadJobs(false); // reorder only — scores unchanged, no rescore
+    this.loadJobs(false); // reorder only — scores unchanged, defer LLM rescore
   }
 
   onFeedback(jobId: string, kind: FeedbackKind): void {


### PR DESCRIPTION
## Problem

Sorting by **match** in the all-sources view showed only `hn_hiring` at the top, yet filtering to `getonboard` alone revealed an 82% job that outranked everything on the all-sources page 1 — the match ranking was **inconsistent across source filters**. Separately, every sort/filter interaction re-ran the full scoring pipeline including a blocking LLM call (the latency dominator in #76).

## Root cause

The match % displayed is the **Tier-1 LLM quick score**, but the global sort + pagination ranked by the **heuristic blend**, and the LLM score was applied **only after pagination** (to the visible page). The heuristic is source-biased: `hn_hiring` (no structured `skills`) scores via `_text_mention_score` over verbose prose and saturates near 1.0; `getonboard`'s structured tags get the dilution-capped overlap (~0.2–0.5). So strong jobs from weak-heuristic sources were buried off page 1 and never LLM-scored in the all-sources view.

## Changes

- **Global cached-LLM ranking:** in `GET /ingestion/jobs`, apply already-cached LLM scores across the whole corpus **before** pagination — one bulk cache read, **no LLM calls** — overriding `match_score` where cached. The cache is keyed by `(job_id, profile_hash)` (source-agnostic), so a job scored under any filter ranks correctly under every filter. Persisted row score stays the heuristic blend (override is request-scoped).
- **`QuickScoringService.score_page` gains `llm_on_miss`** so it can run cache-only.
- **`rescore` query param** (default `true`): `rescore=false` (pure reorder/pagination) defers the page-level blocking LLM round-trip while keeping the set/order pipeline intact.
- **Frontend:** `onSorted` / `onPageChange` / `onPageSizeChange` send `rescore=false`; filter/tab/feedback/fetch/initial-load keep full scoring.

## Tests

- New unit test reproduces the exact bug (page_size=1: a cached-0.82 job must outrank a heuristic-0.78 job globally).
- New `llm_on_miss` cache-only test; route tests assert the cache-only global apply + page-level LLM behavior on both rescore paths.
- New frontend `ingestion.service.spec.ts` covers the `rescore` param wiring.
- Backend: 835 passed / 6 skipped (pgvector). Frontend specs pass; `ng lint` clean.

## Known residual (cold start)

A job that has *never* been LLM-scored in any view still ranks by its biased heuristic until it first lands on a visible page. Fully closing this needs a less source-biased heuristic pre-rank or a wider LLM-scoring window / backfill — tracked separately to avoid unbounded LLM cost.

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)