### PR TITLE
feat(ingestion): job-quality/spam detection, age filter, getonboard company, location & tracking fixes

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -113,6 +113,11 @@ LATEX_TIMEOUT_SECONDS=60.0
 # shows everything; the match column + sort=match_desc are the triage path.
 # Clients can override per request with ?min_score=0.25 etc.
 INGESTION_MIN_MATCH_SCORE=0.0
+# Hide ingestion-list jobs whose posted date is older than this many days
+# (stale / re-surfaced postings, e.g. WeWorkRemotely keeps the original RSS
+# pubDate). Jobs with no posted date are never hidden. 0 disables; 365 hides
+# anything older than a year. Override per request with ?max_age_days=.
+INGESTION_MAX_JOB_AGE_DAYS=365
 # Options: xelatex | docker_xelatex
 CV_DIRECTORY=./cvs
 

--- a/backend/alembic/versions/024_add_job_quality.py
+++ b/backend/alembic/versions/024_add_job_quality.py
@@ -1,0 +1,34 @@
+"""add quality + quality_reason to ingested_jobs
+
+Intrinsic, profile-independent job-quality classification (see JobQuality):
+"ok" | "low_quality" | "spam". Defaults to "ok" with a server_default so every
+existing row backfills to "ok" and nothing is hidden retroactively. The
+ingestion orchestrator (re)classifies jobs on insert/update going forward.
+
+Revision ID: 024
+Revises: 023
+Create Date: 2026-06-08
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "024"
+down_revision: Union[str, None] = "023"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE ingested_jobs "
+        "ADD COLUMN IF NOT EXISTS quality VARCHAR(20) NOT NULL DEFAULT 'ok'"
+    )
+    op.execute(
+        "ALTER TABLE ingested_jobs ADD COLUMN IF NOT EXISTS quality_reason TEXT"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE ingested_jobs DROP COLUMN IF EXISTS quality_reason")
+    op.execute("ALTER TABLE ingested_jobs DROP COLUMN IF EXISTS quality")

--- a/backend/src/hiresense/bootstrap/ingestion.py
+++ b/backend/src/hiresense/bootstrap/ingestion.py
@@ -24,6 +24,7 @@ from hiresense.ingestion.api.provider import IngestionProvider
 from hiresense.ingestion.domain import (
     IngestionOrchestrator,
     JobEmbeddingIndexer,
+    JobQualityClassifier,
     JobRevalidationService,
     PortalScanner,
     load_portals_config,
@@ -124,6 +125,10 @@ def build_ingestion(infra: SharedInfra, tracked: Callable[[str], Any], *, prefer
         else None
     )
 
+    # Intrinsic quality / spam classifier (cheap model, deterministic spam
+    # fast-path + LLM); fails open to "ok" when no LLM is configured.
+    quality_classifier = JobQualityClassifier(llm=tracked("job_quality_classifier"))
+
     ingestion_orchestrator = IngestionOrchestrator(
         sources=sources,
         normalizers=normalizers,
@@ -133,6 +138,7 @@ def build_ingestion(infra: SharedInfra, tracked: Callable[[str], Any], *, prefer
         retention_days=s.ingestion_job_retention_days,
         indexer=boards_indexer,
         closure_miss_threshold=s.job_closure_miss_threshold,
+        quality_classifier=quality_classifier,
     )
 
     # URL-probe revalidation sweep for the boards bucket. Snapshot sources

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -137,6 +137,13 @@ class Settings(BaseSettings):
     # sources like getonboard; only raise if scoring is also fixed.
     ingestion_min_match_score: float = 0.0
 
+    # Hide job listings whose posted_date is older than this many days (stale /
+    # re-surfaced postings — e.g. WeWorkRemotely keeps the original RSS pubDate
+    # while the site shows a bumped date). Jobs with no posted_date are never
+    # hidden (unknown age). Override per request with ?max_age_days=. Default 0
+    # disables the filter; the shipped .env sets 365 (hide > 1 year old).
+    ingestion_max_job_age_days: int = 0
+
     # Language
     supported_languages: list[str] = ["en", "es"]
     default_language: str = "en"

--- a/backend/src/hiresense/ingestion/adapters/getonboard.py
+++ b/backend/src/hiresense/ingestion/adapters/getonboard.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from hiresense.ingestion.domain.models import RawJobListing
 from hiresense.kernel.value_objects import SourceType
+
+logger = logging.getLogger(__name__)
 
 MAX_PAGES = 10
 
@@ -19,6 +22,9 @@ class GetOnBoardAdapter:
         self._base_url = base_url
         # Empty/None → ingest from /search/jobs with no filter.
         self._categories = list(categories) if categories else []
+        # company id → name, resolved lazily and reused across the run so we
+        # never fetch the same company twice (see _resolve_company_names).
+        self._company_cache: dict[str, str] = {}
 
     def supports_snapshot_closure(self) -> bool:
         return False
@@ -60,7 +66,43 @@ class GetOnBoardAdapter:
                 seen=seen,
                 jobs=jobs,
             )
+        await self._resolve_company_names(jobs)
         return jobs
+
+    async def _resolve_company_names(self, jobs: list[RawJobListing]) -> None:
+        """Inject the human-readable company name into each job's attributes.
+
+        getonbrd's job listings carry only a company *id*
+        (``attributes.company.data.id``), not the name, so without this the
+        company column renders blank. We resolve each id via ``/companies/{id}``
+        (cached per run) and stash the result under ``attributes.company_name``,
+        which the normalizer already reads. Failures degrade to a blank company
+        rather than breaking the whole fetch.
+        """
+        for raw in jobs:
+            attrs = raw.raw_data.get("attributes", {})
+            if attrs.get("company_name"):
+                continue
+            company_id = (attrs.get("company") or {}).get("data", {}).get("id")
+            if company_id is None:
+                continue
+            name = await self._company_name(str(company_id))
+            if name:
+                attrs["company_name"] = name
+
+    async def _company_name(self, company_id: str) -> str:
+        if company_id in self._company_cache:
+            return self._company_cache[company_id]
+        name = ""
+        try:
+            response = await self._http.get(f"{self._base_url}/companies/{company_id}")
+            response.raise_for_status()
+            data = response.json().get("data", {}) or {}
+            name = ((data.get("attributes") or {}).get("name") or "").strip()
+        except Exception:
+            logger.warning("getonboard: failed to resolve company %s", company_id, exc_info=True)
+        self._company_cache[company_id] = name
+        return name
 
     async def _fetch_endpoint(
         self,

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -161,15 +161,18 @@ async def list_jobs(
     max_years_experience: int | None = None,
     include_closed: bool = False,
     rescore: bool = True,
+    max_age_days: int | None = None,
+    include_low_quality: bool = False,
 ) -> PaginatedResult:
-    # Default min_score from settings when the client doesn't specify one
-    # (pass min_score=0 explicitly to disable the filter). Tests mount the
+    # Default min_score / max_age_days from settings when the client doesn't
+    # specify them (pass 0 explicitly to disable either filter). Tests mount the
     # router on a bare FastAPI without app.state.settings — fall back to
     # no-filter in that case.
-    if min_score is None:
-        settings = getattr(request.app.state, "settings", None)
-        if settings is not None:
-            min_score = settings.ingestion_min_match_score
+    settings = getattr(request.app.state, "settings", None)
+    if min_score is None and settings is not None:
+        min_score = settings.ingestion_min_match_score
+    if max_age_days is None and settings is not None:
+        max_age_days = settings.ingestion_max_job_age_days
     all_jobs = orchestrator.list_jobs() if tab == "boards" else scanner.list_jobs()
 
     candidate_skills, candidate_summary = await _gather_profile(profile_service)
@@ -255,6 +258,8 @@ async def list_jobs(
         seniority_levels=seniority,
         max_years_experience=max_years_experience,
         include_closed=include_closed,
+        max_age_days=max_age_days,
+        include_low_quality=include_low_quality,
     )
     result = filter_and_paginate(all_jobs, params)
 

--- a/backend/src/hiresense/ingestion/domain/__init__.py
+++ b/backend/src/hiresense/ingestion/domain/__init__.py
@@ -4,6 +4,9 @@ from hiresense.ingestion.domain.content_hash import content_hash
 from hiresense.ingestion.domain.identity import identity_key
 from hiresense.ingestion.domain.job_embedding_indexer import JobEmbeddingIndexer
 from hiresense.ingestion.domain.job_filter import JobQueryParams, PaginatedResult, filter_and_paginate
+from hiresense.ingestion.domain.job_quality import JobQuality
+from hiresense.ingestion.domain.job_quality_classifier import JobQualityClassifier
+from hiresense.ingestion.domain.job_quality_verdict import JobQualityVerdict
 from hiresense.ingestion.domain.job_revalidation_service import JobRevalidationService
 from hiresense.ingestion.domain.job_sort import sort_jobs
 from hiresense.ingestion.domain.portal_config import load_portals_config
@@ -20,6 +23,9 @@ __all__ = [
     "OpenJob",
     "UpsertResult",
     "detect_closures",
+    "JobQuality",
+    "JobQualityClassifier",
+    "JobQualityVerdict",
     "JobQueryParams",
     "PaginatedResult",
     "PortalScanner",

--- a/backend/src/hiresense/ingestion/domain/job_filter.py
+++ b/backend/src/hiresense/ingestion/domain/job_filter.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from pydantic import BaseModel
 
@@ -39,9 +39,16 @@ class JobQueryParams(BaseModel):
     # When False (default), jobs with status == "closed" are hidden. Set True
     # to surface them (e.g. the frontend "Show closed" toggle).
     include_closed: bool = False
+    # When False (default), jobs flagged quality != "ok" (low_quality / spam)
+    # are hidden. Set True to surface them (the "Show low-quality" toggle).
+    include_low_quality: bool = False
     # Maximum minimum-years-experience the user is willing to consider.
     # Jobs with no extractable years string pass through.
     max_years_experience: int | None = None
+    # Hide jobs whose posted_date is older than this many days (stale / re-
+    # surfaced postings). None or <= 0 disables the filter. Jobs with no
+    # posted_date are never hidden (unknown age).
+    max_age_days: int | None = None
 
 
 class PaginatedResult(BaseModel):
@@ -60,6 +67,9 @@ def filter_and_paginate(
 
     if not params.include_closed:
         filtered = [j for j in filtered if j.status != "closed"]
+
+    if not params.include_low_quality:
+        filtered = [j for j in filtered if (j.quality or "ok") == "ok"]
 
     if params.source:
         filtered = [j for j in filtered if j.source == params.source]
@@ -124,16 +134,33 @@ def filter_and_paginate(
             if (extract_min_years(j.description) or 0) <= cap
         ]
 
+    if params.max_age_days is not None and params.max_age_days > 0:
+        cutoff = datetime.now(timezone.utc) - timedelta(days=params.max_age_days)
+
+        def _fresh_enough(job: NormalizedJob) -> bool:
+            posted = job.posted_date
+            if posted is None:
+                return True  # unknown age — never hide
+            # Normalise naive datetimes (some sources) to UTC before comparing.
+            if posted.tzinfo is None:
+                posted = posted.replace(tzinfo=timezone.utc)
+            return posted >= cutoff
+
+        filtered = [j for j in filtered if _fresh_enough(j)]
+
     if params.strict_location and params.user_location:
         user_loc = params.user_location.strip().lower()
         open_keywords = ("worldwide", "anywhere", "global", "remote")
 
         def _matches_country(job: NormalizedJob) -> bool:
-            # Fully-remote postings: treat as applyable from anywhere. Some
-            # sources do restrict remote roles to specific countries, but
-            # that's the minority — rather than false-reject, surface them
-            # and let the user verify on the listing itself.
+            # Remote roles restricted to specific countries must honor that
+            # restriction — e.g. getonbrd "remote_local" surfaces as
+            # "Remote (Chile)" with countries=["Chile"]; an Ecuador user can't
+            # apply, so don't show it. A remote role with NO country list is
+            # worldwide → applyable from anywhere.
             if job.remote_modality == "remote":
+                if job.countries:
+                    return any(user_loc == c.strip().lower() for c in job.countries)
                 return True
             # Hybrid / on-site with a structured countries list: must be one
             # of those countries. The list is authoritative.

--- a/backend/src/hiresense/ingestion/domain/job_quality.py
+++ b/backend/src/hiresense/ingestion/domain/job_quality.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import enum
+
+
+class JobQuality(str, enum.Enum):
+    """Intrinsic, profile-independent quality of a job listing.
+
+    OK           — a normal, legitimate posting (the default; shown).
+    LOW_QUALITY  — thin / empty / low-value (e.g. no company and no description).
+    SPAM         — MLM / franchise / commission-only / scam-style pitch.
+
+    LOW_QUALITY and SPAM are hidden from the listing by default; a toggle
+    reveals them.
+    """
+
+    OK = "ok"
+    LOW_QUALITY = "low_quality"
+    SPAM = "spam"

--- a/backend/src/hiresense/ingestion/domain/job_quality_classifier.py
+++ b/backend/src/hiresense/ingestion/domain/job_quality_classifier.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from hiresense.ingestion.domain.job_quality import JobQuality
+from hiresense.ingestion.domain.job_quality_verdict import JobQualityVerdict
+from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.matching.domain.scorers.json_extract import extract_json
+from hiresense.ports import LLMPort
+
+logger = logging.getLogger(__name__)
+
+# High-precision spam / scam markers. A hit short-circuits straight to SPAM
+# without an LLM call. Kept deliberately tight — these phrases essentially never
+# appear in a legitimate salaried engineering posting. Matched case-insensitively
+# as substrings of "title\ndescription".
+_SPAM_MARKERS: tuple[str, ...] = (
+    "line of business owner",
+    "be your own boss",
+    "commission only",
+    "commission-only",
+    "100% commission",
+    "unlimited earning potential",
+    "unlimited income",
+    "financial freedom",
+    "multi-level marketing",
+    "multi level marketing",
+    "join our downline",
+    "pyramid",
+    "no experience needed, work from home",
+)
+
+_DESC_CHAR_LIMIT = 1200
+
+_SYSTEM_PROMPT = (
+    "You are a strict job-board moderator deciding whether each posting is a "
+    "legitimate job or junk. Return ONLY a JSON array — one object per job, in "
+    'input order: [{"ref": <job number>, "quality": "ok|low_quality|spam", '
+    '"reason": "<short phrase, omit for ok>"}].\n\n'
+    "Classify as:\n"
+    "- \"spam\": MLM / pyramid / franchise / 'be your own boss' / commission-only "
+    "/ pay-to-start / get-rich pitches, or anything not actually offering "
+    "employment.\n"
+    "- \"low_quality\": real but near-empty/uninformative (no company, no real "
+    "description, pure recruiter spam, content-farm repost).\n"
+    "- \"ok\": a normal legitimate job posting. When unsure, choose \"ok\".\n"
+    "Keep each reason under ~10 words."
+)
+
+
+def _deterministic_spam_reason(job: NormalizedJob) -> str | None:
+    haystack = f"{job.title}\n{job.description}".lower()
+    for marker in _SPAM_MARKERS:
+        if marker in haystack:
+            return f"Matched spam marker: '{marker}'"
+    return None
+
+
+def _coerce_quality(raw: Any) -> JobQuality:
+    if isinstance(raw, str):
+        try:
+            return JobQuality(raw.strip().lower())
+        except ValueError:
+            pass
+    return JobQuality.OK  # fail-open on anything unexpected
+
+
+class JobQualityClassifier:
+    """Intrinsic job-quality classifier: deterministic spam fast-path + LLM.
+
+    Quality is profile-independent, so this runs once at ingestion (not per
+    request). Obvious spam is caught by `_SPAM_MARKERS` with no LLM call; the
+    rest is adjudicated by one batched cheap-model call. Every uncertain path
+    fails OPEN to OK — we never hide a job because the LLM was unavailable or
+    its response was unparseable.
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: LLMPort | None,
+        batch_size: int = 20,
+        desc_char_limit: int = _DESC_CHAR_LIMIT,
+    ) -> None:
+        self._llm = llm
+        self._batch_size = max(1, batch_size)
+        self._desc_char_limit = desc_char_limit
+
+    async def classify(self, jobs: list[NormalizedJob]) -> dict[str, JobQualityVerdict]:
+        """Return a verdict for EVERY input job (default OK)."""
+        if not jobs:
+            return {}
+
+        results: dict[str, JobQualityVerdict] = {}
+        needs_llm: list[NormalizedJob] = []
+        for job in jobs:
+            reason = _deterministic_spam_reason(job)
+            if reason is not None:
+                results[job.id] = JobQualityVerdict(
+                    job_id=job.id, quality=JobQuality.SPAM, reason=reason
+                )
+            else:
+                needs_llm.append(job)
+
+        # Fail-open: no LLM → everything not already flagged is OK.
+        if self._llm is None:
+            for job in needs_llm:
+                results[job.id] = JobQualityVerdict(job_id=job.id, quality=JobQuality.OK)
+            return results
+
+        chunks = [
+            needs_llm[i : i + self._batch_size]
+            for i in range(0, len(needs_llm), self._batch_size)
+        ]
+        scored_chunks = await asyncio.gather(*(self._classify_chunk(c) for c in chunks))
+        for chunk_results in scored_chunks:
+            results.update(chunk_results)
+        return results
+
+    async def _classify_chunk(
+        self, chunk: list[NormalizedJob]
+    ) -> dict[str, JobQualityVerdict]:
+        # Default every job in the chunk to OK; override with parsed verdicts.
+        out = {j.id: JobQualityVerdict(job_id=j.id, quality=JobQuality.OK) for j in chunk}
+        prompt = self._build_prompt(chunk)
+        try:
+            response = await self._llm.complete(prompt, system=_SYSTEM_PROMPT)
+        except Exception:
+            logger.exception("Job-quality classification batch failed (size=%d)", len(chunk))
+            return out  # fail-open
+        for ref, item in self._parse(response, chunk):
+            quality = _coerce_quality(item.get("quality"))
+            reason = item.get("reason")
+            out[ref.id] = JobQualityVerdict(
+                job_id=ref.id,
+                quality=quality,
+                reason=(str(reason).strip() if reason and quality is not JobQuality.OK else None),
+            )
+        return out
+
+    def _build_prompt(self, chunk: list[NormalizedJob]) -> str:
+        lines = ["JOBS (classify every one; echo its ref number):"]
+        for ref, job in enumerate(chunk, start=1):
+            desc = (job.description or "").strip()[: self._desc_char_limit]
+            lines.append(f"[{ref}] {job.title} @ {job.company or '(no company)'}")
+            lines.append(f"    {desc}")
+        return "\n".join(lines)
+
+    @staticmethod
+    def _parse(response: str, chunk: list[NormalizedJob]):
+        data = extract_json(response)
+        if isinstance(data, dict):
+            data = [data]
+        if not isinstance(data, list):
+            logger.warning("Job-quality: unparseable response: %s", str(response)[:200])
+            return
+        for idx, item in enumerate(data):
+            if not isinstance(item, dict):
+                continue
+            ref = item.get("ref")
+            if isinstance(ref, (int, float)) and 1 <= int(ref) <= len(chunk):
+                yield chunk[int(ref) - 1], item
+            elif idx < len(chunk):
+                yield chunk[idx], item

--- a/backend/src/hiresense/ingestion/domain/job_quality_verdict.py
+++ b/backend/src/hiresense/ingestion/domain/job_quality_verdict.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from hiresense.ingestion.domain.job_quality import JobQuality
+
+
+class JobQualityVerdict(BaseModel):
+    """The classifier's call on a single job: a quality bucket + a short reason.
+
+    `reason` is None for OK jobs (nothing to explain) and a concise phrase for
+    flagged ones (e.g. "Commission-only MLM pitch").
+    """
+
+    job_id: str
+    quality: JobQuality
+    reason: str | None = None

--- a/backend/src/hiresense/ingestion/domain/models.py
+++ b/backend/src/hiresense/ingestion/domain/models.py
@@ -36,6 +36,12 @@ class NormalizedJob(BaseModel):
     # only postings the candidate can actually take.
     remote_modality: str | None = None
     countries: list[str] = Field(default_factory=list)
+    # Intrinsic, profile-independent quality classification computed once at
+    # ingestion: "ok" | "low_quality" | "spam". Flagged jobs are hidden from the
+    # listing by default (toggle to reveal). `quality_reason` is a short, human
+    # explanation surfaced in the detail panel.
+    quality: str = "ok"
+    quality_reason: str | None = None
     match_score: float | None = None
     semantic_score: float | None = None
     # Transient, per-request LLM scoring (populated by the quick scorer in the

--- a/backend/src/hiresense/ingestion/domain/normalizers/hn_hiring_normalizer.py
+++ b/backend/src/hiresense/ingestion/domain/normalizers/hn_hiring_normalizer.py
@@ -35,6 +35,13 @@ class HNHiringNormalizer:
         }
 
 
+# A real location / work-mode tag is short ("Berlin, Germany", "100% Remote
+# (Global)", "ONSITE & Remote"). Header segments longer than this are almost
+# always description prose that merely *mentions* a keyword like "remote" — they
+# must never be classified as a location, or the whole blurb leaks into the
+# location field (which broke the tracking table).
+_MAX_LOCATION_LEN = 60
+
 # Markers that strongly suggest a part is describing a *location* or
 # *work-mode*, not a role title. Used to disambiguate ambiguous HN headers
 # like "Company | Berlin, Germany | ONSITE & Remote".
@@ -115,7 +122,7 @@ def _looks_like_location(text: str) -> bool:
       * comma-separated multi-region list and no role keyword present
     """
     lower = text.lower().strip()
-    if not lower:
+    if not lower or len(lower) > _MAX_LOCATION_LEN:
         return False
     if any(kw in lower for kw in _LOCATION_KEYWORDS):
         return True
@@ -163,7 +170,7 @@ def _is_pure_employment_marker(text: str) -> bool:
 def _classify_extra(part: str, current: dict[str, str | None]) -> None:
     """Slot a free-form extra field into location / salary based on shape."""
     lower = part.lower()
-    if any(kw in lower for kw in _LOCATION_KEYWORDS):
+    if len(part) <= _MAX_LOCATION_LEN and any(kw in lower for kw in _LOCATION_KEYWORDS):
         loc = current["location"] or ""
         current["location"] = f"{loc} ({part})" if loc else part
         return

--- a/backend/src/hiresense/ingestion/domain/services.py
+++ b/backend/src/hiresense/ingestion/domain/services.py
@@ -13,7 +13,7 @@ from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.normalizer import JobNormalizer
 from hiresense.ingestion.domain.upsert_result import UpsertResult
 from hiresense.ingestion.ports import JobsRepositoryPort
-from hiresense.ingestion.ports.jobs_repository import ScoreUpdate
+from hiresense.ingestion.ports.jobs_repository import QualityUpdate, ScoreUpdate
 from hiresense.kernel.events import JobsIngestedEvent
 from hiresense.observability import get_domain_metrics, get_tracer
 
@@ -40,6 +40,7 @@ class IngestionOrchestrator:
         retention_days: int | None = None,
         indexer: Any | None = None,
         closure_miss_threshold: int = 2,
+        quality_classifier: Any | None = None,
     ) -> None:
         self._sources = sources
         self._normalizers = normalizers
@@ -49,6 +50,7 @@ class IngestionOrchestrator:
         self._retention_days = retention_days
         self._indexer = indexer
         self._closure_miss_threshold = closure_miss_threshold
+        self._quality_classifier = quality_classifier
         self._last_run_at: float = 0.0
 
     async def run(
@@ -68,6 +70,7 @@ class IngestionOrchestrator:
                 await self._prune_expired()
 
                 new_jobs: list[NormalizedJob] = []
+                all_touched: list[NormalizedJob] = []
 
                 for source in self._sources:
                     source_name = source.source_name()
@@ -118,6 +121,8 @@ class IngestionOrchestrator:
                     if touched and self._indexer is not None:
                         await self._indexer.index(touched)
 
+                    all_touched.extend(touched)
+
                     # Disappearance-based closure: only for snapshot sources, only after a
                     # successful fetch (errored fetches `continue` above and never reach here).
                     if source.supports_snapshot_closure():
@@ -126,6 +131,22 @@ class IngestionOrchestrator:
                         )
                         if closed_ids and self._indexer is not None:
                             await self._indexer.remove(closed_ids)
+
+                # Quality classification (intrinsic, profile-independent) for
+                # every inserted/updated/reopened job, in one batched pass.
+                # Failures degrade to leaving the job at its default "ok".
+                if all_touched and self._quality_classifier is not None:
+                    try:
+                        verdicts = await self._quality_classifier.classify(all_touched)
+                        if verdicts:
+                            self._repository.bulk_update_quality(
+                                [
+                                    QualityUpdate(v.job_id, v.quality.value, v.reason)
+                                    for v in verdicts.values()
+                                ]
+                            )
+                    except Exception:
+                        logger.exception("Job-quality classification failed; left as 'ok'")
 
                 # Indexing already happened per-source via `touched` (inserted/updated/
                 # reopened). Here we only announce the newly inserted jobs.

--- a/backend/src/hiresense/ingestion/infrastructure/in_memory_jobs_repository.py
+++ b/backend/src/hiresense/ingestion/infrastructure/in_memory_jobs_repository.py
@@ -7,7 +7,7 @@ from hiresense.ingestion.domain.content_hash import content_hash
 from hiresense.ingestion.domain.identity import identity_key
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.upsert_result import UpsertResult
-from hiresense.ingestion.ports.jobs_repository import ScoreUpdate
+from hiresense.ingestion.ports.jobs_repository import QualityUpdate, ScoreUpdate
 
 
 class InMemoryJobsRepository:
@@ -154,6 +154,16 @@ class InMemoryJobsRepository:
                     "match_score": score_update.match_score,
                     "semantic_score": score_update.semantic_score,
                 }
+            )
+
+    def bulk_update_quality(self, updates: list[QualityUpdate]) -> None:
+        """Update multiple jobs' quality classifications in one pass."""
+        for qu in updates:
+            job = self._jobs.get(qu.job_id)
+            if job is None:
+                continue
+            self._jobs[qu.job_id] = job.model_copy(
+                update={"quality": qu.quality, "quality_reason": qu.quality_reason}
             )
 
     def prune_older_than(self, cutoff: datetime) -> list[str]:

--- a/backend/src/hiresense/ingestion/infrastructure/jobs_repository.py
+++ b/backend/src/hiresense/ingestion/infrastructure/jobs_repository.py
@@ -11,7 +11,7 @@ from hiresense.ingestion.domain.identity import identity_key
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.upsert_result import UpsertResult
 from hiresense.ingestion.infrastructure.models import IngestedJob
-from hiresense.ingestion.ports.jobs_repository import ScoreUpdate
+from hiresense.ingestion.ports.jobs_repository import QualityUpdate, ScoreUpdate
 
 
 def _to_orm(job: NormalizedJob, bucket: str) -> IngestedJob:
@@ -40,6 +40,8 @@ def _to_orm(job: NormalizedJob, bucket: str) -> IngestedJob:
         remote_modality=job.remote_modality,
         match_score=job.match_score,
         semantic_score=job.semantic_score,
+        quality=job.quality,
+        quality_reason=job.quality_reason,
     )
 
 
@@ -66,6 +68,8 @@ def _to_domain(row: IngestedJob) -> NormalizedJob:
         remote_modality=row.remote_modality,
         match_score=row.match_score,
         semantic_score=row.semantic_score,
+        quality=row.quality,
+        quality_reason=row.quality_reason,
     )
 
 
@@ -275,6 +279,24 @@ class JobsRepository:
                         "semantic_score": su.semantic_score,
                     }
                     for su in updates
+                ],
+            )
+            session.commit()
+
+    def bulk_update_quality(self, updates: list[QualityUpdate]) -> None:
+        """Persist quality classifications in a single executemany round-trip."""
+        if not updates:
+            return
+        with self._session_factory() as session:
+            session.execute(
+                update(IngestedJob),
+                [
+                    {
+                        "id": qu.job_id,
+                        "quality": qu.quality,
+                        "quality_reason": qu.quality_reason,
+                    }
+                    for qu in updates
                 ],
             )
             session.commit()

--- a/backend/src/hiresense/ingestion/infrastructure/models.py
+++ b/backend/src/hiresense/ingestion/infrastructure/models.py
@@ -42,6 +42,12 @@ class IngestedJob(Base):
     remote_modality: Mapped[str | None] = mapped_column(String(20), nullable=True)
     match_score: Mapped[float | None] = mapped_column(Float, nullable=True)
     semantic_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    # Intrinsic quality classification (see JobQuality): "ok" | "low_quality" |
+    # "spam". Defaults to "ok" so existing rows are never hidden retroactively.
+    quality: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="ok", server_default="ok"
+    )
+    quality_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
     fetched_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/src/hiresense/ingestion/ports/jobs_repository.py
+++ b/backend/src/hiresense/ingestion/ports/jobs_repository.py
@@ -23,6 +23,15 @@ class ScoreUpdate:
     semantic_score: float | None
 
 
+@dataclasses.dataclass(frozen=True)
+class QualityUpdate:
+    """Immutable value object carrying a single job's quality classification."""
+
+    job_id: str
+    quality: str
+    quality_reason: str | None
+
+
 class JobsRepositoryPort(Protocol):
     def upsert(self, job: NormalizedJob) -> "UpsertResult":
         """Insert, update-in-place (preserving id), reopen, or no-op a job,
@@ -72,6 +81,14 @@ class JobsRepositoryPort(Protocol):
         SQL implementations MUST use a single executemany bulk UPDATE keyed by
         primary key (one session, one commit) — never N individual UPDATE
         statements. In-memory implementations iterate the dict in a single pass.
+        """
+        ...
+
+    def bulk_update_quality(self, updates: list["QualityUpdate"]) -> None:
+        """Persist quality classifications for multiple jobs in one batched write.
+
+        Single executemany bulk UPDATE keyed by primary key (one session, one
+        commit). Unknown IDs are ignored; an empty list is a no-op.
         """
         ...
 

--- a/backend/tests/unit/ingestion/test_getonboard_adapter.py
+++ b/backend/tests/unit/ingestion/test_getonboard_adapter.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+from hiresense.ingestion.adapters import GetOnBoardAdapter
+from hiresense.ingestion.domain.normalizers import GetOnBoardNormalizer
+
+
+class FakeResponse:
+    def __init__(self, data: dict) -> None:
+        self._data = data
+        self.status_code = 200
+
+    def json(self) -> dict:
+        return self._data
+
+    def raise_for_status(self) -> None:
+        pass
+
+
+class FakeHttpClient:
+    """Returns the jobs page for any non-company URL and a company resource for
+    /companies/{id}. Records every fetched URL so we can assert caching."""
+
+    def __init__(self, jobs_page: dict, company_names: dict[str, str]) -> None:
+        self._jobs_page = jobs_page
+        self._company_names = company_names
+        self.calls: list[str] = []
+
+    async def get(self, url: str, **kwargs) -> FakeResponse:
+        self.calls.append(url)
+        if "/companies/" in url:
+            cid = url.rsplit("/", 1)[1]
+            return FakeResponse(
+                {"data": {"id": cid, "attributes": {"name": self._company_names.get(cid, "")}}}
+            )
+        return FakeResponse(self._jobs_page)
+
+
+def _jobs_page(*company_ids: int) -> dict:
+    return {
+        "data": [
+            {
+                "id": f"job-{cid}",
+                "type": "job",
+                "attributes": {
+                    "title": "Dev",
+                    "company": {"data": {"id": cid, "type": "company"}},
+                    "remote": True,
+                    "remote_modality": "remote_local",
+                    "countries": [],
+                    "description": "desc",
+                },
+                "links": {"public_url": f"https://www.getonbrd.com/jobs/job-{cid}"},
+                "relationships": {"tags": {"data": []}},
+            }
+            for cid in company_ids
+        ],
+        "meta": {"total_pages": 1},
+    }
+
+
+@pytest.mark.asyncio
+async def test_getonboard_resolves_company_name_into_attributes() -> None:
+    http = FakeHttpClient(_jobs_page(9458), {"9458": "BC Tecnología"})
+    adapter = GetOnBoardAdapter(http_client=http, base_url="https://api", categories=None)
+
+    jobs = await adapter.fetch_jobs()
+
+    assert jobs[0].raw_data["attributes"]["company_name"] == "BC Tecnología"
+    # The normalizer must then surface the resolved name as the company.
+    out = GetOnBoardNormalizer().normalize(jobs[0])
+    assert out["company"] == "BC Tecnología"
+
+
+@pytest.mark.asyncio
+async def test_getonboard_caches_company_lookups() -> None:
+    # Two jobs share a company id → only one /companies fetch.
+    http = FakeHttpClient(_jobs_page(9458, 9458), {"9458": "BC Tecnología"})
+    adapter = GetOnBoardAdapter(http_client=http, base_url="https://api", categories=None)
+
+    await adapter.fetch_jobs()
+
+    company_calls = [u for u in http.calls if "/companies/" in u]
+    assert company_calls == ["https://api/companies/9458"]
+
+
+@pytest.mark.asyncio
+async def test_getonboard_company_unresolved_leaves_blank() -> None:
+    # Company fetch yields no name → no company_name injected; normalizer blank.
+    http = FakeHttpClient(_jobs_page(123), {})  # 123 not in name map
+    adapter = GetOnBoardAdapter(http_client=http, base_url="https://api", categories=None)
+
+    jobs = await adapter.fetch_jobs()
+
+    assert "company_name" not in jobs[0].raw_data["attributes"]
+    out = GetOnBoardNormalizer().normalize(jobs[0])
+    assert out["company"] == ""

--- a/backend/tests/unit/ingestion/test_getonboard_normalizer.py
+++ b/backend/tests/unit/ingestion/test_getonboard_normalizer.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from hiresense.ingestion.domain.models import RawJobListing
+from hiresense.ingestion.domain.normalizers import GetOnBoardNormalizer
+
+
+def _raw(attributes: dict, source_id: str = "1") -> RawJobListing:
+    return RawJobListing(
+        source="getonboard",
+        source_id=source_id,
+        raw_data={
+            "attributes": attributes,
+            "links": {"public_url": "https://www.getonbrd.com/jobs/x"},
+            "relationships": {"tags": {"data": []}},
+        },
+    )
+
+
+def test_remote_local_captures_country_restriction() -> None:
+    """getonbrd 'remote_local' = remote but restricted to listed countries
+    ("Remote (Chile)"). The normalizer must keep the country so strict-location
+    filtering can hide it for users elsewhere."""
+    out = GetOnBoardNormalizer().normalize(
+        _raw(
+            {
+                "title": "Desarrollador Multi Agente IA",
+                "company_name": "jurispeed",
+                "remote": True,
+                "remote_modality": "remote_local",
+                "countries": ["Chile"],
+                "description": "desc",
+            }
+        )
+    )
+    assert out["remote_modality"] == "remote"
+    assert out["countries"] == ["Chile"]
+    assert out["location"] == "Chile (Remote)"
+
+
+def test_worldwide_remote_has_no_country_restriction() -> None:
+    out = GetOnBoardNormalizer().normalize(
+        _raw(
+            {
+                "title": "Backend Engineer",
+                "company_name": "acme",
+                "remote": True,
+                "remote_modality": "remote_local",
+                "countries": [],
+                "description": "desc",
+            }
+        )
+    )
+    assert out["remote_modality"] == "remote"
+    assert out["countries"] == []
+    assert out["location"] == "Remote"

--- a/backend/tests/unit/ingestion/test_hn_hiring_normalizer.py
+++ b/backend/tests/unit/ingestion/test_hn_hiring_normalizer.py
@@ -24,6 +24,27 @@ def test_role_location_mode_header() -> None:
     assert "REMOTE" in out["location"]
 
 
+def test_long_description_part_not_appended_to_location() -> None:
+    """Regression: a long header segment that merely *mentions* a location
+    keyword (e.g. 'fully-remote', 'global') must NOT be concatenated into the
+    location field. This is what broke the tracking table — the location cell
+    contained the whole description blob. Only short place/mode tags belong.
+    """
+    n = HNHiringNormalizer()
+    long_blurb = (
+        "Full-Time MixRank processes petabytes of data every month and we are "
+        "a fully-remote company with a global footprint in over 20 countries"
+    )
+    out = n.normalize(
+        _raw(f"MixRank | Software Engineers | 100% Remote (Global) | {long_blurb}")
+    )
+    assert out["company"] == "MixRank"
+    assert out["title"] == "Software Engineers"
+    assert "100% Remote (Global)" in out["location"]
+    assert long_blurb not in out["location"]  # the blurb must not leak in
+    assert len(out["location"]) < 60
+
+
 def test_location_first_role_second_does_not_steal_title() -> None:
     """Real bug from prod: 'NetBird | Berlin, Germany | ONSITE & Remote ...'
 

--- a/backend/tests/unit/ingestion/test_job_filter.py
+++ b/backend/tests/unit/ingestion/test_job_filter.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 
 from hiresense.ingestion.domain.job_filter import JobQueryParams, filter_and_paginate
 from hiresense.ingestion.domain.models import NormalizedJob
@@ -22,6 +22,7 @@ def _job(
     status: str = "open",
     match_score: float | None = None,
     semantic_score: float | None = None,
+    quality: str = "ok",
 ) -> NormalizedJob:
     return NormalizedJob(
         id=id,
@@ -39,6 +40,7 @@ def _job(
         status=status,
         match_score=match_score,
         semantic_score=semantic_score,
+        quality=quality,
     )
 
 
@@ -235,16 +237,64 @@ def test_strict_location_excludes_non_matching() -> None:
     assert result.total == 0
 
 
-def test_strict_location_passes_remote_jobs() -> None:
-    """Fully-remote postings should be applyable regardless of country."""
+def test_low_quality_hidden_by_default_and_revealed_by_toggle() -> None:
     jobs = [
-        _job(id="1", location="USA only"),
-        _job(id="2", location="Remote"),
-        _job(id="3", remote_modality="remote", countries=["Argentina"]),
+        _job(id="ok", quality="ok"),
+        _job(id="spam", quality="spam"),
+        _job(id="low", quality="low_quality"),
+    ]
+    # Default: only the OK job shows.
+    assert {j.id for j in filter_and_paginate(jobs, JobQueryParams()).jobs} == {"ok"}
+    # Toggle on: everything shows.
+    revealed = filter_and_paginate(jobs, JobQueryParams(include_low_quality=True)).jobs
+    assert {j.id for j in revealed} == {"ok", "spam", "low"}
+
+
+def test_max_age_days_hides_stale_jobs() -> None:
+    """Jobs older than max_age_days are hidden; recent jobs and jobs with an
+    unknown (None) posted_date are kept."""
+    now = datetime.now(timezone.utc)
+    jobs = [
+        _job(id="old", posted_date=now - timedelta(days=400)),  # > 1 year → hidden
+        _job(id="fresh", posted_date=now - timedelta(days=10)),  # recent → shown
+        _job(id="unknown", posted_date=None),  # unknown age → shown
+    ]
+    params = JobQueryParams(max_age_days=365)
+    result = filter_and_paginate(jobs, params)
+    assert {j.id for j in result.jobs} == {"fresh", "unknown"}
+
+
+def test_max_age_days_disabled_when_zero_or_none() -> None:
+    now = datetime.now(timezone.utc)
+    jobs = [_job(id="old", posted_date=now - timedelta(days=400))]
+    assert {j.id for j in filter_and_paginate(jobs, JobQueryParams()).jobs} == {"old"}
+    assert {j.id for j in filter_and_paginate(jobs, JobQueryParams(max_age_days=0)).jobs} == {"old"}
+
+
+def test_max_age_days_handles_naive_posted_date() -> None:
+    # Some sources yield tz-naive datetimes; the filter must not crash on them.
+    old_naive = datetime.now() - timedelta(days=400)
+    jobs = [_job(id="old", posted_date=old_naive)]
+    result = filter_and_paginate(jobs, JobQueryParams(max_age_days=365))
+    assert result.jobs == []
+
+
+def test_strict_location_remote_honors_country_restriction() -> None:
+    """Worldwide remote passes; remote *restricted* to specific countries is
+    honored — e.g. getonbrd 'remote_local' surfaces as "Remote (Chile)" with
+    countries=["Chile"], and must be hidden for a user outside that list."""
+    jobs = [
+        _job(id="1", location="USA only"),  # free-text, not worldwide, no match
+        _job(id="2", location="Remote"),  # free-text worldwide remote → passes
+        _job(id="3", remote_modality="remote", countries=["Argentina"]),  # remote, AR-only
+        _job(id="4", remote_modality="remote", countries=["Chile"]),  # remote, CL-only
+        _job(id="5", remote_modality="remote", countries=[]),  # remote, worldwide
     ]
     params = JobQueryParams(user_location="Chile", strict_location=True)
     result = filter_and_paginate(jobs, params)
-    assert {j.id for j in result.jobs} == {"2", "3"}
+    # AR-only remote (id=3) is now excluded for a Chile user; worldwide remote
+    # (2, 5) and Chile-restricted remote (4) pass.
+    assert {j.id for j in result.jobs} == {"2", "4", "5"}
 
 
 def test_strict_location_hybrid_requires_country_match() -> None:

--- a/backend/tests/unit/ingestion/test_job_quality_classifier.py
+++ b/backend/tests/unit/ingestion/test_job_quality_classifier.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hiresense.ingestion.domain.job_quality import JobQuality
+from hiresense.ingestion.domain.job_quality_classifier import JobQualityClassifier
+from hiresense.ingestion.domain.models import NormalizedJob
+
+
+def _job(job_id: str, title: str = "Backend Engineer", description: str = "Build APIs.",
+         company: str = "Acme") -> NormalizedJob:
+    return NormalizedJob(
+        id=job_id, title=title, company=company, description=description, skills=[],
+        source="weworkremotely", source_type="rss", url=f"https://e.com/{job_id}",
+    )
+
+
+class StubLLM:
+    def __init__(self, response: str) -> None:
+        self.response = response
+        self.calls: list[str] = []
+
+    async def complete(self, prompt: str, *, system: str = "", model: str = "") -> str:
+        self.calls.append(prompt)
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_deterministic_spam_phrase_flags_without_llm() -> None:
+    llm = StubLLM("[]")
+    svc = JobQualityClassifier(llm=llm)
+    jobs = [
+        _job("a", title="Marketing Automation SaaS + Services - Line of Business Owner"),
+    ]
+    out = await svc.classify(jobs)
+    assert out["a"].quality is JobQuality.SPAM
+    assert out["a"].reason  # a concrete reason is attached
+    assert llm.calls == []  # high-precision marker short-circuits the LLM
+
+
+@pytest.mark.asyncio
+async def test_llm_classifies_non_obvious_jobs() -> None:
+    response = json.dumps(
+        [
+            {"ref": 1, "quality": "ok"},
+            {"ref": 2, "quality": "spam", "reason": "Commission-only sales pitch"},
+        ]
+    )
+    llm = StubLLM(response)
+    svc = JobQualityClassifier(llm=llm)
+    out = await svc.classify([_job("a"), _job("b", title="Sales Rep")])
+    assert out["a"].quality is JobQuality.OK
+    assert out["b"].quality is JobQuality.SPAM
+    assert out["b"].reason == "Commission-only sales pitch"
+    assert len(llm.calls) == 1  # one batched call
+
+
+@pytest.mark.asyncio
+async def test_no_llm_fails_open_to_ok() -> None:
+    svc = JobQualityClassifier(llm=None)
+    out = await svc.classify([_job("a"), _job("b")])
+    assert out["a"].quality is JobQuality.OK
+    assert out["b"].quality is JobQuality.OK
+
+
+@pytest.mark.asyncio
+async def test_llm_error_fails_open_to_ok() -> None:
+    class BoomLLM:
+        async def complete(self, prompt: str, *, system: str = "", model: str = "") -> str:
+            raise RuntimeError("llm down")
+
+    svc = JobQualityClassifier(llm=BoomLLM())
+    out = await svc.classify([_job("a")])
+    assert out["a"].quality is JobQuality.OK
+
+
+@pytest.mark.asyncio
+async def test_unparseable_llm_response_fails_open() -> None:
+    svc = JobQualityClassifier(llm=StubLLM("the model rambled"))
+    out = await svc.classify([_job("a")])
+    assert out["a"].quality is JobQuality.OK
+
+
+@pytest.mark.asyncio
+async def test_empty_input_is_noop() -> None:
+    llm = StubLLM("[]")
+    svc = JobQualityClassifier(llm=llm)
+    assert await svc.classify([]) == {}
+    assert llm.calls == []

--- a/backend/tests/unit/ingestion/test_orchestrator.py
+++ b/backend/tests/unit/ingestion/test_orchestrator.py
@@ -82,6 +82,39 @@ async def test_orchestrator_fetches_and_publishes() -> None:
     assert events[0].event_type == "jobs.ingested"
 
 
+@pytest.mark.asyncio
+async def test_orchestrator_classifies_and_persists_quality() -> None:
+    from hiresense.ingestion.domain.job_quality import JobQuality
+    from hiresense.ingestion.domain.job_quality_verdict import JobQualityVerdict
+
+    class FakeClassifier:
+        def __init__(self) -> None:
+            self.seen: list[str] = []
+
+        async def classify(self, jobs):
+            self.seen = [j.id for j in jobs]
+            return {
+                j.id: JobQualityVerdict(job_id=j.id, quality=JobQuality.SPAM, reason="junk")
+                for j in jobs
+            }
+
+    repo = InMemoryJobsRepository()
+    classifier = FakeClassifier()
+    orchestrator = IngestionOrchestrator(
+        sources=[FakeJobSource()],
+        normalizers={"fake": FakeNormalizer()},
+        event_bus=InMemoryEventBus(),
+        repository=repo,
+        quality_classifier=classifier,
+    )
+    await orchestrator.run()
+
+    assert classifier.seen  # the newly ingested job was handed to the classifier
+    stored = repo.list_all()
+    assert stored
+    assert all(j.quality == "spam" and j.quality_reason == "junk" for j in stored)
+
+
 # --- Lifecycle: change detection + disappearance closure (Task 11) ---
 
 def _raw(sid: str, *, title: str = "Engineer", salary: str = "") -> RawJobListing:

--- a/docs/superpowers/specs/2026-06-08-job-quality-detection-design.md
+++ b/docs/superpowers/specs/2026-06-08-job-quality-detection-design.md
@@ -1,0 +1,98 @@
+# Job Quality / Trash-&-Spam Detection — Design
+
+**Date:** 2026-06-08
+**Status:** Approved (direct user request — "do the full change correctly")
+**Scope:** Detect and hide low-quality / fake / spam job listings (MLM pitches,
+commission-only "be your own boss" roles, content-farm reposts, empty shells)
+so they don't pollute the ingestion list. Triggered by listings like
+"Marketing Automation SaaS + Services — Line of Business Owner" surfacing as
+real jobs.
+
+## Problem
+
+The ingestion pipeline ranks and shows everything it fetches. Three classes of
+junk slip through:
+
+1. **Stale** — re-surfaced postings with an old `posted_date`. *(Handled
+   separately by the `max_age_days` filter — out of scope here.)*
+2. **Empty / data-quality** — blank company, no description. *(Partly handled
+   by source-specific normalizer fixes, e.g. getonboard company resolution.)*
+3. **Spam / scam / low-value** — MLM, franchise/"line of business owner",
+   commission-only, pyramid pitches, recruiter content-farms. **This is what
+   this feature targets.**
+
+These are not reliably separable by keywords alone (a legit "Business
+Development" role vs an MLM "be your own boss" pitch share vocabulary), so the
+detector must be **LLM-backed**, not purely heuristic.
+
+## Approach: classify once at ingestion, persist on the job, filter at query
+
+Job quality is **intrinsic to the job and profile-independent**, so — unlike the
+match score — it is computed **once when a job is ingested** (insert / update /
+reopen) and persisted on the job row. The listing query then hides flagged jobs
+by default, with an opt-in toggle to reveal them (mirrors the existing
+`include_closed` / "Show closed" pattern).
+
+### Hybrid classifier (deterministic fast-path + LLM)
+
+`JobQualityClassifier` (ingestion domain service, depends only on `LLMPort`):
+
+1. **Deterministic spam signals** (cheap, run first): a small set of
+   high-precision markers — "line of business owner", "be your own boss",
+   "commission only", "unlimited earning potential", MLM/franchise phrases,
+   empty company **and** thin description, etc. A strong hit short-circuits to
+   `SPAM` with the matched reason (no LLM call needed).
+2. **LLM adjudication** (the non-heuristic part): for everything else, a single
+   cheap-model call classifies the job as `ok | low_quality | spam` with a short
+   reason. Batched per ingestion run, degrades to `OK` (fail-open — never hide a
+   job because the LLM was unavailable) on error / no LLM configured.
+
+Result: `JobQualityVerdict { quality: JobQuality, reason: str | None }`.
+
+`JobQuality` ∈ `{ ok, low_quality, spam }`.
+
+### Persistence
+
+- `NormalizedJob` gains `quality: str = "ok"` and `quality_reason: str | None`.
+- `JobOrm` gains `quality` + `quality_reason` columns (Alembic migration; the
+  default backfills existing rows to `ok` so nothing is hidden retroactively).
+- Repository maps both directions; content-hash is **not** affected by quality
+  (quality is derived, not source data).
+
+### Where it runs
+
+In `IngestionOrchestrator.run`, after upsert, the same `touched` set that is
+sent to the indexer is sent to the classifier; verdicts are persisted via a
+batched score-style write. Classification failures are logged and skipped (the
+job stays `ok`). This keeps it off the request path entirely.
+
+### Query / API
+
+- `filter_and_paginate` gains `include_low_quality: bool`. When `False`
+  (default), jobs with `quality != "ok"` are hidden. Pgvector semantic search
+  also excludes them (same as closed).
+- `GET /ingestion/jobs` gains `include_low_quality` query param; the frontend
+  adds a "Show low-quality" toggle next to "Show closed", and the detail panel
+  shows the quality reason when flagged.
+
+## Fail-open principle
+
+Every uncertain path defaults to **showing** the job (`ok`): no LLM, LLM error,
+parse failure, or unknown verdict → `ok`. Hiding a real job is worse than
+showing a borderline one; the toggle always reveals everything.
+
+## Testing
+
+- Deterministic signals: spam phrases → `SPAM` without an LLM call.
+- LLM path: stubbed LLM returns each verdict; fail-open on error / no LLM.
+- Filter: `quality != ok` hidden unless `include_low_quality`.
+- Orchestrator: touched jobs get classified + persisted; failure leaves `ok`.
+- Migration: column added with `ok` default; round-trips through the repo.
+
+## Non-goals
+
+- Ghost-job / "is this company actually hiring" detection (needs external
+  signals).
+- Per-profile relevance (that's the match score, already handled).
+- Re-classifying the entire existing corpus automatically — a one-off backfill
+  endpoint can be added later; new/updated jobs are classified going forward.

--- a/frontend/src/app/core/services/ingestion.service.ts
+++ b/frontend/src/app/core/services/ingestion.service.ts
@@ -35,6 +35,8 @@ export class IngestionService {
     // skill+ANN+min_score pipeline (set/order unchanged) but defers the blocking
     // LLM call, reusing cached scores (#76). Defaults to true (full scoring).
     rescore = true,
+    // Reveal jobs flagged low-quality / spam (hidden by default).
+    includeLowQuality = false,
   ): Observable<PaginatedJobsResponse> {
     let params = new HttpParams()
       .set('tab', tab)
@@ -43,6 +45,7 @@ export class IngestionService {
 
     if (includeClosed) params = params.set('include_closed', 'true');
     if (!rescore) params = params.set('rescore', 'false');
+    if (includeLowQuality) params = params.set('include_low_quality', 'true');
 
     if (filters.source) params = params.set('source', filters.source);
     if (filters.keyword) params = params.set('keyword', filters.keyword);

--- a/frontend/src/app/pages/applications/components/job-tab.component.html
+++ b/frontend/src/app/pages/applications/components/job-tab.component.html
@@ -1,7 +1,7 @@
 <div class="job-tab">
   <div class="row">
     <label for="job-tab-description">Job description</label>
-    <textarea id="job-tab-description" rows="10" [ngModel]="description()" (ngModelChange)="description.set($event)"></textarea>
+    <textarea id="job-tab-description" rows="10" [ngModel]="description()" (ngModelChange)="setDescription($event)"></textarea>
   </div>
 
   <div class="row">
@@ -27,5 +27,8 @@
     <button class="btn-primary" (click)="save()" [disabled]="saving()">
       @if (saving()) { Saving... } @else { Save snapshot }
     </button>
+    @if (saved()) {
+      <span class="save-confirmation" role="status">✓ Saved</span>
+    }
   </div>
 </div>

--- a/frontend/src/app/pages/applications/components/job-tab.component.scss
+++ b/frontend/src/app/pages/applications/components/job-tab.component.scss
@@ -41,7 +41,19 @@ textarea {
 
 .btn-sm { font-size: 0.85em; padding: 4px 10px; }
 
-.actions { display: flex; gap: 8px; }
+.actions { display: flex; gap: 8px; align-items: center; }
+
+.save-confirmation {
+  color: #15803d;
+  font-size: 0.875rem;
+  font-weight: 600;
+  animation: fadeIn 0.2s ease both;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
 
 .alert-error {
   background: #fef2f2;

--- a/frontend/src/app/pages/applications/components/job-tab.component.spec.ts
+++ b/frontend/src/app/pages/applications/components/job-tab.component.spec.ts
@@ -87,6 +87,24 @@ describe('JobTabComponent', () => {
     expect(fixture.componentInstance.saving()).toBe(false);
   });
 
+  it('shows the saved confirmation on success and clears it on edit', () => {
+    const { fixture } = mount();
+    expect(fixture.componentInstance.saved()).toBe(false);
+    fixture.componentInstance.save();
+    expect(fixture.componentInstance.saved()).toBe(true);
+    // Editing the description must clear the stale confirmation.
+    fixture.componentInstance.setDescription('changed');
+    expect(fixture.componentInstance.saved()).toBe(false);
+  });
+
+  it('does not show the saved confirmation when save fails', () => {
+    const { fixture } = mount(makeAggregate(), {
+      updateSnapshot: () => throwError(() => ({ error: { detail: 'save boom' } })),
+    });
+    fixture.componentInstance.save();
+    expect(fixture.componentInstance.saved()).toBe(false);
+  });
+
   it('surfaces an error when save fails', () => {
     const { fixture } = mount(makeAggregate(), {
       updateSnapshot: () => throwError(() => ({ error: { detail: 'save boom' } })),

--- a/frontend/src/app/pages/applications/components/job-tab.component.ts
+++ b/frontend/src/app/pages/applications/components/job-tab.component.ts
@@ -22,6 +22,9 @@ export class JobTabComponent implements OnChanges {
   description = signal('');
   skills = signal<string[]>([]);
   saving = signal(false);
+  // True after a successful save; reset the moment the user edits again, so the
+  // "Saved ✓" confirmation can't go stale (the save itself gave no feedback).
+  saved = signal(false);
   regenerating = signal(false);
   error = signal('');
 
@@ -29,12 +32,19 @@ export class JobTabComponent implements OnChanges {
     const snap = this.aggregate().job_snapshot;
     this.description.set(snap?.description ?? '');
     this.skills.set(snap?.required_skills ?? []);
+    this.saved.set(false);
   }
 
   source = computed(() => this.aggregate().job_snapshot?.source ?? 'manual');
 
+  setDescription(value: string): void {
+    this.description.set(value);
+    this.saved.set(false);
+  }
+
   save(): void {
     this.saving.set(true);
+    this.saved.set(false);
     this.error.set('');
     this.service
       .updateSnapshot(this.aggregate().id, {
@@ -45,6 +55,7 @@ export class JobTabComponent implements OnChanges {
       .subscribe({
         next: () => {
           this.saving.set(false);
+          this.saved.set(true);
           this.changed.emit();
         },
         error: (err) => {
@@ -72,9 +83,11 @@ export class JobTabComponent implements OnChanges {
 
   addSkill(skill: string): void {
     this.skills.update((arr) => [...arr, skill]);
+    this.saved.set(false);
   }
 
   removeSkill(skill: string): void {
     this.skills.update((arr) => arr.filter((s) => s !== skill));
+    this.saved.set(false);
   }
 }

--- a/frontend/src/app/pages/ingestion/ingestion.component.html
+++ b/frontend/src/app/pages/ingestion/ingestion.component.html
@@ -132,6 +132,15 @@
         />
         Show closed
       </label>
+      <label class="toggle-label">
+        <input
+          type="checkbox"
+          [checked]="includeLowQuality()"
+          (change)="onIncludeLowQualityChange($event)"
+          class="toggle-checkbox"
+        />
+        Show low-quality
+      </label>
     </div>
   }
 

--- a/frontend/src/app/pages/ingestion/ingestion.component.ts
+++ b/frontend/src/app/pages/ingestion/ingestion.component.ts
@@ -109,6 +109,8 @@ export class IngestionComponent implements OnInit {
 
   // Show closed jobs toggle
   includeClosed = signal(false);
+  // Show low-quality / spam jobs toggle (hidden by default).
+  includeLowQuality = signal(false);
 
   ngOnInit(): void {
     this.feedbackRefetch$
@@ -150,6 +152,7 @@ export class IngestionComponent implements OnInit {
         filtersWithSort,
         this.includeClosed(),
         rescore,
+        this.includeLowQuality(),
       )
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
@@ -301,6 +304,12 @@ export class IngestionComponent implements OnInit {
 
   onIncludeClosedChange(event: Event): void {
     this.includeClosed.set((event.target as HTMLInputElement).checked);
+    this.page.set(1);
+    this.loadJobs();
+  }
+
+  onIncludeLowQualityChange(event: Event): void {
+    this.includeLowQuality.set((event.target as HTMLInputElement).checked);
     this.page.set(1);
     this.loadJobs();
   }

--- a/frontend/src/app/pages/tracking/tracking.component.html
+++ b/frontend/src/app/pages/tracking/tracking.component.html
@@ -134,7 +134,7 @@
                     {{ app.title }}
                   }
                 </td>
-                <td>{{ app.location || '—' }}</td>
+                <td class="location" [title]="app.location || ''">{{ app.location || '—' }}</td>
                 <td>{{ app.salary_range || '—' }}</td>
                 <td>
                   @if (app.source) {

--- a/frontend/src/app/pages/tracking/tracking.component.scss
+++ b/frontend/src/app/pages/tracking/tracking.component.scss
@@ -14,6 +14,16 @@
 .company { font-weight: 500; color: var(--text-primary); }
 .title { color: var(--text-secondary); }
 .date { color: var(--text-muted); font-size: 0.8125rem; white-space: nowrap; }
+// Location can occasionally carry a long, messy free-text value (e.g. HN
+// postings); clamp it so one row can never blow up the whole table layout.
+// Full text remains available via the cell's title tooltip.
+.location {
+  color: var(--text-secondary);
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .notes {
   color: var(--text-muted);
   max-width: 200px;


### PR DESCRIPTION
Bundles ingestion/applications data-quality + UX fixes (design: docs/superpowers/specs/2026-06-08-job-quality-detection-design.md).

## Job quality / spam detection (new feature)
- JobQualityClassifier (ingestion domain): deterministic spam-marker fast-path (MLM / "line of business owner" / commission-only / pyramid) plus a batched LLM adjudicator. Fails open to "ok". Runs once at ingestion; persists quality + quality_reason on the job row (migration 024, defaults ok).
- filter_and_paginate hides quality != ok unless include_low_quality; frontend "Show low-quality" toggle.

## getonboard company
- Listings carry only a company id; GetOnBoardAdapter resolves names via /companies/{id} (cached) and injects company_name.

## Stale-job filter
- max_age_days + ingestion_max_job_age_days (.env=365, 0=off). Hides jobs older than N days; unknown posted_date exempt.

## Carried fixes
- strict_location honors remote country restrictions (getonbrd remote_local).
- hn_hiring location parsing caps part length so the description stops leaking into location (broke the tracking table).
- Tracking table truncating .location cell.
- Application Job tab "Saved" confirmation.

## Tests
Backend 852 passed / 6 skipped; ruff + ng lint clean; migration 024 chains from 023.

## Post-merge
Run `uv run python -m alembic upgrade head`. Quality verdicts + getonboard names populate on the next ingestion run; existing rows stay "ok" until re-ingested.

Generated with Claude Code
