### PR TITLE
fix(ingestion): bound JobQualityClassifier LLM concurrency; add backfill ops scripts

### DIFF
--- a/backend/scripts/backfill_job_quality.py
+++ b/backend/scripts/backfill_job_quality.py
@@ -1,0 +1,71 @@
+"""One-off backfill: classify quality/spam for the existing boards corpus.
+
+Quality is computed at ingestion going forward, but jobs already stored before
+the feature shipped are all "ok". This re-runs the real (LLM-backed) classifier
+over the stored corpus and persists verdicts so the "Show low-quality" filter
+takes effect immediately, without an external re-fetch.
+
+Run from backend/:  uv run python -m scripts.backfill_job_quality
+
+Concurrency is bounded by processing in sequential slices (the classifier itself
+gathers its per-20 chunks concurrently, so a whole-corpus call would otherwise
+fire ~N/20 LLM requests at once).
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from collections import Counter
+
+# Import the app factory first so the package graph initialises in the right
+# order (importing the ports submodule directly first triggers a circular import
+# via portal_scanner).
+from hiresense.main import create_app
+from hiresense.ingestion.ports.jobs_repository import QualityUpdate
+
+SLICE = 60  # jobs per classify() call → ~3 concurrent LLM chunks at a time
+
+
+async def main() -> None:
+    app = create_app()
+    orchestrator = app.state.ingestion.get_orchestrator()
+    classifier = orchestrator._quality_classifier  # noqa: SLF001 (one-off ops script)
+    repository = orchestrator._repository  # noqa: SLF001
+
+    if classifier is None:
+        print("No quality classifier wired; nothing to do.")
+        return
+
+    jobs = repository.list_all()
+    # Optional source filter: `... backfill_job_quality.py getonboard` reclassifies
+    # just that source (e.g. after a re-fetch resolved its company names).
+    source_filter = sys.argv[1] if len(sys.argv) > 1 else None
+    if source_filter:
+        jobs = [j for j in jobs if j.source == source_filter]
+    print(f"Classifying {len(jobs)} {source_filter or 'boards'} jobs in slices of {SLICE}...")
+
+    tally: Counter[str] = Counter()
+    flagged: list[tuple[str, str, str]] = []
+    for start in range(0, len(jobs), SLICE):
+        chunk = jobs[start : start + SLICE]
+        verdicts = await classifier.classify(chunk)
+        updates = [
+            QualityUpdate(v.job_id, v.quality.value, v.reason) for v in verdicts.values()
+        ]
+        repository.bulk_update_quality(updates)
+        for v in verdicts.values():
+            tally[v.quality.value] += 1
+            if v.quality.value != "ok":
+                job = next((j for j in chunk if j.id == v.job_id), None)
+                title = job.title if job else v.job_id
+                flagged.append((v.quality.value, title, v.reason or ""))
+        print(f"  {min(start + SLICE, len(jobs))}/{len(jobs)} done", flush=True)
+
+    print("\nQuality distribution:", dict(tally))
+    print(f"\nFlagged {len(flagged)} jobs:")
+    for quality, title, reason in flagged[:50]:
+        print(f"  [{quality}] {title[:70]} — {reason[:60]}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/scripts/refetch_getonboard.py
+++ b/backend/scripts/refetch_getonboard.py
@@ -1,0 +1,37 @@
+"""One-off: re-fetch ONLY getonboard so company names get resolved + persisted.
+
+The getonboard company *id* was never stored, so the blank-company rows can only
+be fixed by re-pulling from the API (the adapter resolves names via
+/companies/{id} and the upsert persists them). We limit the orchestrator to the
+getonboard source and disable the inline quality classifier (re-run
+scripts/backfill_job_quality.py afterward, which classifies with bounded
+concurrency) to avoid firing ~N/20 concurrent LLM calls on the touched set.
+
+Run from backend/:  uv run python scripts/refetch_getonboard.py
+"""
+from __future__ import annotations
+
+import asyncio
+
+from hiresense.main import create_app
+
+
+async def main() -> None:
+    app = create_app()
+    orchestrator = app.state.ingestion.get_orchestrator()
+
+    sources = [s for s in orchestrator._sources if s.source_name() == "getonboard"]  # noqa: SLF001
+    if not sources:
+        print("getonboard source not enabled; nothing to do.")
+        return
+    orchestrator._sources = sources  # noqa: SLF001
+    orchestrator._quality_classifier = None  # noqa: SLF001  (reclassify via backfill)
+    orchestrator._last_run_at = 0.0  # noqa: SLF001  (fresh process, skip cooldown)
+
+    print("Re-fetching getonboard (resolving company names)...")
+    new_jobs = await orchestrator.run()
+    print(f"Done. {len(new_jobs)} new job(s) inserted; existing rows updated in place.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/src/hiresense/ingestion/domain/job_quality_classifier.py
+++ b/backend/src/hiresense/ingestion/domain/job_quality_classifier.py
@@ -83,10 +83,16 @@ class JobQualityClassifier:
         llm: LLMPort | None,
         batch_size: int = 20,
         desc_char_limit: int = _DESC_CHAR_LIMIT,
+        max_concurrency: int = 4,
     ) -> None:
         self._llm = llm
         self._batch_size = max(1, batch_size)
         self._desc_char_limit = desc_char_limit
+        # Cap concurrent LLM chunk calls so a large ingestion (or a backfill)
+        # can't fan out one request per 20-job chunk all at once and trip the
+        # provider's rate limit. Created lazily per classify() so it always
+        # binds to the running event loop.
+        self._max_concurrency = max(1, max_concurrency)
 
     async def classify(self, jobs: list[NormalizedJob]) -> dict[str, JobQualityVerdict]:
         """Return a verdict for EVERY input job (default OK)."""
@@ -114,7 +120,13 @@ class JobQualityClassifier:
             needs_llm[i : i + self._batch_size]
             for i in range(0, len(needs_llm), self._batch_size)
         ]
-        scored_chunks = await asyncio.gather(*(self._classify_chunk(c) for c in chunks))
+        sem = asyncio.Semaphore(self._max_concurrency)
+
+        async def _bounded(chunk: list[NormalizedJob]) -> dict[str, JobQualityVerdict]:
+            async with sem:
+                return await self._classify_chunk(chunk)
+
+        scored_chunks = await asyncio.gather(*(_bounded(c) for c in chunks))
         for chunk_results in scored_chunks:
             results.update(chunk_results)
         return results

--- a/backend/tests/unit/ingestion/test_job_quality_classifier.py
+++ b/backend/tests/unit/ingestion/test_job_quality_classifier.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -81,6 +82,32 @@ async def test_unparseable_llm_response_fails_open() -> None:
     svc = JobQualityClassifier(llm=StubLLM("the model rambled"))
     out = await svc.classify([_job("a")])
     assert out["a"].quality is JobQuality.OK
+
+
+@pytest.mark.asyncio
+async def test_classify_bounds_llm_concurrency() -> None:
+    """A whole-corpus classify() must not fire one LLM call per 20-job chunk all
+    at once — concurrency is capped so a big ingestion can't burst rate limits."""
+
+    class ConcurrencyTrackingLLM:
+        def __init__(self) -> None:
+            self.current = 0
+            self.max_seen = 0
+
+        async def complete(self, prompt: str, *, system: str = "", model: str = "") -> str:
+            self.current += 1
+            self.max_seen = max(self.max_seen, self.current)
+            await asyncio.sleep(0.02)
+            self.current -= 1
+            return "[]"
+
+    llm = ConcurrencyTrackingLLM()
+    svc = JobQualityClassifier(llm=llm, batch_size=10, max_concurrency=2)
+    jobs = [_job(f"j{i}") for i in range(50)]  # 5 chunks
+
+    await svc.classify(jobs)
+
+    assert llm.max_seen == 2  # capped at max_concurrency, and did run concurrently
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up to the job-quality feature (#79).

## Concurrency fix
`JobQualityClassifier.classify` gathered its per-20-job chunks **unbounded**, so a large ingestion (or whole-corpus backfill) could fire ~N/20 concurrent LLM requests at once and trip the provider's rate limit. Adds a `max_concurrency` cap (default 4) via an `asyncio.Semaphore` created per `classify()` call (so it binds to the running loop). New test asserts concurrency is capped.

## Ops scripts (used to roll the feature out over the existing corpus)
- `scripts/backfill_job_quality.py` — classify the stored corpus in bounded slices; optional source-name arg to reclassify one source.
- `scripts/refetch_getonboard.py` — re-fetch only getonboard so company names (resolved via `/companies/{id}`) persist on existing rows.

Backend 853 passed / 6 skipped; ruff clean.

Generated with Claude Code
