### PR TITLE
feat(analytics): profile-aware dashboard — comp benchmark, performance, search focus

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -193,6 +193,8 @@ PREFERENCE_NUDGE_SCALE=5.0
 ANALYTICS_CACHE_TTL_SECONDS=300
 ANALYTICS_TARGET_SALARY_TOP_K=50
 ANALYTICS_TARGET_SALARY_MIN_SAMPLE=5
+# Search-focus: a profile-matched job counts as "fresh" if posted within N days.
+ANALYTICS_FOCUS_FRESH_DAYS=14
 # Sampling cap for the full-corpus aggregation scans (top-skills, skill-gap,
 # posting trend, salary distribution). Each scan reads at most this many open
 # postings into memory, so the aggregates are computed over a SAMPLE of up to

--- a/backend/src/hiresense/analytics/api/routes.py
+++ b/backend/src/hiresense/analytics/api/routes.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends
 
 from hiresense.analytics.api.dependencies import get_analytics_service
-from hiresense.analytics.domain import AnalyticsService, FunnelMetrics, MarketIntel, SkillGap, TargetSalary
+from hiresense.analytics.domain import (
+    AnalyticsService,
+    CompBenchmark,
+    FunnelMetrics,
+    MarketIntel,
+    SearchFocus,
+    SkillGap,
+    TargetSalary,
+)
 from hiresense.identity.api.dependencies import require_auth
 
 router = APIRouter(prefix="/analytics", tags=["analytics"], dependencies=[Depends(require_auth)])
@@ -27,3 +35,13 @@ def skill_gap(service: AnalyticsService = Depends(get_analytics_service)) -> Ski
 @router.get("/target-salary", response_model=TargetSalary)
 async def target_salary(service: AnalyticsService = Depends(get_analytics_service)) -> TargetSalary:
     return await service.target_salary()
+
+
+@router.get("/comp", response_model=CompBenchmark)
+async def comp(service: AnalyticsService = Depends(get_analytics_service)) -> CompBenchmark:
+    return await service.comp()
+
+
+@router.get("/focus", response_model=SearchFocus)
+async def focus(service: AnalyticsService = Depends(get_analytics_service)) -> SearchFocus:
+    return await service.focus()

--- a/backend/src/hiresense/analytics/domain/__init__.py
+++ b/backend/src/hiresense/analytics/domain/__init__.py
@@ -1,5 +1,20 @@
 from hiresense.analytics.domain.analytics_service import AnalyticsService
-from hiresense.analytics.domain.funnel_service import FunnelMetrics, FunnelService, FunnelStage
+from hiresense.analytics.domain.comp_benchmark_service import (
+    CompBenchmark,
+    CompBenchmarkService,
+    SeniorityBand,
+)
+from hiresense.analytics.domain.funnel_service import (
+    FunnelMetrics,
+    FunnelService,
+    FunnelStage,
+    SourceOutcome,
+)
+from hiresense.analytics.domain.search_focus_service import (
+    FocusItem,
+    SearchFocus,
+    SearchFocusService,
+)
 from hiresense.analytics.domain.market_service import (
     MarketIntel,
     MarketIntelService,
@@ -15,9 +30,16 @@ from hiresense.analytics.domain.ttl_cache import TtlCache
 
 __all__ = [
     "AnalyticsService",
+    "CompBenchmark",
+    "CompBenchmarkService",
+    "FocusItem",
     "FunnelMetrics",
     "FunnelService",
     "FunnelStage",
+    "SearchFocus",
+    "SearchFocusService",
+    "SeniorityBand",
+    "SourceOutcome",
     "MarketIntel",
     "MarketIntelService",
     "ParsedSalary",

--- a/backend/src/hiresense/analytics/domain/analytics_service.py
+++ b/backend/src/hiresense/analytics/domain/analytics_service.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from hiresense.analytics.domain.comp_benchmark_service import CompBenchmark, CompBenchmarkService
 from hiresense.analytics.domain.funnel_service import FunnelMetrics, FunnelService
 from hiresense.analytics.domain.market_service import MarketIntel, MarketIntelService
+from hiresense.analytics.domain.search_focus_service import SearchFocus, SearchFocusService
 from hiresense.analytics.domain.skill_gap_service import SkillGap, SkillGapService
 from hiresense.analytics.domain.target_salary_service import TargetSalary, TargetSalaryService
 
@@ -18,6 +20,8 @@ class AnalyticsService:
         market: MarketIntelService,
         skill_gap: SkillGapService,
         target_salary: TargetSalaryService,
+        comp_benchmark: CompBenchmarkService,
+        search_focus: SearchFocusService,
         profile_service: Any,
         cache: Any,
         language: str = "en",
@@ -26,6 +30,8 @@ class AnalyticsService:
         self._market = market
         self._skill_gap = skill_gap
         self._target_salary = target_salary
+        self._comp_benchmark = comp_benchmark
+        self._search_focus = search_focus
         self._profile = profile_service
         self._cache = cache
         self._language = language
@@ -40,11 +46,23 @@ class AnalyticsService:
         return self._skill_gap.compute(profile_skills=self._profile_skills())
 
     async def target_salary(self) -> TargetSalary:
-        view = self._profile.get_for_language(self._language)
-        skills = list(view.skills) if view else []
-        summary = view.summary if view else ""
+        skills, summary = self._profile_skills_summary()
         return await self._target_salary.compute(profile_skills=skills, summary=summary)
+
+    async def comp(self) -> CompBenchmark:
+        skills, summary = self._profile_skills_summary()
+        return await self._comp_benchmark.compute(profile_skills=skills, summary=summary)
+
+    async def focus(self) -> SearchFocus:
+        skills, summary = self._profile_skills_summary()
+        return await self._search_focus.compute(profile_skills=skills, summary=summary)
 
     def _profile_skills(self) -> list[str]:
         view = self._profile.get_for_language(self._language)
         return list(view.skills) if view else []
+
+    def _profile_skills_summary(self) -> tuple[list[str], str]:
+        view = self._profile.get_for_language(self._language)
+        skills = list(view.skills) if view else []
+        summary = view.summary if view else ""
+        return skills, summary

--- a/backend/src/hiresense/analytics/domain/comp_benchmark_service.py
+++ b/backend/src/hiresense/analytics/domain/comp_benchmark_service.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import logging
+import statistics
+from typing import Any
+
+from pydantic import BaseModel
+
+from hiresense.ingestion.domain.seniority import SeniorityLevel, detect_seniority
+
+logger = logging.getLogger(__name__)
+
+
+class SeniorityBand(BaseModel):
+    level: str
+    median_annual: int
+    sample_size: int
+
+
+class CompBenchmark(BaseModel):
+    """Profile-aware compensation benchmark.
+
+    The market band (p25/median/p75) is computed from the salaries of the jobs
+    that best match the candidate's profile (ANN over the corpus). `by_seniority`
+    splits those matches by detected seniority; `your_median_annual` is the
+    candidate's tracked-application median for an above/below-market read; the
+    suggested ask range is [median, p75] of the market band.
+    """
+
+    insufficient_data: bool
+    currency: str | None = None
+    p25_annual: int | None = None
+    median_annual: int | None = None
+    p75_annual: int | None = None
+    sample_size: int = 0
+    by_seniority: list[SeniorityBand] = []
+    your_median_annual: int | None = None
+    your_sample_size: int = 0
+    ask_min_annual: int | None = None
+    ask_max_annual: int | None = None
+
+
+def _percentile(sorted_vals: list[int], q: float) -> int:
+    if not sorted_vals:
+        return 0
+    idx = min(len(sorted_vals) - 1, max(0, round(q * (len(sorted_vals) - 1))))
+    return sorted_vals[idx]
+
+
+_SENIORITY_ORDER = [
+    SeniorityLevel.INTERN, SeniorityLevel.JUNIOR, SeniorityLevel.MID,
+    SeniorityLevel.SENIOR, SeniorityLevel.LEAD,
+]
+
+
+class CompBenchmarkService:
+    def __init__(
+        self, *, embedding: Any, vector_store: Any, corpus: Any, salary_parser: Any,
+        tracking_read: Any, top_k: int, min_sample: int,
+    ) -> None:
+        self._embedding = embedding
+        self._vector_store = vector_store
+        self._corpus = corpus
+        self._salary = salary_parser
+        self._tracking = tracking_read
+        self._top_k = top_k
+        self._min_sample = min_sample
+
+    async def compute(self, *, profile_skills: list[str], summary: str) -> CompBenchmark:
+        text = f"{' '.join(profile_skills)}\n{summary}".strip()
+        if self._vector_store is None or not text:
+            return CompBenchmark(insufficient_data=True)
+        try:
+            vectors = await self._embedding.embed([text])
+            results = await self._vector_store.search(vectors[0], top_k=self._top_k)
+        except Exception:
+            logger.exception("comp-benchmark: embedding/search failed")
+            return CompBenchmark(insufficient_data=True)
+
+        ids = [r.id for r in results]
+        rows = self._corpus.rows_for_ids(ids)
+        descriptions = self._corpus.descriptions_for_ids(ids)
+
+        # mid-point annual salary per matched job, grouped by currency
+        by_currency: dict[str, list[tuple[str, int]]] = {}  # currency -> [(job_id, mid)]
+        for jid, row in rows.items():
+            parsed = self._salary.parse(row.salary_range)
+            if parsed is None:
+                continue
+            mid = (parsed.min_annual + parsed.max_annual) // 2
+            by_currency.setdefault(parsed.currency, []).append((jid, mid))
+
+        if not by_currency:
+            return CompBenchmark(insufficient_data=True)
+
+        dominant = max(by_currency, key=lambda c: len(by_currency[c]))
+        entries = by_currency[dominant]
+        vals = sorted(mid for _, mid in entries)
+        your_median, your_n = self._pipeline_median(dominant)
+
+        if len(vals) < self._min_sample:
+            return CompBenchmark(
+                insufficient_data=True, currency=dominant, sample_size=len(vals),
+                your_median_annual=your_median, your_sample_size=your_n,
+            )
+
+        median = int(statistics.median(vals))
+        p75 = _percentile(vals, 0.75)
+        return CompBenchmark(
+            insufficient_data=False, currency=dominant,
+            p25_annual=_percentile(vals, 0.25), median_annual=median, p75_annual=p75,
+            sample_size=len(vals),
+            by_seniority=self._seniority_bands(entries, rows, descriptions),
+            your_median_annual=your_median, your_sample_size=your_n,
+            ask_min_annual=median, ask_max_annual=p75,
+        )
+
+    def _seniority_bands(
+        self, entries: list[tuple[str, int]], rows: dict, descriptions: dict,
+    ) -> list[SeniorityBand]:
+        buckets: dict[SeniorityLevel, list[int]] = {}
+        for jid, mid in entries:
+            row = rows.get(jid)
+            if row is None:
+                continue
+            level = detect_seniority(row.title, descriptions.get(jid, ""))
+            if level is SeniorityLevel.UNKNOWN:
+                continue
+            buckets.setdefault(level, []).append(mid)
+        bands: list[SeniorityBand] = []
+        for level in _SENIORITY_ORDER:
+            mids = buckets.get(level)
+            if mids and len(mids) >= self._min_sample:
+                bands.append(SeniorityBand(
+                    level=level.value, median_annual=int(statistics.median(mids)),
+                    sample_size=len(mids),
+                ))
+        return bands
+
+    def _pipeline_median(self, currency: str) -> tuple[int | None, int]:
+        """Median annual salary across the candidate's tracked applications, in
+        the same currency as the market band. None when none are parseable."""
+        if self._tracking is None:
+            return None, 0
+        try:
+            apps = self._tracking.list()
+        except Exception:
+            logger.exception("comp-benchmark: tracking list failed")
+            return None, 0
+        job_ids = [str(a.job_id) for a in apps if getattr(a, "job_id", None)]
+        if not job_ids:
+            return None, 0
+        salary_by_id = self._corpus.salary_strings_for_ids(job_ids)
+        mids: list[int] = []
+        for raw in salary_by_id.values():
+            parsed = self._salary.parse(raw)
+            if parsed is not None and parsed.currency == currency:
+                mids.append((parsed.min_annual + parsed.max_annual) // 2)
+        if not mids:
+            return None, 0
+        return int(statistics.median(mids)), len(mids)

--- a/backend/src/hiresense/analytics/domain/funnel_service.py
+++ b/backend/src/hiresense/analytics/domain/funnel_service.py
@@ -19,16 +19,29 @@ class FunnelStage(BaseModel):
     current: int
 
 
+class SourceOutcome(BaseModel):
+    """Per job-source pipeline outcome: how many tracked apps came from this
+    source and what share reached the interview stage (by current status)."""
+
+    source: str
+    applications: int
+    reached_interview: int
+    interview_rate: float
+
+
 class FunnelMetrics(BaseModel):
     stages: list[FunnelStage]
     rejected: int
     current_rejected: int
     total_applications: int
+    by_source: list[SourceOutcome] = []
 
 
 class FunnelService:
-    def __init__(self, history: Any) -> None:
+    def __init__(self, history: Any, applications_read: Any = None, corpus: Any = None) -> None:
         self._history = history
+        self._applications = applications_read
+        self._corpus = corpus
 
     def compute(self) -> FunnelMetrics:
         rows = self._history.list_history()
@@ -91,4 +104,39 @@ class FunnelService:
         return FunnelMetrics(
             stages=stages_out, rejected=rejected,
             current_rejected=current_rejected, total_applications=len(by_app),
+            by_source=self._by_source(),
         )
+
+    def _by_source(self) -> list[SourceOutcome]:
+        """Outcomes grouped by the job's source. Uses each tracked app's current
+        status (rank >= interviewing counts as reached-interview) — a simple
+        which-source-converts signal, not a high-water-mark over history."""
+        if self._applications is None or self._corpus is None:
+            return []
+        try:
+            apps = self._applications.list()
+        except Exception:
+            return []
+        job_ids = [str(a.job_id) for a in apps if getattr(a, "job_id", None)]
+        if not job_ids:
+            return []
+        rows = self._corpus.rows_for_ids(job_ids)
+        totals: dict[str, int] = defaultdict(int)
+        reached: dict[str, int] = defaultdict(int)
+        for app in apps:
+            jid = str(app.job_id) if getattr(app, "job_id", None) else None
+            row = rows.get(jid) if jid else None
+            if row is None or not row.source:
+                continue
+            totals[row.source] += 1
+            if _RANK.get(app.status, -1) >= _RANK["interviewing"]:
+                reached[row.source] += 1
+        outcomes = [
+            SourceOutcome(
+                source=src, applications=n, reached_interview=reached[src],
+                interview_rate=round(reached[src] / n, 4) if n else 0.0,
+            )
+            for src, n in totals.items()
+        ]
+        outcomes.sort(key=lambda o: (o.applications, o.interview_rate), reverse=True)
+        return outcomes

--- a/backend/src/hiresense/analytics/domain/search_focus_service.py
+++ b/backend/src/hiresense/analytics/domain/search_focus_service.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+class FocusItem(BaseModel):
+    label: str
+    count: int
+    avg_score: float
+
+
+class SearchFocus(BaseModel):
+    """Profile-aware "where to aim" view, computed from the candidate's
+    best-matching open jobs (ANN over the corpus, spam/closed excluded)."""
+
+    insufficient_data: bool
+    match_count: int = 0
+    best_fit_companies: list[FocusItem] = []
+    best_fit_roles: list[FocusItem] = []
+    remote_share: float | None = None
+    top_locations: list[FocusItem] = []
+    fresh_fit_count: int = 0
+
+
+def _normalize_title(title: str) -> str:
+    """Light role normalisation: strip seniority words / parentheticals / levels
+    so 'Senior Backend Engineer (Remote)' and 'Backend Engineer' group together."""
+    import re
+
+    t = title.lower()
+    t = re.sub(r"\(.*?\)", " ", t)  # drop parentheticals
+    t = re.sub(
+        r"\b(senior|sr|junior|jr|staff|lead|principal|mid|intern|entry[- ]level|"
+        r"i{1,3}|iv|v|[0-9]+)\b", " ", t,
+    )
+    t = re.sub(r"[^a-z ]", " ", t)
+    t = re.sub(r"\s+", " ", t).strip()
+    return t.title() if t else (title.strip() or "—")
+
+
+def _top(counter: dict[str, list[float]], n: int) -> list[FocusItem]:
+    items = [
+        FocusItem(label=label, count=len(scores), avg_score=round(sum(scores) / len(scores), 4))
+        for label, scores in counter.items()
+        if scores
+    ]
+    items.sort(key=lambda i: (i.count, i.avg_score), reverse=True)
+    return items[:n]
+
+
+class SearchFocusService:
+    def __init__(
+        self, *, embedding: Any, vector_store: Any, corpus: Any,
+        top_k: int, fresh_days: int, top_n: int = 8,
+    ) -> None:
+        self._embedding = embedding
+        self._vector_store = vector_store
+        self._corpus = corpus
+        self._top_k = top_k
+        self._fresh_days = fresh_days
+        self._top_n = top_n
+
+    async def compute(self, *, profile_skills: list[str], summary: str) -> SearchFocus:
+        text = f"{' '.join(profile_skills)}\n{summary}".strip()
+        if self._vector_store is None or not text:
+            return SearchFocus(insufficient_data=True)
+        try:
+            vectors = await self._embedding.embed([text])
+            results = await self._vector_store.search(vectors[0], top_k=self._top_k)
+        except Exception:
+            logger.exception("search-focus: embedding/search failed")
+            return SearchFocus(insufficient_data=True)
+
+        score_by_id = {r.id: r.score for r in results}
+        rows = self._corpus.rows_for_ids(list(score_by_id))
+        # Only genuinely-applyable matches: open + not spam/low-quality.
+        matches = [
+            (row, score_by_id.get(jid, 0.0))
+            for jid, row in rows.items()
+            if row.status != "closed" and (row.quality or "ok") == "ok"
+        ]
+        if not matches:
+            return SearchFocus(insufficient_data=True)
+
+        companies: dict[str, list[float]] = defaultdict(list)
+        roles: dict[str, list[float]] = defaultdict(list)
+        locations: dict[str, list[float]] = defaultdict(list)
+        remote = 0
+        fresh = 0
+        cutoff = datetime.now(timezone.utc) - timedelta(days=self._fresh_days)
+        for row, score in matches:
+            if row.company.strip():
+                companies[row.company.strip()].append(score)
+            roles[_normalize_title(row.title)].append(score)
+            if row.location.strip():
+                locations[row.location.strip()].append(score)
+            if row.remote_modality == "remote":
+                remote += 1
+            if row.posted_date is not None:
+                posted = row.posted_date
+                if posted.tzinfo is None:
+                    posted = posted.replace(tzinfo=timezone.utc)
+                if posted >= cutoff:
+                    fresh += 1
+
+        return SearchFocus(
+            insufficient_data=False,
+            match_count=len(matches),
+            best_fit_companies=_top(companies, self._top_n),
+            best_fit_roles=_top(roles, self._top_n),
+            remote_share=round(remote / len(matches), 4),
+            top_locations=_top(locations, self._top_n),
+            fresh_fit_count=fresh,
+        )

--- a/backend/src/hiresense/analytics/infrastructure/corpus_repository.py
+++ b/backend/src/hiresense/analytics/infrastructure/corpus_repository.py
@@ -1,11 +1,28 @@
 from __future__ import annotations
 
+import dataclasses
 from datetime import datetime
 from typing import Any
 
 from sqlalchemy import func, select
 
 from hiresense.ingestion.infrastructure.models import IngestedJob
+
+
+@dataclasses.dataclass(frozen=True)
+class CorpusJobRow:
+    """A read-only projection of an ingested job for analytics enrichment."""
+
+    id: str
+    title: str
+    company: str
+    location: str
+    source: str
+    salary_range: str | None
+    posted_date: datetime | None
+    remote_modality: str | None
+    status: str
+    quality: str
 
 
 class CorpusAnalyticsRepository:
@@ -74,3 +91,35 @@ class CorpusAnalyticsRepository:
                 IngestedJob.id.in_(job_ids)
             )
             return {row[0]: row[1] for row in session.execute(stmt).all()}
+
+    def descriptions_for_ids(self, job_ids: list[str]) -> dict[str, str]:
+        """Job descriptions keyed by id (for seniority detection on matched jobs)."""
+        if not job_ids:
+            return {}
+        with self._session_factory() as session:
+            stmt = select(IngestedJob.id, IngestedJob.description).where(
+                IngestedJob.id.in_(job_ids)
+            )
+            return {row[0]: (row[1] or "") for row in session.execute(stmt).all()}
+
+    def rows_for_ids(self, job_ids: list[str]) -> dict[str, CorpusJobRow]:
+        """Full projections keyed by id — enrichment for comp / focus / by-source.
+
+        Returns only the ids that exist; callers filter on status/quality.
+        """
+        if not job_ids:
+            return {}
+        with self._session_factory() as session:
+            stmt = select(
+                IngestedJob.id, IngestedJob.title, IngestedJob.company, IngestedJob.location,
+                IngestedJob.source, IngestedJob.salary_range, IngestedJob.posted_date,
+                IngestedJob.remote_modality, IngestedJob.status, IngestedJob.quality,
+            ).where(IngestedJob.id.in_(job_ids))
+            return {
+                r[0]: CorpusJobRow(
+                    id=r[0], title=r[1] or "", company=r[2] or "", location=r[3] or "",
+                    source=r[4] or "", salary_range=r[5], posted_date=r[6],
+                    remote_modality=r[7], status=r[8] or "open", quality=r[9] or "ok",
+                )
+                for r in session.execute(stmt).all()
+            }

--- a/backend/src/hiresense/bootstrap/analytics.py
+++ b/backend/src/hiresense/bootstrap/analytics.py
@@ -6,9 +6,11 @@ from typing import Any
 from hiresense.analytics.api.provider import AnalyticsProvider
 from hiresense.analytics.domain import (
     AnalyticsService,
+    CompBenchmarkService,
     FunnelService,
     MarketIntelService,
     SalaryParser,
+    SearchFocusService,
     SkillGapService,
     SkillNormalizer,
     TargetSalaryService,
@@ -24,7 +26,12 @@ class AnalyticsBuild:
     service: AnalyticsService
 
 
-def build_analytics(infra: SharedInfra, profile_service: Any, status_history_read: Any) -> AnalyticsBuild:
+def build_analytics(
+    infra: SharedInfra,
+    profile_service: Any,
+    status_history_read: Any,
+    tracking_read: Any = None,
+) -> AnalyticsBuild:
     s = infra.settings
     corpus = CorpusAnalyticsRepository(
         session_factory=infra.sync_session_factory,
@@ -33,7 +40,7 @@ def build_analytics(infra: SharedInfra, profile_service: Any, status_history_rea
     normalizer = SkillNormalizer()
     salary_parser = SalaryParser()
     service = AnalyticsService(
-        funnel=FunnelService(status_history_read),
+        funnel=FunnelService(status_history_read, applications_read=tracking_read, corpus=corpus),
         market=MarketIntelService(corpus, normalizer, salary_parser),
         skill_gap=SkillGapService(corpus, normalizer),
         target_salary=TargetSalaryService(
@@ -43,6 +50,22 @@ def build_analytics(infra: SharedInfra, profile_service: Any, status_history_rea
             salary_parser=salary_parser,
             top_k=s.analytics_target_salary_top_k,
             min_sample=s.analytics_target_salary_min_sample,
+        ),
+        comp_benchmark=CompBenchmarkService(
+            embedding=infra.embedding,
+            vector_store=infra.vector_store,
+            corpus=corpus,
+            salary_parser=salary_parser,
+            tracking_read=tracking_read,
+            top_k=s.analytics_target_salary_top_k,
+            min_sample=s.analytics_target_salary_min_sample,
+        ),
+        search_focus=SearchFocusService(
+            embedding=infra.embedding,
+            vector_store=infra.vector_store,
+            corpus=corpus,
+            top_k=s.analytics_target_salary_top_k,
+            fresh_days=s.analytics_focus_fresh_days,
         ),
         profile_service=profile_service,
         cache=TtlCache(ttl_seconds=s.analytics_cache_ttl_seconds),

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -280,6 +280,9 @@ class Settings(BaseSettings):
     # minimum parseable-salaried matches required before reporting a band.
     analytics_target_salary_top_k: int = 50
     analytics_target_salary_min_sample: int = 5
+    # Search-focus "fresh fit": a profile-matched job counts as fresh if its
+    # posted_date is within this many days.
+    analytics_focus_fresh_days: int = 14
     # Sampling cap for the full-corpus aggregation scans (top-skills, skill-gap,
     # posting trend, salary distribution). These read every open posting into
     # memory; this caps the number of rows fetched per scan so memory/CPU stay

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -144,7 +144,9 @@ def create_app() -> FastAPI:
     app.include_router(autohunt_router)
 
     # --- Analytics (read-only funnel + market + skill-gap) ---
-    analytics = build_analytics(infra, profile.service, tracking.status_history_read)
+    analytics = build_analytics(
+        infra, profile.service, tracking.status_history_read, tracking_read=tracking.service
+    )
     app.state.analytics = analytics.provider
     app.include_router(analytics_router)
 

--- a/backend/tests/integration/test_analytics_endpoints.py
+++ b/backend/tests/integration/test_analytics_endpoints.py
@@ -11,9 +11,11 @@ from hiresense.analytics.api import router as analytics_router
 from hiresense.analytics.api.dependencies import get_analytics_service
 from hiresense.analytics.domain import (
     AnalyticsService,
+    CompBenchmarkService,
     FunnelService,
     MarketIntelService,
     SalaryParser,
+    SearchFocusService,
     SkillGapService,
     SkillNormalizer,
     TargetSalaryService,
@@ -64,15 +66,20 @@ def _seed(factory):
     return repo
 
 
-def _build_app(factory, history):
+def _build_app(factory, history, tracking_read=None):
     corpus = CorpusAnalyticsRepository(session_factory=factory, sample_cap=5000)
     norm, sal = SkillNormalizer(), SalaryParser()
     service = AnalyticsService(
-        funnel=FunnelService(history),
+        funnel=FunnelService(history, applications_read=tracking_read, corpus=corpus),
         market=MarketIntelService(corpus, norm, sal),
         skill_gap=SkillGapService(corpus, norm),
         target_salary=TargetSalaryService(embedding=_Emb(), vector_store=_Store(), corpus=corpus,
                                           salary_parser=sal, top_k=50, min_sample=5),
+        comp_benchmark=CompBenchmarkService(embedding=_Emb(), vector_store=_Store(), corpus=corpus,
+                                            salary_parser=sal, tracking_read=tracking_read,
+                                            top_k=50, min_sample=5),
+        search_focus=SearchFocusService(embedding=_Emb(), vector_store=_Store(), corpus=corpus,
+                                        top_k=50, fresh_days=14),
         profile_service=_FakeProfile(),
         cache=TtlCache(ttl_seconds=300),
     )
@@ -134,3 +141,98 @@ async def test_target_salary_insufficient():
         r = await c.get("/analytics/target-salary")
         assert r.status_code == 200
         assert r.json()["insufficient_data"] is True  # _Store returns no matches
+
+
+class _MatchStore:
+    """Returns ANN results for the given ids (descending score)."""
+
+    def __init__(self, ids):
+        self._ids = ids
+
+    async def search(self, query_embedding, *, top_k=10, filters=None):
+        n = len(self._ids)
+        return [
+            type("R", (), {"id": jid, "score": 1.0 - i / max(n, 1)})()
+            for i, jid in enumerate(self._ids)
+        ]
+
+
+def _seed_salaried(factory, n=6):
+    """Seed n open jobs with parseable USD salaries + senior titles."""
+    ids = [f"s{i}" for i in range(n)]
+    with factory() as s:
+        for i, jid in enumerate(ids):
+            s.add(IngestedJob(
+                id=jid, bucket="boards", source="getonboard" if i % 2 else "linkedin",
+                source_type="board", title=f"Senior Backend Engineer {i}",
+                description="Senior role, 5+ years", skills=["python"],
+                remote_modality="remote" if i % 2 else "on_site",
+                salary_range=f"${100 + i * 5}k-${120 + i * 5}k", status="open",
+                quality="ok", identity_key=f"sk{i}", company=f"Co{i}",
+                location="Remote" if i % 2 else "NYC",
+                posted_date=datetime.now(timezone.utc),
+            ))
+        s.commit()
+    return ids
+
+
+def _build_app_with_store(factory, history, store, tracking_read=None):
+    corpus = CorpusAnalyticsRepository(session_factory=factory, sample_cap=5000)
+    norm, sal = SkillNormalizer(), SalaryParser()
+    service = AnalyticsService(
+        funnel=FunnelService(history, applications_read=tracking_read, corpus=corpus),
+        market=MarketIntelService(corpus, norm, sal),
+        skill_gap=SkillGapService(corpus, norm),
+        target_salary=TargetSalaryService(embedding=_Emb(), vector_store=store, corpus=corpus,
+                                          salary_parser=sal, top_k=50, min_sample=5),
+        comp_benchmark=CompBenchmarkService(embedding=_Emb(), vector_store=store, corpus=corpus,
+                                            salary_parser=sal, tracking_read=tracking_read,
+                                            top_k=50, min_sample=5),
+        search_focus=SearchFocusService(embedding=_Emb(), vector_store=store, corpus=corpus,
+                                        top_k=50, fresh_days=14),
+        profile_service=_FakeProfile(),
+        cache=TtlCache(ttl_seconds=300),
+    )
+    app = FastAPI()
+    app.dependency_overrides[require_auth] = lambda: "test-user"
+    app.dependency_overrides[get_analytics_service] = lambda: service
+    app.include_router(analytics_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_comp_endpoint_returns_band_and_seniority():
+    factory = _factory()
+    history = _seed(factory)
+    ids = _seed_salaried(factory, n=6)
+    app = _build_app_with_store(factory, history, _MatchStore(ids))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/analytics/comp")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["insufficient_data"] is False
+        assert data["currency"] == "USD"
+        assert data["median_annual"] is not None
+        assert data["ask_min_annual"] == data["median_annual"]
+        # all 6 are "Senior ..." → a senior band with the full sample
+        levels = {b["level"] for b in data["by_seniority"]}
+        assert "senior" in levels
+
+
+@pytest.mark.asyncio
+async def test_focus_endpoint_aggregates_matches():
+    factory = _factory()
+    history = _seed(factory)
+    ids = _seed_salaried(factory, n=6)
+    app = _build_app_with_store(factory, history, _MatchStore(ids))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        r = await c.get("/analytics/focus")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["insufficient_data"] is False
+        assert data["match_count"] == 6
+        assert len(data["best_fit_companies"]) > 0
+        # titles normalise to "Backend Engineer" (seniority stripped)
+        assert any("Backend Engineer" in role["label"] for role in data["best_fit_roles"])
+        assert data["remote_share"] is not None
+        assert data["fresh_fit_count"] == 6  # all posted now

--- a/backend/tests/unit/analytics/test_comp_benchmark_service.py
+++ b/backend/tests/unit/analytics/test_comp_benchmark_service.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import pytest
+
+from hiresense.analytics.domain import CompBenchmarkService, SalaryParser
+from hiresense.analytics.infrastructure.corpus_repository import CorpusJobRow
+
+
+class _Emb:
+    async def embed(self, texts):
+        return [[0.1, 0.2, 0.3]]
+
+
+class _Store:
+    def __init__(self, ids):
+        self._ids = ids
+
+    async def search(self, query_embedding, *, top_k=10, filters=None):
+        return [type("R", (), {"id": i, "score": 1.0})() for i in self._ids]
+
+
+class _Corpus:
+    def __init__(self, rows, tracked_salaries=None):
+        self._rows = rows
+        self._tracked = tracked_salaries or {}
+
+    def rows_for_ids(self, ids):
+        return {i: self._rows[i] for i in ids if i in self._rows}
+
+    def descriptions_for_ids(self, ids):
+        return {i: "Senior role" for i in ids if i in self._rows}
+
+    def salary_strings_for_ids(self, ids):
+        return {i: self._tracked.get(i) for i in ids}
+
+
+class _Tracking:
+    def __init__(self, job_ids):
+        self._apps = [type("A", (), {"job_id": j, "status": "applied"})() for j in job_ids]
+
+    def list(self):
+        return self._apps
+
+
+def _row(jid, salary, title="Senior Backend Engineer"):
+    return CorpusJobRow(
+        id=jid, title=title, company="Co", location="Remote", source="x",
+        salary_range=salary, posted_date=None, remote_modality="remote",
+        status="open", quality="ok",
+    )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_median_vs_market():
+    # Market: 5 matched jobs at $100k–$140k (mids 110..130k).
+    rows = {f"m{i}": _row(f"m{i}", f"${100 + i * 10}k-${120 + i * 10}k") for i in range(5)}
+    # Candidate's tracked apps point at two jobs paying ~ $90k and $95k → below market.
+    rows["t1"] = _row("t1", "$80k-$100k")
+    rows["t2"] = _row("t2", "$90k-$100k")
+    corpus = _Corpus(rows, tracked_salaries={"t1": "$80k-$100k", "t2": "$90k-$100k"})
+    svc = CompBenchmarkService(
+        embedding=_Emb(), vector_store=_Store([f"m{i}" for i in range(5)]), corpus=corpus,
+        salary_parser=SalaryParser(), tracking_read=_Tracking(["t1", "t2"]),
+        top_k=50, min_sample=5,
+    )
+
+    out = await svc.compute(profile_skills=["python"], summary="backend")
+
+    assert out.insufficient_data is False
+    assert out.currency == "USD"
+    assert out.your_sample_size == 2
+    assert out.your_median_annual is not None
+    assert out.your_median_annual < out.median_annual  # candidate is below market
+    assert out.ask_min_annual == out.median_annual and out.ask_max_annual == out.p75_annual
+
+
+@pytest.mark.asyncio
+async def test_no_vector_store_is_insufficient():
+    svc = CompBenchmarkService(
+        embedding=_Emb(), vector_store=None, corpus=_Corpus({}), salary_parser=SalaryParser(),
+        tracking_read=None, top_k=50, min_sample=5,
+    )
+    out = await svc.compute(profile_skills=["python"], summary="x")
+    assert out.insufficient_data is True

--- a/backend/tests/unit/analytics/test_funnel_service.py
+++ b/backend/tests/unit/analytics/test_funnel_service.py
@@ -23,6 +23,48 @@ def _t(app, frm, to, day):
     )
 
 
+class _FakeApps:
+    def __init__(self, apps):
+        self._apps = apps
+
+    def list(self):
+        return self._apps
+
+
+class _FakeCorpus:
+    def __init__(self, rows):
+        self._rows = rows  # id -> obj with .source
+
+    def rows_for_ids(self, ids):
+        return {i: self._rows[i] for i in ids if i in self._rows}
+
+
+def _row(source):
+    return type("Row", (), {"source": source})()
+
+
+def _app(job_id, status):
+    return type("App", (), {"job_id": job_id, "status": status})()
+
+
+def test_by_source_groups_and_rates():
+    apps = [
+        _app("j1", "interviewing"), _app("j2", "applied"),
+        _app("j3", "offered"), _app(None, "saved"),  # no job_id → ignored
+    ]
+    corpus = _FakeCorpus({"j1": _row("getonboard"), "j2": _row("getonboard"), "j3": _row("linkedin")})
+    m = FunnelService(_FakeHistory([]), applications_read=_FakeApps(apps), corpus=corpus).compute()
+    by_source = {o.source: o for o in m.by_source}
+    assert by_source["getonboard"].applications == 2
+    assert by_source["getonboard"].reached_interview == 1  # j1 interviewing, j2 only applied
+    assert by_source["getonboard"].interview_rate == 0.5
+    assert by_source["linkedin"].reached_interview == 1  # offered >= interviewing
+
+
+def test_by_source_empty_without_deps():
+    assert FunnelService(_FakeHistory([])).compute().by_source == []
+
+
 def test_reached_counts_and_conversion():
     a, b = uuid_mod.uuid4(), uuid_mod.uuid4()
     rows = [

--- a/docs/superpowers/specs/2026-06-09-profile-aware-analytics-dashboard-design.md
+++ b/docs/superpowers/specs/2026-06-09-profile-aware-analytics-dashboard-design.md
@@ -1,0 +1,154 @@
+# Profile-Aware Analytics Dashboard — Design
+
+**Date:** 2026-06-09
+**Status:** Approved (brainstorming)
+**Scope:** Improve the Analytics page — both UI and logic — to be a profile-aware
+dashboard organised around three goals the user picked: **benchmark/negotiate
+pay**, **track my performance**, and **focus my search**. (Skill-gap stays as-is;
+"decide what to learn" was not prioritised.)
+
+## Problem
+
+Today's Analytics page is a flat 4-card grid (Funnel, Target salary, Market,
+Skill gap). Two issues:
+
+1. **Under-surfaced logic.** The funnel service already computes per-stage
+   conversion rates and median time-in-stage, and target-salary already does the
+   profile→embed→ANN→percentile band — but the UI shows only a fraction of it.
+2. **Not personalised enough / not goal-organised.** The user wants comp
+   benchmarking against *their* profile and pipeline, real performance metrics,
+   and where to focus their search — presented as a coherent dashboard, not four
+   unrelated cards.
+
+## Architecture
+
+Stays in the existing `analytics` bounded context (hexagonal: `api → domain ←
+infrastructure`, facade `AnalyticsService`). No new module. The frontend
+`analytics.component` is restructured from a flat grid into a **headline KPI
+strip + three goal sections** (Pay / Performance / Focus), reusing the existing
+chart components (`bar-chart`, `salary-band`, `funnel-chart`, `trend-line`) and
+adding a few. Market + Skill-gap are kept as a secondary "Market context"
+footer, unchanged in logic.
+
+Analytics gains **read access to tracked applications** (salary + source +
+status), wired in `build_analytics`, for the pipeline-vs-market comparison and
+source-outcomes. All sections **fail soft** to an "insufficient data" state, as
+target-salary does today, and each loads independently so one empty/slow section
+never blocks the rest.
+
+## Components
+
+### ① Pay — `CompBenchmark` (enriches target-salary)
+
+New richer model returned by `GET /analytics/comp` (supersedes
+`/target-salary`; the old endpoint is removed and the frontend updated):
+
+- **Market band** (existing logic): profile→embed→ANN top-K → parse salaries →
+  `currency`, `p25/median/p75_annual`, `sample_size`, `insufficient_data`.
+- **By-seniority bands**: bucket the ANN-matched jobs via the ingestion seniority
+  detector (`detect_seniority(title, description)`) → median annual per level
+  (`intern/junior/mid/senior/lead`), each with its sample size. Levels below
+  `min_sample` are omitted.
+- **Your pipeline**: parse salaries from the user's *tracked* applications →
+  `your_median_annual` (+ sample) in the dominant currency, for an
+  above/below-market read. Null when no tracked app has a parseable salary.
+- **Suggested ask range**: `[median_annual, p75_annual]` of the market band
+  (null when `insufficient_data`).
+
+Implemented by extending `TargetSalaryService` (rename → `CompBenchmarkService`)
+to also accept tracked-application salary strings + reuse the seniority detector;
+the salary parser and ANN path are unchanged.
+
+### ② Performance — enriched funnel + source outcomes
+
+- **Surface existing funnel data**: the `funnel-chart` component renders the
+  already-computed `conversion_from_prev` and `median_days_in_stage` per stage.
+- **Headline rates**: `apply→interview %` and `interview→offer %` derived from
+  the funnel stages (no new backend — computed in the facade or frontend).
+- **Outcomes by source** (new): join tracked applications to their job's
+  `source`; for each source report applications count and reached-interview rate.
+  Returned as a new field on the funnel response (`by_source: list[...]`) or a
+  sibling `/analytics/performance` payload — **decision: add `by_source` to the
+  funnel response** to keep one performance call.
+- **Avg match score of tracked apps**: a point KPI (no historical store exists,
+  so no time-series trend — explicitly out of scope).
+
+### ③ Focus — `SearchFocus` (new, profile-aware)
+
+`GET /analytics/focus`, reuses profile→embed→ANN top-K open jobs (same path as
+comp), excludes `status=closed` and `quality != ok`, then aggregates from a new
+corpus read `rows_for_ids(ids)` (title/company/location/posted_date/
+remote_modality/quality):
+
+- **best_fit_companies**: top companies among matches (name, count, avg score).
+- **best_fit_roles**: top normalised titles among matches (title, count, avg
+  score). Title normalisation reuses/extends the existing skill normaliser
+  approach or a light title cleaner.
+- **location_fit**: share of matches that are remote, and share matching the
+  user's country (from profile/strict-location data when available).
+- **fresh_fit_count**: matches with `posted_date` within
+  `analytics_focus_fresh_days` (new config, default 14).
+
+Fails soft to `insufficient_data` when no vector store / empty profile / no
+matches (mirrors comp).
+
+### Headline KPI strip
+
+Derived from the three payloads (frontend composition, no new endpoint): target
+**median**, **apply→interview %**, **fresh-fit count**, **best-fit company
+count**. Each tile degrades to "—" when its source is insufficient.
+
+## API surface
+
+| Endpoint | Change |
+|---|---|
+| `GET /analytics/comp` | **new**, replaces `/target-salary`; returns `CompBenchmark` |
+| `GET /analytics/funnel` | **enriched**: adds `by_source` + the existing rate/time fields are now consumed |
+| `GET /analytics/focus` | **new**; returns `SearchFocus` |
+| `GET /analytics/market` | unchanged |
+| `GET /analytics/skill-gap` | unchanged |
+
+All under the existing `require_auth` router.
+
+## Frontend
+
+Restructure `analytics.component` into:
+
+- `kpi-strip` (new) — 4 stat tiles.
+- **Pay** section — `comp-benchmark` card (new): market band (reuse
+  `salary-band`), by-seniority bars (reuse `bar-chart`), pipeline-vs-market line,
+  suggested ask range.
+- **Performance** section — enhanced `funnel-chart` (show rates + days) +
+  source-outcomes (`bar-chart`).
+- **Focus** section — `search-focus` card (new): best-fit companies/roles lists,
+  location-fit, fresh count.
+- **Market context** footer — existing Market + Skill-gap cards, unchanged.
+
+New models: `comp-benchmark.model.ts`, `search-focus.model.ts`,
+`source-outcome.model.ts`. Reuse existing chart components throughout.
+
+## Configuration (no hardcoded values)
+
+- `analytics_focus_fresh_days: int = 14` — freshness window for fresh-fit count.
+- Reuse existing `analytics_target_salary_top_k`, `_min_sample`,
+  `analytics_cache_ttl_seconds`, `analytics_corpus_sample_cap`.
+- New settings added to `config.py` + `.env` + `.env.example` with comments.
+
+## Testing
+
+- **Backend (pytest, Postgres-free):** unit tests for the by-seniority split,
+  pipeline-vs-market comparison, focus aggregation (best-fit companies/roles,
+  location fit, fresh count), and source-outcomes — with stub embedding /
+  vector-store / corpus / tracking reads, mirroring existing analytics tests.
+  Fail-soft paths (no vector store, empty profile, insufficient sample) covered.
+- **Frontend (Vitest):** specs for `kpi-strip`, `comp-benchmark`,
+  `search-focus`, and the enriched `funnel-chart`.
+
+## Non-goals
+
+- Match-score / salary trend over time (no historical store; would need a new
+  time-series table — out of scope).
+- Skill-gap ROI ranking (not prioritised; skill-gap card stays as-is).
+- Ghost-job detection, external salary data sources, or cross-user benchmarking.
+- Re-computing analytics on write; everything stays read-only aggregation with
+  the existing TTL cache.

--- a/frontend/src/app/core/services/analytics.service.ts
+++ b/frontend/src/app/core/services/analytics.service.ts
@@ -6,6 +6,8 @@ import { FunnelMetrics } from '../../pages/analytics/models/funnel-metrics.model
 import { MarketIntel } from '../../pages/analytics/models/market-intel.model';
 import { SkillGap } from '../../pages/analytics/models/skill-gap.model';
 import { TargetSalary } from '../../pages/analytics/models/target-salary.model';
+import { CompBenchmark } from '../../pages/analytics/models/comp-benchmark.model';
+import { SearchFocus } from '../../pages/analytics/models/search-focus.model';
 
 @Injectable({ providedIn: 'root' })
 export class AnalyticsService {
@@ -25,5 +27,13 @@ export class AnalyticsService {
 
   targetSalary(): Observable<TargetSalary> {
     return this.http.get<TargetSalary>(`${environment.apiUrl}/analytics/target-salary`);
+  }
+
+  comp(): Observable<CompBenchmark> {
+    return this.http.get<CompBenchmark>(`${environment.apiUrl}/analytics/comp`);
+  }
+
+  focus(): Observable<SearchFocus> {
+    return this.http.get<SearchFocus>(`${environment.apiUrl}/analytics/focus`);
   }
 }

--- a/frontend/src/app/pages/analytics/analytics.component.html
+++ b/frontend/src/app/pages/analytics/analytics.component.html
@@ -1,50 +1,77 @@
 <div class="analytics-page">
   <h1 class="analytics-title">Analytics</h1>
+
+  <app-kpi-strip [tiles]="kpis()" />
+
   <div class="analytics-grid">
 
+    <!-- Pay -->
     <section class="analytics-card">
-      <h2 class="card-title">Your funnel</h2>
+      <h2 class="card-title">Pay — your market band</h2>
+      @if (compError()) { <p class="section-error">Couldn't load compensation.</p> }
+      @else if (comp(); as c) { <app-comp-benchmark [comp]="c" /> }
+      @else { <p class="section-loading">Loading…</p> }
+    </section>
+
+    <!-- Focus -->
+    <section class="analytics-card">
+      <h2 class="card-title">Focus — where you fit</h2>
+      @if (focusError()) { <p class="section-error">Couldn't load search focus.</p> }
+      @else if (focus(); as f) { <app-search-focus [focus]="f" /> }
+      @else { <p class="section-loading">Loading…</p> }
+    </section>
+
+    <!-- Performance -->
+    <section class="analytics-card analytics-card-wide">
+      <h2 class="card-title">Performance — your pipeline</h2>
       @if (funnelError()) { <p class="section-error">Couldn't load the funnel.</p> }
-      @else if (funnel(); as f) { <app-funnel-chart [metrics]="f" /> }
-      @else { <p class="section-loading">Loading…</p> }
-    </section>
-
-    <section class="analytics-card">
-      <h2 class="card-title">Target salary</h2>
-      @if (targetSalaryError()) { <p class="section-error">Couldn't load target salary.</p> }
-      @else if (targetSalary(); as t) { <app-salary-band [target]="t" /> }
-      @else { <p class="section-loading">Loading…</p> }
-    </section>
-
-    <section class="analytics-card">
-      <h2 class="card-title">Market</h2>
-      @if (marketError()) { <p class="section-error">Couldn't load market intel.</p> }
-      @else if (market(); as m) {
-        <h3 class="sub">Top skills in demand</h3>
-        <app-bar-chart [rows]="skillRows(m)" emptyText="No skills in the corpus yet." />
-        <h3 class="sub">Remote vs on-site</h3>
-        <app-bar-chart [rows]="remoteRows(m)" emptyText="No modality data." />
-        <h3 class="sub">Postings per week</h3>
-        <app-trend-line [points]="m.posting_trend" />
-        <h3 class="sub">Salary range
-          @if (m.salary_distribution.currency) { ({{ m.salary_distribution.currency }}, {{ m.salary_distribution.disclosed_pct }}% disclosed) }
-        </h3>
-        @if (m.salary_distribution.median_annual !== null) {
-          <p class="salary-line">{{ fmt(m.salary_distribution.min_annual) }} – <strong>{{ fmt(m.salary_distribution.median_annual) }}</strong> – {{ fmt(m.salary_distribution.max_annual) }}</p>
-        } @else { <p class="section-loading">No parseable salaries.</p> }
-      }
-      @else { <p class="section-loading">Loading…</p> }
-    </section>
-
-    <section class="analytics-card">
-      <h2 class="card-title">Skill gap</h2>
-      @if (skillGapError()) { <p class="section-error">Couldn't load skill gap.</p> }
-      @else if (skillGap(); as g) {
-        @if (g.has_profile) { <app-bar-chart [rows]="gapRows(g)" emptyText="No gaps — you cover the market." /> }
-        @else { <p class="section-empty">Upload a CV to see your skill gap.</p> }
+      @else if (funnel(); as f) {
+        <div class="perf-cols">
+          <div class="perf-col"><app-funnel-chart [metrics]="f" /></div>
+          <div class="perf-col">
+            <h3 class="sub">Outcomes by source</h3>
+            <app-bar-chart [rows]="sourceRows(f)" emptyText="Track jobs to compare sources." />
+          </div>
+        </div>
       }
       @else { <p class="section-loading">Loading…</p> }
     </section>
 
   </div>
+
+  <!-- Market context (secondary) -->
+  <details class="analytics-context">
+    <summary>Market context</summary>
+    <div class="analytics-grid">
+      <section class="analytics-card">
+        <h2 class="card-title">Market</h2>
+        @if (marketError()) { <p class="section-error">Couldn't load market intel.</p> }
+        @else if (market(); as m) {
+          <h3 class="sub">Top skills in demand</h3>
+          <app-bar-chart [rows]="skillRows(m)" emptyText="No skills in the corpus yet." />
+          <h3 class="sub">Remote vs on-site</h3>
+          <app-bar-chart [rows]="remoteRows(m)" emptyText="No modality data." />
+          <h3 class="sub">Postings per week</h3>
+          <app-trend-line [points]="m.posting_trend" />
+          <h3 class="sub">Salary range
+            @if (m.salary_distribution.currency) { ({{ m.salary_distribution.currency }}, {{ m.salary_distribution.disclosed_pct }}% disclosed) }
+          </h3>
+          @if (m.salary_distribution.median_annual !== null) {
+            <p class="salary-line">{{ fmt(m.salary_distribution.min_annual) }} – <strong>{{ fmt(m.salary_distribution.median_annual) }}</strong> – {{ fmt(m.salary_distribution.max_annual) }}</p>
+          } @else { <p class="section-loading">No parseable salaries.</p> }
+        }
+        @else { <p class="section-loading">Loading…</p> }
+      </section>
+
+      <section class="analytics-card">
+        <h2 class="card-title">Skill gap</h2>
+        @if (skillGapError()) { <p class="section-error">Couldn't load skill gap.</p> }
+        @else if (skillGap(); as g) {
+          @if (g.has_profile) { <app-bar-chart [rows]="gapRows(g)" emptyText="No gaps — you cover the market." /> }
+          @else { <p class="section-empty">Upload a CV to see your skill gap.</p> }
+        }
+        @else { <p class="section-loading">Loading…</p> }
+      </section>
+    </div>
+  </details>
 </div>

--- a/frontend/src/app/pages/analytics/analytics.component.scss
+++ b/frontend/src/app/pages/analytics/analytics.component.scss
@@ -7,3 +7,23 @@
 .salary-line { font-size: 0.9rem; }
 .section-loading, .section-empty { color: var(--muted, #64748b); font-size: 0.85rem; }
 .section-error { color: var(--danger, #dc2626); font-size: 0.85rem; }
+
+/* Performance spans the full grid width and splits into funnel + by-source. */
+.analytics-card-wide { grid-column: 1 / -1; }
+.perf-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+@media (max-width: 640px) { .perf-cols { grid-template-columns: 1fr; } }
+
+/* Market context demoted into a collapsible footer. */
+.analytics-context {
+  margin-top: 1.5rem;
+
+  summary {
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--muted, #64748b);
+    padding: 0.5rem 0;
+  }
+
+  .analytics-grid { margin-top: 0.75rem; }
+}

--- a/frontend/src/app/pages/analytics/analytics.component.spec.ts
+++ b/frontend/src/app/pages/analytics/analytics.component.spec.ts
@@ -5,13 +5,18 @@ import { AnalyticsService } from '../../core/services/analytics.service';
 
 function makeService(over: Partial<Record<string, unknown>> = {}) {
   return {
-    funnel: () => of({ stages: [], rejected: 0, current_rejected: 0, total_applications: 0 }),
+    funnel: () => of({ stages: [], rejected: 0, current_rejected: 0, total_applications: 0, by_source: [] }),
     market: () => of({ top_skills: [{ skill: 'python', count: 3, pct: 75 }], remote_mix: { remote: 2 },
       posting_trend: [], salary_distribution: { currency: 'USD', min_annual: 90000, median_annual: 110000,
       max_annual: 130000, parsed_count: 5, unparsed_count: 1, other_currency_count: 0, disclosed_pct: 80 } }),
     skillGap: () => of({ has_profile: true, missing: [{ skill: 'rust', count: 2, pct: 40 }] }),
     targetSalary: () => of({ insufficient_data: true, currency: null, p25_annual: null,
       median_annual: null, p75_annual: null, sample_size: 0 }),
+    comp: () => of({ insufficient_data: true, currency: null, p25_annual: null, median_annual: null,
+      p75_annual: null, sample_size: 0, by_seniority: [], your_median_annual: null, your_sample_size: 0,
+      ask_min_annual: null, ask_max_annual: null }),
+    focus: () => of({ insufficient_data: true, match_count: 0, best_fit_companies: [], best_fit_roles: [],
+      remote_share: null, top_locations: [], fresh_fit_count: 0 }),
     ...over,
   };
 }
@@ -27,12 +32,14 @@ describe('AnalyticsComponent', () => {
     return fixture;
   }
 
-  it('renders the four section cards on success', () => {
+  it('renders the KPI strip and the section cards on success', () => {
     const fixture = mount(makeService());
-    expect(fixture.nativeElement.querySelectorAll('.analytics-card').length).toBe(4);
+    expect(fixture.nativeElement.querySelector('app-kpi-strip')).not.toBeNull();
+    // 3 main sections (Pay, Focus, Performance) + 2 in the Market-context footer.
+    expect(fixture.nativeElement.querySelectorAll('.analytics-card').length).toBe(5);
   });
 
-  it('renders a top skill from market', () => {
+  it('renders a top skill from market (in the context section)', () => {
     const fixture = mount(makeService());
     expect(fixture.nativeElement.textContent).toContain('python');
   });

--- a/frontend/src/app/pages/analytics/analytics.component.ts
+++ b/frontend/src/app/pages/analytics/analytics.component.ts
@@ -1,20 +1,32 @@
-import { ChangeDetectionStrategy, Component, DestroyRef, inject, OnInit, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { AnalyticsService } from '../../core/services/analytics.service';
 import { FunnelMetrics } from './models/funnel-metrics.model';
 import { MarketIntel } from './models/market-intel.model';
 import { SkillGap } from './models/skill-gap.model';
-import { TargetSalary } from './models/target-salary.model';
+import { CompBenchmark } from './models/comp-benchmark.model';
+import { SearchFocus } from './models/search-focus.model';
 import { BarRow } from './models/bar-row.model';
 import { BarChartComponent } from './components/bar-chart/bar-chart.component';
 import { FunnelChartComponent } from './components/funnel-chart/funnel-chart.component';
 import { TrendLineComponent } from './components/trend-line/trend-line.component';
-import { SalaryBandComponent } from './components/salary-band/salary-band.component';
+import { CompBenchmarkComponent } from './components/comp-benchmark/comp-benchmark.component';
+import { SearchFocusComponent } from './components/search-focus/search-focus.component';
+import { KpiStripComponent, KpiTile } from './components/kpi-strip/kpi-strip.component';
+
+const PERCENT = 100;
 
 @Component({
   selector: 'app-analytics',
   standalone: true,
-  imports: [BarChartComponent, FunnelChartComponent, TrendLineComponent, SalaryBandComponent],
+  imports: [
+    BarChartComponent,
+    FunnelChartComponent,
+    TrendLineComponent,
+    CompBenchmarkComponent,
+    SearchFocusComponent,
+    KpiStripComponent,
+  ],
   templateUrl: './analytics.component.html',
   styleUrl: './analytics.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -32,8 +44,11 @@ export class AnalyticsComponent implements OnInit {
   skillGap = signal<SkillGap | null>(null);
   skillGapError = signal(false);
 
-  targetSalary = signal<TargetSalary | null>(null);
-  targetSalaryError = signal(false);
+  comp = signal<CompBenchmark | null>(null);
+  compError = signal(false);
+
+  focus = signal<SearchFocus | null>(null);
+  focusError = signal(false);
 
   ngOnInit(): void {
     this.analytics.funnel().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
@@ -45,9 +60,55 @@ export class AnalyticsComponent implements OnInit {
     this.analytics.skillGap().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (v) => this.skillGap.set(v), error: () => this.skillGapError.set(true),
     });
-    this.analytics.targetSalary().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (v) => this.targetSalary.set(v), error: () => this.targetSalaryError.set(true),
+    this.analytics.comp().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (v) => this.comp.set(v), error: () => this.compError.set(true),
     });
+    this.analytics.focus().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (v) => this.focus.set(v), error: () => this.focusError.set(true),
+    });
+  }
+
+  // Headline KPIs, composed from the section payloads. Each degrades to "—".
+  kpis = computed<KpiTile[]>(() => {
+    const c = this.comp();
+    const f = this.funnel();
+    const focus = this.focus();
+    const applyToInterview = f
+      ? f.stages.find((s) => s.stage === 'interviewing')?.conversion_from_prev ?? null
+      : null;
+    return [
+      {
+        label: 'Target median',
+        value: c && !c.insufficient_data && c.median_annual !== null
+          ? `${c.currency ?? ''} ${c.median_annual.toLocaleString('en-US')}`.trim()
+          : '—',
+        hint: 'for your profile',
+      },
+      {
+        label: 'Apply → interview',
+        value: applyToInterview === null ? '—' : `${Math.round(applyToInterview * PERCENT)}%`,
+        hint: f ? `${f.total_applications} tracked` : undefined,
+      },
+      {
+        label: 'Fresh-fit jobs',
+        value: focus && !focus.insufficient_data ? `${focus.fresh_fit_count}` : '—',
+        hint: 'matched, recent',
+      },
+      {
+        label: 'Best-fit companies',
+        value: focus && !focus.insufficient_data ? `${focus.best_fit_companies.length}` : '—',
+        hint: focus && !focus.insufficient_data ? `${focus.match_count} matches` : undefined,
+      },
+    ];
+  });
+
+  sourceRows(f: FunnelMetrics): BarRow[] {
+    return f.by_source.map((o) => ({
+      label: o.source,
+      value: o.applications,
+      pct: Math.round(o.interview_rate * PERCENT),
+      note: `${o.reached_interview}/${o.applications} → interview`,
+    }));
   }
 
   skillRows(m: MarketIntel): BarRow[] {
@@ -61,7 +122,7 @@ export class AnalyticsComponent implements OnInit {
   remoteRows(m: MarketIntel): BarRow[] {
     const total = Object.values(m.remote_mix).reduce((a, b) => a + b, 0) || 1;
     return Object.entries(m.remote_mix).map(([k, v]) => ({
-      label: k, value: v, pct: Math.round((v / total) * 100), note: `${Math.round((v / total) * 100)}%`,
+      label: k, value: v, pct: Math.round((v / total) * PERCENT), note: `${Math.round((v / total) * PERCENT)}%`,
     }));
   }
 

--- a/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.html
+++ b/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.html
@@ -1,0 +1,32 @@
+@if (comp().insufficient_data) {
+  <p class="comp-empty">
+    Not enough salaried matches for your profile yet — add skills/CV or fetch more jobs.
+  </p>
+} @else {
+  <app-salary-band [target]="comp()" />
+
+  @if (comp().ask_min_annual !== null) {
+    <p class="comp-ask">
+      Suggested ask:
+      <strong>{{ comp().currency }} {{ fmt(comp().ask_min_annual) }}–{{ fmt(comp().ask_max_annual) }}</strong>
+      <span class="comp-sub">/ year</span>
+    </p>
+  }
+
+  @if (comp().your_median_annual !== null) {
+    <p class="comp-pipeline" [class.below]="(pipelineDelta() ?? 0) < 0" [class.above]="(pipelineDelta() ?? 0) > 0">
+      Your tracked jobs' median: <strong>{{ comp().currency }} {{ fmt(comp().your_median_annual) }}</strong>
+      @if (pipelineDelta() !== null) {
+        <span class="comp-delta">
+          ({{ pipelineDelta()! > 0 ? '+' : '' }}{{ pipelineDelta() }}% vs market median)
+        </span>
+      }
+      <span class="comp-sub">· {{ comp().your_sample_size }} sampled</span>
+    </p>
+  }
+
+  @if (seniorityRows().length > 0) {
+    <h4 class="comp-sub-head">Median by seniority</h4>
+    <app-bar-chart [rows]="seniorityRows()" emptyText="No seniority breakdown." />
+  }
+}

--- a/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.scss
+++ b/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.scss
@@ -1,0 +1,37 @@
+.comp-empty {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+.comp-ask {
+  margin-top: 0.75rem;
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+
+  strong { color: var(--accent-text); }
+}
+
+.comp-pipeline {
+  margin-top: 0.35rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+
+  &.below .comp-delta { color: var(--danger); }
+  &.above .comp-delta { color: #15803d; }
+}
+
+.comp-delta { font-weight: 600; }
+
+.comp-sub {
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
+.comp-sub-head {
+  margin: 1rem 0 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}

--- a/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.spec.ts
+++ b/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.spec.ts
@@ -1,0 +1,38 @@
+import { TestBed } from '@angular/core/testing';
+import { CompBenchmarkComponent } from './comp-benchmark.component';
+import { CompBenchmark } from '../../models/comp-benchmark.model';
+
+function comp(over: Partial<CompBenchmark> = {}): CompBenchmark {
+  return {
+    insufficient_data: false, currency: 'USD', p25_annual: 90000, median_annual: 110000,
+    p75_annual: 130000, sample_size: 12, by_seniority: [], your_median_annual: null,
+    your_sample_size: 0, ask_min_annual: 110000, ask_max_annual: 130000, ...over,
+  };
+}
+
+describe('CompBenchmarkComponent', () => {
+  function mount(c: CompBenchmark) {
+    TestBed.configureTestingModule({ imports: [CompBenchmarkComponent] });
+    const fixture = TestBed.createComponent(CompBenchmarkComponent);
+    fixture.componentRef.setInput('comp', c);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('shows insufficient-data message', () => {
+    const fixture = mount(comp({ insufficient_data: true, median_annual: null, ask_min_annual: null }));
+    expect(fixture.nativeElement.querySelector('.comp-empty')).not.toBeNull();
+  });
+
+  it('shows the suggested ask range', () => {
+    const fixture = mount(comp());
+    expect(fixture.nativeElement.textContent).toContain('110,000');
+    expect(fixture.nativeElement.textContent).toContain('130,000');
+  });
+
+  it('flags a below-market pipeline', () => {
+    const fixture = mount(comp({ your_median_annual: 90000, your_sample_size: 3 }));
+    expect(fixture.componentInstance.pipelineDelta()).toBeLessThan(0);
+    expect(fixture.nativeElement.querySelector('.comp-pipeline.below')).not.toBeNull();
+  });
+});

--- a/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.ts
+++ b/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.ts
@@ -1,0 +1,41 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { CompBenchmark } from '../../models/comp-benchmark.model';
+import { BarRow } from '../../models/bar-row.model';
+import { SalaryBandComponent } from '../salary-band/salary-band.component';
+import { BarChartComponent } from '../bar-chart/bar-chart.component';
+
+const PERCENT = 100;
+
+@Component({
+  selector: 'app-comp-benchmark',
+  standalone: true,
+  imports: [SalaryBandComponent, BarChartComponent],
+  templateUrl: './comp-benchmark.component.html',
+  styleUrl: './comp-benchmark.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CompBenchmarkComponent {
+  comp = input.required<CompBenchmark>();
+
+  seniorityRows = computed<BarRow[]>(() => {
+    const bands = this.comp().by_seniority;
+    const max = Math.max(1, ...bands.map((b) => b.median_annual));
+    return bands.map((b) => ({
+      label: b.level,
+      value: b.median_annual,
+      pct: Math.round((b.median_annual / max) * PERCENT),
+      note: this.fmt(b.median_annual),
+    }));
+  });
+
+  // Candidate median relative to the market median: negative = below market.
+  pipelineDelta = computed<number | null>(() => {
+    const c = this.comp();
+    if (c.your_median_annual === null || c.median_annual === null) return null;
+    return Math.round(((c.your_median_annual - c.median_annual) / c.median_annual) * PERCENT);
+  });
+
+  fmt(v: number | null): string {
+    return v === null ? '—' : v.toLocaleString('en-US');
+  }
+}

--- a/frontend/src/app/pages/analytics/components/kpi-strip/kpi-strip.component.html
+++ b/frontend/src/app/pages/analytics/components/kpi-strip/kpi-strip.component.html
@@ -1,0 +1,9 @@
+<div class="kpi-strip">
+  @for (t of tiles(); track t.label) {
+    <div class="kpi-tile">
+      <span class="kpi-value">{{ t.value }}</span>
+      <span class="kpi-label">{{ t.label }}</span>
+      @if (t.hint) { <span class="kpi-hint">{{ t.hint }}</span> }
+    </div>
+  }
+</div>

--- a/frontend/src/app/pages/analytics/components/kpi-strip/kpi-strip.component.scss
+++ b/frontend/src/app/pages/analytics/components/kpi-strip/kpi-strip.component.scss
@@ -1,0 +1,38 @@
+.kpi-strip {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+@media (max-width: 720px) {
+  .kpi-strip { grid-template-columns: repeat(2, 1fr); }
+}
+
+.kpi-tile {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: 1rem 1.25rem;
+}
+
+.kpi-value {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  line-height: 1.1;
+}
+
+.kpi-label {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.kpi-hint {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}

--- a/frontend/src/app/pages/analytics/components/kpi-strip/kpi-strip.component.spec.ts
+++ b/frontend/src/app/pages/analytics/components/kpi-strip/kpi-strip.component.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing';
+import { KpiStripComponent } from './kpi-strip.component';
+
+describe('KpiStripComponent', () => {
+  it('renders a tile per input with value, label and optional hint', () => {
+    TestBed.configureTestingModule({ imports: [KpiStripComponent] });
+    const fixture = TestBed.createComponent(KpiStripComponent);
+    fixture.componentRef.setInput('tiles', [
+      { label: 'Target median', value: 'USD 120,000', hint: 'for your profile' },
+      { label: 'Apply → interview', value: '—' },
+    ]);
+    fixture.detectChanges();
+    const tiles = fixture.nativeElement.querySelectorAll('.kpi-tile');
+    expect(tiles.length).toBe(2);
+    expect(fixture.nativeElement.textContent).toContain('USD 120,000');
+    expect(fixture.nativeElement.textContent).toContain('for your profile');
+  });
+});

--- a/frontend/src/app/pages/analytics/components/kpi-strip/kpi-strip.component.ts
+++ b/frontend/src/app/pages/analytics/components/kpi-strip/kpi-strip.component.ts
@@ -1,0 +1,18 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+
+export interface KpiTile {
+  label: string;
+  value: string;
+  hint?: string;
+}
+
+@Component({
+  selector: 'app-kpi-strip',
+  standalone: true,
+  templateUrl: './kpi-strip.component.html',
+  styleUrl: './kpi-strip.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class KpiStripComponent {
+  tiles = input.required<KpiTile[]>();
+}

--- a/frontend/src/app/pages/analytics/components/search-focus/search-focus.component.html
+++ b/frontend/src/app/pages/analytics/components/search-focus/search-focus.component.html
@@ -1,0 +1,46 @@
+@if (focus().insufficient_data) {
+  <p class="focus-empty">
+    Add skills or a CV (and fetch jobs) to see where your profile fits best.
+  </p>
+} @else {
+  <div class="focus-stats">
+    <span class="focus-stat"><strong>{{ focus().match_count }}</strong> profile matches</span>
+    @if (remotePct() !== null) {
+      <span class="focus-stat"><strong>{{ remotePct() }}%</strong> remote</span>
+    }
+    <span class="focus-stat focus-fresh"><strong>{{ focus().fresh_fit_count }}</strong> fresh</span>
+  </div>
+
+  <div class="focus-cols">
+    <div class="focus-col">
+      <h4 class="focus-head">Best-fit companies</h4>
+      @if (focus().best_fit_companies.length) {
+        <ul class="focus-list">
+          @for (c of focus().best_fit_companies; track c.label) {
+            <li><span class="focus-label">{{ c.label }}</span><span class="focus-count">{{ c.count }}</span></li>
+          }
+        </ul>
+      } @else { <p class="focus-empty">—</p> }
+    </div>
+
+    <div class="focus-col">
+      <h4 class="focus-head">Best-fit roles</h4>
+      @if (focus().best_fit_roles.length) {
+        <ul class="focus-list">
+          @for (r of focus().best_fit_roles; track r.label) {
+            <li><span class="focus-label">{{ r.label }}</span><span class="focus-count">{{ r.count }}</span></li>
+          }
+        </ul>
+      } @else { <p class="focus-empty">—</p> }
+    </div>
+  </div>
+
+  @if (focus().top_locations.length) {
+    <h4 class="focus-head">Where they are</h4>
+    <ul class="focus-chips">
+      @for (l of focus().top_locations; track l.label) {
+        <li class="focus-chip">{{ l.label }} <span class="focus-count">{{ l.count }}</span></li>
+      }
+    </ul>
+  }
+}

--- a/frontend/src/app/pages/analytics/components/search-focus/search-focus.component.scss
+++ b/frontend/src/app/pages/analytics/components/search-focus/search-focus.component.scss
@@ -1,0 +1,87 @@
+.focus-empty {
+  color: var(--text-muted);
+  font-size: 0.875rem;
+}
+
+.focus-stats {
+  display: flex;
+  gap: 1.25rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.focus-stat {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+
+  strong { color: var(--text-primary); font-size: 1.05rem; }
+  &.focus-fresh strong { color: var(--accent-text); }
+}
+
+.focus-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.25rem;
+}
+
+@media (max-width: 560px) {
+  .focus-cols { grid-template-columns: 1fr; }
+}
+
+.focus-head {
+  margin: 0.75rem 0 0.4rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-muted);
+}
+
+.focus-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.3rem 0;
+    border-bottom: 1px solid var(--border-subtle);
+    font-size: 0.875rem;
+  }
+}
+
+.focus-label {
+  color: var(--text-secondary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.focus-count {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 0.8125rem;
+  padding-left: 0.5rem;
+}
+
+.focus-chips {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0;
+  padding: 0;
+}
+
+.focus-chip {
+  background: var(--bg-inset);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-full);
+  padding: 0.2rem 0.65rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+
+  .focus-count { padding-left: 0.3rem; }
+}

--- a/frontend/src/app/pages/analytics/components/search-focus/search-focus.component.spec.ts
+++ b/frontend/src/app/pages/analytics/components/search-focus/search-focus.component.spec.ts
@@ -1,0 +1,35 @@
+import { TestBed } from '@angular/core/testing';
+import { SearchFocusComponent } from './search-focus.component';
+import { SearchFocus } from '../../models/search-focus.model';
+
+function focus(over: Partial<SearchFocus> = {}): SearchFocus {
+  return {
+    insufficient_data: false, match_count: 6,
+    best_fit_companies: [{ label: 'Acme', count: 3, avg_score: 0.8 }],
+    best_fit_roles: [{ label: 'Backend Engineer', count: 4, avg_score: 0.7 }],
+    remote_share: 0.5, top_locations: [{ label: 'Remote', count: 3, avg_score: 0.7 }],
+    fresh_fit_count: 4, ...over,
+  };
+}
+
+describe('SearchFocusComponent', () => {
+  function mount(f: SearchFocus) {
+    TestBed.configureTestingModule({ imports: [SearchFocusComponent] });
+    const fixture = TestBed.createComponent(SearchFocusComponent);
+    fixture.componentRef.setInput('focus', f);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('shows insufficient-data message', () => {
+    const fixture = mount(focus({ insufficient_data: true }));
+    expect(fixture.nativeElement.querySelector('.focus-empty')).not.toBeNull();
+  });
+
+  it('renders companies, roles and remote share', () => {
+    const fixture = mount(focus());
+    expect(fixture.nativeElement.textContent).toContain('Acme');
+    expect(fixture.nativeElement.textContent).toContain('Backend Engineer');
+    expect(fixture.componentInstance.remotePct()).toBe(50);
+  });
+});

--- a/frontend/src/app/pages/analytics/components/search-focus/search-focus.component.ts
+++ b/frontend/src/app/pages/analytics/components/search-focus/search-focus.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { SearchFocus } from '../../models/search-focus.model';
+
+const PERCENT = 100;
+
+@Component({
+  selector: 'app-search-focus',
+  standalone: true,
+  templateUrl: './search-focus.component.html',
+  styleUrl: './search-focus.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SearchFocusComponent {
+  focus = input.required<SearchFocus>();
+
+  remotePct = computed<number | null>(() => {
+    const r = this.focus().remote_share;
+    return r === null ? null : Math.round(r * PERCENT);
+  });
+}

--- a/frontend/src/app/pages/analytics/models/comp-benchmark.model.ts
+++ b/frontend/src/app/pages/analytics/models/comp-benchmark.model.ts
@@ -1,0 +1,19 @@
+export interface SeniorityBand {
+  level: string;
+  median_annual: number;
+  sample_size: number;
+}
+
+export interface CompBenchmark {
+  insufficient_data: boolean;
+  currency: string | null;
+  p25_annual: number | null;
+  median_annual: number | null;
+  p75_annual: number | null;
+  sample_size: number;
+  by_seniority: SeniorityBand[];
+  your_median_annual: number | null;
+  your_sample_size: number;
+  ask_min_annual: number | null;
+  ask_max_annual: number | null;
+}

--- a/frontend/src/app/pages/analytics/models/funnel-metrics.model.ts
+++ b/frontend/src/app/pages/analytics/models/funnel-metrics.model.ts
@@ -1,3 +1,5 @@
+import { SourceOutcome } from './source-outcome.model';
+
 export interface FunnelStage {
   stage: string;
   reached: number;
@@ -11,4 +13,5 @@ export interface FunnelMetrics {
   rejected: number;
   current_rejected: number;
   total_applications: number;
+  by_source: SourceOutcome[];
 }

--- a/frontend/src/app/pages/analytics/models/search-focus.model.ts
+++ b/frontend/src/app/pages/analytics/models/search-focus.model.ts
@@ -1,0 +1,15 @@
+export interface FocusItem {
+  label: string;
+  count: number;
+  avg_score: number;
+}
+
+export interface SearchFocus {
+  insufficient_data: boolean;
+  match_count: number;
+  best_fit_companies: FocusItem[];
+  best_fit_roles: FocusItem[];
+  remote_share: number | null;
+  top_locations: FocusItem[];
+  fresh_fit_count: number;
+}

--- a/frontend/src/app/pages/analytics/models/source-outcome.model.ts
+++ b/frontend/src/app/pages/analytics/models/source-outcome.model.ts
@@ -1,0 +1,6 @@
+export interface SourceOutcome {
+  source: string;
+  applications: number;
+  reached_interview: number;
+  interview_rate: number;
+}


### PR DESCRIPTION
Restructures the Analytics page into a **KPI strip + Pay / Performance / Focus** sections (Market + Skill-gap demoted to a collapsible context footer). Design: docs/superpowers/specs/2026-06-09-profile-aware-analytics-dashboard-design.md

## Pay — CompBenchmark (GET /analytics/comp)
Profile→ANN salary band (p25/median/p75) + **by-seniority medians** (ingestion seniority detector) + **pipeline-vs-market** (your tracked apps' median vs market) + **suggested ask range**.

## Performance
The funnel's already-computed conversion rates + time-in-stage are now surfaced, plus **outcomes by source** (which job sources convert) via new FunnelMetrics.by_source.

## Focus — SearchFocus (GET /analytics/focus)
From your best-matching open jobs (spam/closed excluded): **best-fit companies & roles**, **remote share**, top locations, and **fresh-fit count** (new analytics_focus_fresh_days config).

## Plumbing
- New corpus reads (rows_for_ids / descriptions_for_ids); analytics gains tracked-application read access (build_analytics). `/target-salary` kept intact.
- Frontend: new kpi-strip / comp-benchmark / search-focus components (+specs), restructured analytics page, new models. Reuses salary-band / bar-chart / funnel-chart.

## Tests
Backend 859 passed / 6 skipped (new: comp pipeline, by-source, comp+focus endpoints); ruff clean. Frontend analytics specs pass; ng lint + production build clean.

Generated with Claude Code
