### PR TITLE
fix(analytics): polish dashboard visuals

### DIFF
--- a/frontend/src/app/pages/analytics/analytics.component.html
+++ b/frontend/src/app/pages/analytics/analytics.component.html
@@ -30,7 +30,21 @@
           <div class="perf-col"><app-funnel-chart [metrics]="f" /></div>
           <div class="perf-col">
             <h3 class="sub">Outcomes by source</h3>
-            <app-bar-chart [rows]="sourceRows(f)" emptyText="Track jobs to compare sources." />
+            @if (f.by_source.length) {
+              <ul class="source-list">
+                @for (o of f.by_source; track o.source) {
+                  <li class="source-row">
+                    <span class="source-name">{{ o.source }}</span>
+                    <span class="source-apps">{{ o.applications }} tracked</span>
+                    <span class="source-rate" [class.zero]="o.reached_interview === 0">
+                      {{ interviewPct(o) }}% → interview
+                    </span>
+                  </li>
+                }
+              </ul>
+            } @else {
+              <p class="section-empty">Track jobs to compare sources.</p>
+            }
           </div>
         </div>
       }

--- a/frontend/src/app/pages/analytics/analytics.component.scss
+++ b/frontend/src/app/pages/analytics/analytics.component.scss
@@ -1,8 +1,9 @@
 .analytics-page { padding: 1.25rem; }
 .analytics-title { font-size: 1.4rem; margin: 0 0 1rem; }
-.analytics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); gap: 1rem; }
-.analytics-card { border: 1px solid var(--border, #e2e8f0); border-radius: 10px; padding: 1rem; background: var(--surface, #fff); }
-.card-title { font-size: 1rem; margin: 0 0 0.75rem; }
+/* align-items: start so a short card (Pay) never stretches to match a tall one (Focus). */
+.analytics-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); gap: 1rem; align-items: start; }
+.analytics-card { border: 1px solid var(--border-subtle, #eae8e4); border-radius: var(--radius-lg, 12px); padding: 1.25rem 1.4rem; background: var(--bg-card, #fff); }
+.card-title { font-size: 1.0625rem; font-weight: 600; margin: 0 0 1rem; letter-spacing: -0.01em; }
 .sub { font-size: 0.8rem; color: var(--muted, #64748b); margin: 0.9rem 0 0.4rem; text-transform: uppercase; letter-spacing: 0.03em; }
 .salary-line { font-size: 0.9rem; }
 .section-loading, .section-empty { color: var(--muted, #64748b); font-size: 0.85rem; }
@@ -10,8 +11,28 @@
 
 /* Performance spans the full grid width and splits into funnel + by-source. */
 .analytics-card-wide { grid-column: 1 / -1; }
-.perf-cols { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+.perf-cols { display: grid; grid-template-columns: 1.2fr 1fr; gap: 2rem; }
 @media (max-width: 640px) { .perf-cols { grid-template-columns: 1fr; } }
+
+/* Outcomes-by-source: a compact stat list (not a misleading 0%-wide bar). */
+.source-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.source-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: baseline;
+  gap: 0.75rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border-subtle, #eae8e4);
+  font-size: 0.85rem;
+}
+.source-name { font-weight: 600; color: var(--text-primary, #18181b); }
+.source-apps { color: var(--text-muted, #a1a1aa); font-size: 0.8125rem; }
+.source-rate {
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  color: var(--accent-text, #065f46);
+  &.zero { color: var(--text-muted, #a1a1aa); font-weight: 400; }
+}
 
 /* Market context demoted into a collapsible footer. */
 .analytics-context {

--- a/frontend/src/app/pages/analytics/analytics.component.ts
+++ b/frontend/src/app/pages/analytics/analytics.component.ts
@@ -102,21 +102,23 @@ export class AnalyticsComponent implements OnInit {
     ];
   });
 
-  sourceRows(f: FunnelMetrics): BarRow[] {
-    return f.by_source.map((o) => ({
-      label: o.source,
-      value: o.applications,
-      pct: Math.round(o.interview_rate * PERCENT),
-      note: `${o.reached_interview}/${o.applications} → interview`,
-    }));
+  // Cap the secondary market/skill-gap lists so they don't become 20-row walls.
+  private static readonly MARKET_ROW_CAP = 8;
+
+  interviewPct(o: { interview_rate: number }): number {
+    return Math.round(o.interview_rate * PERCENT);
   }
 
   skillRows(m: MarketIntel): BarRow[] {
-    return m.top_skills.map((s) => ({ label: s.skill, value: s.count, pct: s.pct, note: `${s.pct}%` }));
+    return m.top_skills
+      .slice(0, AnalyticsComponent.MARKET_ROW_CAP)
+      .map((s) => ({ label: s.skill, value: s.count, pct: s.pct, note: `${s.pct}%` }));
   }
 
   gapRows(g: SkillGap): BarRow[] {
-    return g.missing.map((s) => ({ label: s.skill, value: s.count, pct: s.pct, note: `in ${s.pct}%` }));
+    return g.missing
+      .slice(0, AnalyticsComponent.MARKET_ROW_CAP)
+      .map((s) => ({ label: s.skill, value: s.count, pct: s.pct, note: `in ${s.pct}%` }));
   }
 
   remoteRows(m: MarketIntel): BarRow[] {

--- a/frontend/src/app/pages/analytics/components/bar-chart/bar-chart.component.html
+++ b/frontend/src/app/pages/analytics/components/bar-chart/bar-chart.component.html
@@ -8,7 +8,7 @@
         <span class="bar-track">
           <span class="bar-fill" [style.width.%]="row.pct"></span>
         </span>
-        <span class="bar-value">{{ row.value }}@if (row.note) { <span class="bar-note">{{ row.note }}</span> }</span>
+        <span class="bar-value">{{ row.value | number }}@if (row.note) { <span class="bar-note">{{ row.note }}</span> }</span>
       </li>
     }
   </ul>

--- a/frontend/src/app/pages/analytics/components/bar-chart/bar-chart.component.scss
+++ b/frontend/src/app/pages/analytics/components/bar-chart/bar-chart.component.scss
@@ -1,8 +1,36 @@
-.bar-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.4rem; }
-.bar-row { display: grid; grid-template-columns: 9rem 1fr auto; align-items: center; gap: 0.6rem; font-size: 0.85rem; }
-.bar-label { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.bar-track { background: var(--surface-hover, #f1f5f9); border-radius: 999px; height: 0.6rem; overflow: hidden; }
-.bar-fill { display: block; height: 100%; background: var(--accent, #4f46e5); border-radius: 999px; transition: width 0.3s; }
-.bar-value { font-variant-numeric: tabular-nums; color: var(--muted, #64748b); }
-.bar-note { margin-left: 0.35rem; }
-.bar-empty { color: var(--muted, #64748b); font-size: 0.85rem; }
+.bar-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 0.55rem; }
+.bar-row {
+  display: grid;
+  grid-template-columns: 8.5rem 1fr 4.75rem;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.8125rem;
+}
+.bar-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--text-secondary);
+}
+.bar-track {
+  background: var(--bg-inset);
+  border-radius: var(--radius-full);
+  height: 0.5rem;
+  overflow: hidden;
+}
+.bar-fill {
+  display: block;
+  height: 100%;
+  min-width: 0.5rem; /* a present-but-tiny value reads as a sliver, never "broken empty" */
+  background: linear-gradient(90deg, var(--accent), var(--accent-hover));
+  border-radius: var(--radius-full);
+  transition: width 0.4s ease;
+}
+.bar-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+  font-weight: 600;
+  text-align: right;
+}
+.bar-note { margin-left: 0.35rem; color: var(--text-muted); font-weight: 400; }
+.bar-empty { color: var(--text-muted); font-size: 0.85rem; }

--- a/frontend/src/app/pages/analytics/components/bar-chart/bar-chart.component.ts
+++ b/frontend/src/app/pages/analytics/components/bar-chart/bar-chart.component.ts
@@ -1,9 +1,11 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { DecimalPipe } from '@angular/common';
 import { BarRow } from '../../models/bar-row.model';
 
 @Component({
   selector: 'app-bar-chart',
   standalone: true,
+  imports: [DecimalPipe],
   templateUrl: './bar-chart.component.html',
   styleUrl: './bar-chart.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.ts
+++ b/frontend/src/app/pages/analytics/components/comp-benchmark/comp-benchmark.component.ts
@@ -24,7 +24,7 @@ export class CompBenchmarkComponent {
       label: b.level,
       value: b.median_annual,
       pct: Math.round((b.median_annual / max) * PERCENT),
-      note: this.fmt(b.median_annual),
+      note: `· ${b.sample_size}`,
     }));
   });
 


### PR DESCRIPTION
Visual polish for the analytics dashboard (follow-up to #81).

- **bar-chart**: thousands-separator formatting (fixes the duplicated "35400 35,400" seniority readout); design-token styling (bg-inset track, accent-gradient fill, min-width sliver so a tiny value never looks "broken").
- **Outcomes by source**: compact stat list (`source · N tracked · % → interview`) instead of misleading full-width 0%-wide bars.
- **Market / Skill-gap**: capped to top 8 rows — no more two 20-row bar walls in the context footer.
- **Layout**: grid `align-items:start` so the short Pay card stops stretching with dead space.
- Spacing / typography / card-padding polish on existing tokens.

Frontend analytics specs pass; ng lint + production build clean.

Generated with Claude Code
