### PR TITLE
Audit remediation: security hardening, stability, and ingestion performance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     env:
       # config.py has no defaults for these — supply them so Settings() resolves.
       AUTH_USERNAME: admin
-      AUTH_PASSWORD: changeme
+      AUTH_PASSWORD: ci-test-password-not-for-production
       JWT_SECRET_KEY: ci-test-secret-not-for-production
       LLM_API_KEY: test-key
       DATABASE_URL: postgresql+asyncpg://hiresense:hiresense@localhost:5432/hiresense

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -5,6 +5,9 @@ CORS_ORIGINS=http://localhost:4200
 
 # === Auth ===
 AUTH_USERNAME=admin
+# The two sample values below are REJECTED at startup — replace both before
+# first run. Generate strong values with:
+#   python -c "import secrets; print(secrets.token_urlsafe(48))"
 AUTH_PASSWORD=changeme
 JWT_SECRET_KEY=change-this-to-a-random-secret
 # Role embedded in issued tokens. Single-user instance is admin by default;

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -121,6 +121,8 @@ LATEX_TIMEOUT_SECONDS=60.0
 INGESTION_MIN_MATCH_SCORE=0.0
 # Hard cap on ?page_size for job listings (values above are clamped).
 INGESTION_MAX_PAGE_SIZE=100
+# Directory CSV-import file_path filters are confined to (path-traversal guard).
+CSV_IMPORT_DIR=./csv_imports
 # Hide ingestion-list jobs whose posted date is older than this many days
 # (stale / re-surfaced postings, e.g. WeWorkRemotely keeps the original RSS
 # pubDate). Jobs with no posted date are never hidden. 0 disables; 365 hides

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -26,6 +26,11 @@ AUTH_ROLE=admin
 
 # === Database ===
 DATABASE_URL=postgresql+asyncpg://hiresense:hiresense@localhost:5432/hiresense
+# Connection-pool sizing for the shared sync engine (ignored for SQLite).
+DB_POOL_SIZE=10
+DB_MAX_OVERFLOW=20
+DB_POOL_PRE_PING=true
+DB_POOL_RECYCLE_SECONDS=3600
 
 # === LLM ===
 LLM_PROVIDER=anthropic

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -12,6 +12,8 @@ CORS_ALLOW_HEADERS=Authorization,Content-Type
 RATE_LIMIT_ENABLED=true
 RATE_LIMIT_MAX_REQUESTS=30
 RATE_LIMIT_WINDOW_SECONDS=60
+# Seconds shutdown waits for in-flight domain-event handlers before cancelling.
+EVENT_BUS_DRAIN_TIMEOUT_SECONDS=5
 
 # === Auth ===
 AUTH_USERNAME=admin

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,9 @@
 APP_NAME=HireSense
 DEBUG=false
 CORS_ORIGINS=http://localhost:4200
+# Explicit CORS allow-lists (no wildcards; allow_credentials is on).
+CORS_ALLOW_METHODS=GET,POST,PUT,PATCH,DELETE
+CORS_ALLOW_HEADERS=Authorization,Content-Type
 
 # === Auth ===
 AUTH_USERNAME=admin
@@ -116,6 +119,8 @@ LATEX_TIMEOUT_SECONDS=60.0
 # shows everything; the match column + sort=match_desc are the triage path.
 # Clients can override per request with ?min_score=0.25 etc.
 INGESTION_MIN_MATCH_SCORE=0.0
+# Hard cap on ?page_size for job listings (values above are clamped).
+INGESTION_MAX_PAGE_SIZE=100
 # Hide ingestion-list jobs whose posted date is older than this many days
 # (stale / re-surfaced postings, e.g. WeWorkRemotely keeps the original RSS
 # pubDate). Jobs with no posted date are never hidden. 0 disables; 365 hides

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,6 +14,9 @@ RATE_LIMIT_MAX_REQUESTS=30
 RATE_LIMIT_WINDOW_SECONDS=60
 # Seconds shutdown waits for in-flight domain-event handlers before cancelling.
 EVENT_BUS_DRAIN_TIMEOUT_SECONDS=5
+# Bounds for the in-process embedding caches (LRU eviction).
+SEMANTIC_JOB_CACHE_SIZE=2000
+SEMANTIC_PROFILE_CACHE_SIZE=8
 
 # === Auth ===
 AUTH_USERNAME=admin

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,6 +6,13 @@ CORS_ORIGINS=http://localhost:4200
 CORS_ALLOW_METHODS=GET,POST,PUT,PATCH,DELETE
 CORS_ALLOW_HEADERS=Authorization,Content-Type
 
+# === Rate limiting (expensive endpoints) ===
+# In-process sliding-window limiter, keyed by client IP, applied to the
+# LLM/network-heavy endpoints. Disable for load tests.
+RATE_LIMIT_ENABLED=true
+RATE_LIMIT_MAX_REQUESTS=30
+RATE_LIMIT_WINDOW_SECONDS=60
+
 # === Auth ===
 AUTH_USERNAME=admin
 # The two sample values below are REJECTED at startup — replace both before

--- a/backend/alembic/versions/025_add_vector_embeddings_bucket_index.py
+++ b/backend/alembic/versions/025_add_vector_embeddings_bucket_index.py
@@ -1,0 +1,31 @@
+"""index vector_embeddings metadata bucket
+
+PgVectorStore.search() always filters by metadata->>'bucket' ("boards" /
+"portals") before the HNSW ANN ordering. Without an index that filter is a
+sequential scan over every vector row; an expression index keeps the filtered
+ANN search cheap as the corpus grows.
+
+Revision ID: 025
+Revises: 024
+Create Date: 2026-06-09
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "025"
+down_revision: Union[str, None] = "024"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_vector_embeddings_bucket "
+        "ON vector_embeddings ((metadata->>'bucket'))"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS ix_vector_embeddings_bucket")

--- a/backend/src/hiresense/adapters/event_bus/in_memory_bus.py
+++ b/backend/src/hiresense/adapters/event_bus/in_memory_bus.py
@@ -20,6 +20,10 @@ class InMemoryEventBus:
         self._subscribers: dict[
             str, list[Callable[[DomainEvent], Awaitable[None]]]
         ] = defaultdict(list)
+        # Strong references to in-flight handler tasks: the event loop only
+        # holds weak refs, so without these the GC may drop a task mid-run.
+        # They also let shutdown drain handlers instead of orphaning them.
+        self._tasks: set[asyncio.Task[None]] = set()
 
     def subscribe(
         self,
@@ -33,7 +37,21 @@ class InMemoryEventBus:
         metrics.events_published_total.add(1, {"type": event.event_type})
         handlers = self._subscribers.get(event.event_type, [])
         for handler in handlers:
-            asyncio.create_task(self._safe_invoke(handler, event))
+            task = asyncio.create_task(self._safe_invoke(handler, event))
+            self._tasks.add(task)
+            task.add_done_callback(self._tasks.discard)
+
+    async def aclose(self, timeout: float = 5.0) -> None:
+        """Drain in-flight handlers on shutdown; cancel stragglers after timeout."""
+        pending = {task for task in self._tasks if not task.done()}
+        if not pending:
+            return
+        _done, still_pending = await asyncio.wait(pending, timeout=timeout)
+        for task in still_pending:
+            logger.warning("Cancelling event handler still running at shutdown: %r", task)
+            task.cancel()
+        if still_pending:
+            await asyncio.gather(*still_pending, return_exceptions=True)
 
     async def _safe_invoke(
         self,

--- a/backend/src/hiresense/bootstrap/ingestion.py
+++ b/backend/src/hiresense/bootstrap/ingestion.py
@@ -72,7 +72,7 @@ def build_ingestion(infra: SharedInfra, tracked: Callable[[str], Any], *, prefer
             sources.append(RemoteOKAdapter(http_client=http_client, base_url=s.remoteok_api_url))
             normalizers["remoteok"] = RemoteOKNormalizer()
         elif source_name == "csv":
-            sources.append(CSVImportAdapter())
+            sources.append(CSVImportAdapter(import_dir=s.csv_import_dir))
             normalizers["csv"] = CSVNormalizer()
         elif source_name == "jobicy":
             sources.append(JobicyAdapter(http_client=http_client, base_url=s.jobicy_api_url))

--- a/backend/src/hiresense/bootstrap/ingestion.py
+++ b/backend/src/hiresense/bootstrap/ingestion.py
@@ -205,7 +205,11 @@ def build_ingestion(infra: SharedInfra, tracked: Callable[[str], Any], *, prefer
     from hiresense.ingestion.domain.semantic_pre_ranker import SemanticPreRanker
     from hiresense.ingestion.domain.semantic_scoring_service import SemanticScoringService
 
-    semantic_scoring = SemanticScoringService(embedding_port=infra.embedding)
+    semantic_scoring = SemanticScoringService(
+        embedding_port=infra.embedding,
+        job_cache_size=s.semantic_job_cache_size,
+        profile_cache_size=s.semantic_profile_cache_size,
+    )
 
     # SemanticPreRanker wires vector store + embedding for global ANN pre-ranking.
     # When vector store is None (no pgvector configured), pre_ranker is still
@@ -217,6 +221,7 @@ def build_ingestion(infra: SharedInfra, tracked: Callable[[str], Any], *, prefer
         skill_weight=s.prerank_weight_skill,
         semantic_weight=s.prerank_weight_semantic,
         preference=preference_query,
+        profile_cache_size=s.semantic_profile_cache_size,
     )
 
     match_cache_repo = JobMatchCacheRepository(session_factory=infra.sync_session_factory)

--- a/backend/src/hiresense/bootstrap/shared_infra.py
+++ b/backend/src/hiresense/bootstrap/shared_infra.py
@@ -41,7 +41,19 @@ def build_shared_infra(settings: Settings, http_client: httpx.AsyncClient) -> Sh
     )
 
     sync_db_url = settings.database_url.replace("+asyncpg", "")
-    sync_engine = create_engine(sync_db_url, echo=settings.debug)
+    # SQLite (tests) has no server-side pool semantics — pool kwargs would be
+    # rejected or meaningless there.
+    pool_kwargs = (
+        {}
+        if sync_db_url.startswith("sqlite")
+        else {
+            "pool_size": settings.db_pool_size,
+            "max_overflow": settings.db_max_overflow,
+            "pool_pre_ping": settings.db_pool_pre_ping,
+            "pool_recycle": settings.db_pool_recycle_seconds,
+        }
+    )
+    sync_engine = create_engine(sync_db_url, echo=settings.debug, **pool_kwargs)
     sync_session_factory = sessionmaker(bind=sync_engine, expire_on_commit=False)
 
     # Imported lazily so the heavy sentence-transformers model is only loaded

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -113,6 +113,14 @@ class Settings(BaseSettings):
 
     # Database
     database_url: str
+    # Connection-pool sizing for the shared sync engine. pool_size persistent
+    # connections + up to max_overflow burst ones; pre_ping validates a
+    # connection before reuse (drops stale ones after DB restarts); recycle
+    # replaces connections older than this many seconds.
+    db_pool_size: int = 10
+    db_max_overflow: int = 20
+    db_pool_pre_ping: bool = True
+    db_pool_recycle_seconds: int = 3600
 
     # LLM
     llm_provider: str = "anthropic"

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -29,6 +29,8 @@ class _CommaSeparatedMixin:
             "getonboard_categories",
             "job_closed_markers",
             "http_retry_status_codes",
+            "cors_allow_methods",
+            "cors_allow_headers",
         }
     )
 
@@ -60,6 +62,11 @@ class Settings(BaseSettings):
     app_port: int = 8000
     debug: bool = False
     cors_origins: list[str] = ["http://localhost:4200"]
+    # Explicit CORS method/header allow-lists. Wildcards are deliberately not
+    # the default: combined with allow_credentials=True they over-grant to any
+    # origin that slips into cors_origins.
+    cors_allow_methods: list[str] = ["GET", "POST", "PUT", "PATCH", "DELETE"]
+    cors_allow_headers: list[str] = ["Authorization", "Content-Type"]
 
     # --- Observability (OpenTelemetry) ---
     # Master switch. When False, setup_telemetry() is a no-op and the app
@@ -163,6 +170,11 @@ class Settings(BaseSettings):
     # this re-introduces the tag-dilution failure mode for verbose-tag
     # sources like getonboard; only raise if scoring is also fixed.
     ingestion_min_match_score: float = 0.0
+
+    # Hard cap on the ?page_size accepted by job-listing endpoints. Values
+    # above this are clamped server-side to bound per-request memory and
+    # scoring cost.
+    ingestion_max_page_size: int = 100
 
     # Hide job listings whose posted_date is older than this many days (stale /
     # re-surfaced postings — e.g. WeWorkRemotely keeps the original RSS pubDate

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -276,6 +276,10 @@ class Settings(BaseSettings):
     # A cap larger than the corpus keeps the global-ordering guarantee intact
     # while bounding ANN query cost on large data sets.
     prerank_top_k_cap: int = 2000
+    # Bounds for the in-process embedding caches (LRU eviction). Job vectors
+    # are ~3 KB each; profile entries are one per distinct profile text.
+    semantic_job_cache_size: int = 2000
+    semantic_profile_cache_size: int = 8
 
     # Matching weights (must sum to 100)
     weight_semantic: int = 15

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -387,6 +387,10 @@ class Settings(BaseSettings):
     # Per-job description truncation (chars) for the deeper single-job analysis.
     match_deep_job_char_limit: int = 6000
 
+    # Seconds the shutdown lifespan waits for in-flight domain-event handlers
+    # before cancelling them.
+    event_bus_drain_timeout_seconds: float = 5.0
+
     # --- Rate limiting (expensive endpoints) ---
     # In-process sliding-window limiter applied to LLM/network-heavy endpoints
     # (ingestion fetch/scan/list/analysis/backfill, matching, optimization).

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -379,6 +379,14 @@ class Settings(BaseSettings):
     # Per-job description truncation (chars) for the deeper single-job analysis.
     match_deep_job_char_limit: int = 6000
 
+    # --- Rate limiting (expensive endpoints) ---
+    # In-process sliding-window limiter applied to LLM/network-heavy endpoints
+    # (ingestion fetch/scan/list/analysis/backfill, matching, optimization).
+    # Keyed by client IP. Disable for load tests with RATE_LIMIT_ENABLED=false.
+    rate_limit_enabled: bool = True
+    rate_limit_max_requests: int = 30
+    rate_limit_window_seconds: float = 60.0
+
     # Upload
     max_upload_bytes: int = 10 * 1024 * 1024  # 10 MB
 

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -158,6 +158,9 @@ class Settings(BaseSettings):
         "linkedin",
     ]
 
+    # Directory CSV-import file_path filters are confined to (path-traversal guard).
+    csv_import_dir: str = "./csv_imports"
+
     # LaTeX
     latex_compiler: str = "xelatex"
     latex_timeout_seconds: float = 60.0

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -1,6 +1,22 @@
 from typing import Any, ClassVar
 
-from pydantic_settings import BaseSettings, DotEnvSettingsSource, EnvSettingsSource, SettingsConfigDict
+from pydantic import field_validator
+from pydantic_settings import (
+    BaseSettings,
+    DotEnvSettingsSource,
+    EnvSettingsSource,
+    SettingsConfigDict,
+)
+
+# Known sample values shipped in .env.example. Startup refuses to run with
+# these so a copied-but-unedited .env fails loudly instead of exposing the
+# instance behind guessable credentials.
+_PLACEHOLDER_SECRETS: frozenset[str] = frozenset(
+    {
+        "changeme",
+        "change-this-to-a-random-secret",
+    }
+)
 
 
 class _CommaSeparatedMixin:
@@ -73,6 +89,17 @@ class Settings(BaseSettings):
     auth_username: str
     auth_password: str
     jwt_secret_key: str
+
+    @field_validator("auth_password", "jwt_secret_key")
+    @classmethod
+    def _reject_placeholder_secrets(cls, value: str, info: Any) -> str:
+        if value in _PLACEHOLDER_SECRETS:
+            raise ValueError(
+                f"{info.field_name} is still set to the .env.example placeholder; "
+                'generate a real value (e.g. python -c "import secrets; print(secrets.token_urlsafe(48))")'
+            )
+        return value
+
     # Role embedded in issued tokens. A single-user instance is admin by default;
     # set to a non-admin value to genuinely exercise the admin gate.
     auth_role: str = "admin"

--- a/backend/src/hiresense/identity/api/dependencies.py
+++ b/backend/src/hiresense/identity/api/dependencies.py
@@ -34,6 +34,24 @@ def get_current_user(
     return payload
 
 
+def enforce_expensive_rate_limit(request: Request) -> None:
+    """Per-client-IP sliding-window limit for LLM/network-heavy endpoints.
+
+    No-ops when no limiter is wired on app.state (bare test apps, or
+    RATE_LIMIT_ENABLED=false).
+    """
+    limiter = getattr(request.app.state, "rate_limiter", None)
+    if limiter is None:
+        return
+    key = request.client.host if request.client else "unknown"
+    if not limiter.allow(key):
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail="Rate limit exceeded for expensive operations",
+            headers={"Retry-After": str(int(limiter.window_seconds))},
+        )
+
+
 def require_admin(
     credentials: Annotated[HTTPAuthorizationCredentials, Depends(security)],
     auth_service: Annotated[AuthService, Depends(get_auth_service)],

--- a/backend/src/hiresense/infrastructure/database.py
+++ b/backend/src/hiresense/infrastructure/database.py
@@ -1,21 +1,7 @@
 from __future__ import annotations
 
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase
-
-from hiresense.config import Settings
 
 
 class Base(DeclarativeBase):
     pass
-
-
-def build_engine(settings: Settings):
-    return create_async_engine(settings.database_url, echo=settings.debug)
-
-
-def build_session_factory(settings: Settings) -> async_sessionmaker[AsyncSession]:
-    engine = build_engine(settings)
-    return async_sessionmaker(engine, expire_on_commit=False)
-
-

--- a/backend/src/hiresense/ingestion/adapters/csv_import.py
+++ b/backend/src/hiresense/ingestion/adapters/csv_import.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import uuid
+from pathlib import Path
 from typing import Any
 
 from hiresense.ingestion.domain.models import RawJobListing
@@ -9,6 +10,9 @@ from hiresense.kernel.value_objects import SourceType
 
 
 class CSVImportAdapter:
+    def __init__(self, import_dir: str = "./csv_imports") -> None:
+        self._import_dir = Path(import_dir).resolve()
+
     def supports_snapshot_closure(self) -> bool:
         return False
 
@@ -18,12 +22,23 @@ class CSVImportAdapter:
     def source_type(self) -> SourceType:
         return SourceType.MANUAL
 
+    def _resolve_inside_import_dir(self, candidate: str) -> Path:
+        """Confine the requested file to the configured import directory.
+
+        `file_path` arrives via request filters, so a relative or absolute
+        path escaping the import dir (e.g. ../../etc/passwd) must be rejected.
+        """
+        resolved = (self._import_dir / candidate).resolve()
+        if not resolved.is_relative_to(self._import_dir):
+            raise ValueError(f"CSV import path escapes the import directory: {candidate}")
+        return resolved
+
     async def fetch_jobs(
         self, filters: dict[str, Any] | None = None
     ) -> list[RawJobListing]:
         if not filters or "file_path" not in filters:
             return []
-        file_path = filters["file_path"]
+        file_path = self._resolve_inside_import_dir(str(filters["file_path"]))
         jobs: list[RawJobListing] = []
         with open(file_path, newline="", encoding="utf-8") as f:
             reader = csv.DictReader(f)

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from hiresense.identity.api.dependencies import require_auth
+from hiresense.identity.api.dependencies import enforce_expensive_rate_limit, require_auth
 from hiresense.ingestion.api.dependencies import (
     get_backfill_service,
     get_deep_analysis,
@@ -95,7 +95,7 @@ class FetchResponse(BaseModel):
     jobs: list[NormalizedJob]
 
 
-@router.post("/fetch", response_model=FetchResponse)
+@router.post("/fetch", response_model=FetchResponse, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def fetch_jobs(
     orchestrator: Annotated[IngestionOrchestrator, Depends(get_ingestion_orchestrator)],
 ) -> FetchResponse | JSONResponse:
@@ -110,7 +110,7 @@ async def fetch_jobs(
     return FetchResponse(count=len(jobs), jobs=jobs)
 
 
-@router.post("/scan-portals", response_model=ScanResult)
+@router.post("/scan-portals", response_model=ScanResult, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def scan_portals(
     filters: ScanFilters,
     scanner: Annotated[PortalScanner, Depends(get_portal_scanner)],
@@ -137,7 +137,7 @@ async def revalidate_jobs(
     return RevalidationResponse(closed=len(closed))
 
 
-@router.get("/jobs", response_model=PaginatedResult)
+@router.get("/jobs", response_model=PaginatedResult, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def list_jobs(
     request: Request,
     tab: Annotated[Literal["boards", "portals"], Query()],
@@ -342,7 +342,7 @@ async def list_jobs(
     return result
 
 
-@router.get("/jobs/{job_id}/analysis", response_model=DeepAnalysisResult)
+@router.get("/jobs/{job_id}/analysis", response_model=DeepAnalysisResult, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def analyze_job(
     job_id: str,
     orchestrator: Annotated[IngestionOrchestrator, Depends(get_ingestion_orchestrator)],
@@ -388,7 +388,7 @@ class BackfillResponse(BaseModel):
     total: int
 
 
-@router.post("/backfill-embeddings", response_model=BackfillResponse)
+@router.post("/backfill-embeddings", response_model=BackfillResponse, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def backfill_embeddings(
     service: Annotated[EmbeddingBackfillService | None, Depends(get_backfill_service)],
 ) -> BackfillResponse:

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -21,6 +21,7 @@ from hiresense.ingestion.api.dependencies import (
 )
 from hiresense.ingestion.domain.embedding_backfill_service import EmbeddingBackfillService
 from hiresense.ingestion.domain.job_filter import JobQueryParams, PaginatedResult, filter_and_paginate
+from hiresense.ingestion.domain.job_list_criteria import JobListCriteria
 from hiresense.ingestion.domain.job_revalidation_service import JobRevalidationService
 from hiresense.ingestion.domain.job_sort import sort_jobs
 from hiresense.ingestion.domain.job_scorer import (
@@ -181,7 +182,19 @@ async def list_jobs(
     # Query(le=) bound.
     if settings is not None:
         page_size = min(page_size, settings.ingestion_max_page_size)
-    all_jobs = orchestrator.list_jobs() if tab == "boards" else scanner.list_jobs()
+    # Push the cheap selective predicates into the repository (SQL WHERE) so
+    # closed/filtered rows never reach the scoring pipeline below.
+    # filter_and_paginate re-applies them idempotently alongside the
+    # Python-only heuristics.
+    criteria = JobListCriteria(
+        include_closed=include_closed,
+        include_low_quality=include_low_quality,
+        source=source,
+        company=company,
+        date_from=date_from,
+        date_to=date_to,
+    )
+    all_jobs = orchestrator.list_jobs(criteria) if tab == "boards" else scanner.list_jobs(criteria)
 
     candidate_skills, candidate_summary = await _gather_profile(profile_service)
 

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -42,7 +42,9 @@ from hiresense.matching.domain.deep_analysis_service import DeepAnalysisService
 from hiresense.profile.api.dependencies import get_profile_service
 from hiresense.profile.domain import ProfileService
 
-router = APIRouter(prefix="/ingestion", tags=["ingestion"])
+router = APIRouter(
+    prefix="/ingestion", tags=["ingestion"], dependencies=[Depends(require_auth)]
+)
 
 # Accepted sort tokens (`<field>_<dir>`) plus the legacy `date_*` aliases. Any
 # value outside this set falls back to the default `match_desc`.
@@ -383,9 +385,6 @@ class BackfillResponse(BaseModel):
 
 @router.post("/backfill-embeddings", response_model=BackfillResponse)
 async def backfill_embeddings(
-    # The authenticated user IS the operator — this is a single-user app with
-    # no role system. require_auth verifies the JWT and returns the subject claim.
-    _operator: Annotated[str, Depends(require_auth)],
     service: Annotated[EmbeddingBackfillService | None, Depends(get_backfill_service)],
 ) -> BackfillResponse:
     """Re-embed all ingested jobs into pgvector so SemanticPreRanker can rank them.

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime
 from typing import Annotated, Literal
 
@@ -194,7 +195,11 @@ async def list_jobs(
         date_from=date_from,
         date_to=date_to,
     )
-    all_jobs = orchestrator.list_jobs(criteria) if tab == "boards" else scanner.list_jobs(criteria)
+    # Corpus load + score persists below run sync SQLAlchemy sessions; offload
+    # to a worker thread so they don't block the event loop.
+    all_jobs = await asyncio.to_thread(
+        orchestrator.list_jobs if tab == "boards" else scanner.list_jobs, criteria
+    )
 
     candidate_skills, candidate_summary = await _gather_profile(profile_service)
 
@@ -235,8 +240,9 @@ async def list_jobs(
         )
 
     if candidate_skills:
-        persist_scores_batch(
-            [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in all_jobs]
+        await asyncio.to_thread(
+            persist_scores_batch,
+            [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in all_jobs],
         )
 
     # GLOBAL apply of already-cached Tier-1 LLM scores BEFORE pagination. The
@@ -318,8 +324,9 @@ async def list_jobs(
             )
             for j in result.jobs
         ]
-        persist_scores_batch(
-            [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in result.jobs]
+        await asyncio.to_thread(
+            persist_scores_batch,
+            [ScoreUpdate(j.id, j.match_score, j.semantic_score) for j in result.jobs],
         )
         # Page-level re-sort so the order reflects the post-semantic match_score
         # that the user actually sees. Phase-1 sort happens pre-pagination on

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -147,8 +147,8 @@ async def list_jobs(
     semantic_scoring: Annotated[SemanticScoringService | None, Depends(get_semantic_scoring)],
     quick_scoring: Annotated[QuickScoringService | None, Depends(get_quick_scoring)],
     pre_ranker: Annotated[SemanticPreRanker | None, Depends(get_pre_ranker)],
-    page: int = 1,
-    page_size: int = 20,
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1)] = 20,
     source: str | None = None,
     company: str | None = None,
     keyword: str | None = None,
@@ -176,6 +176,11 @@ async def list_jobs(
         min_score = settings.ingestion_min_match_score
     if max_age_days is None and settings is not None:
         max_age_days = settings.ingestion_max_job_age_days
+    # Clamp page_size to the configured cap (bounds per-request memory and
+    # quick-scoring cost). The cap lives in settings, so it can't be a static
+    # Query(le=) bound.
+    if settings is not None:
+        page_size = min(page_size, settings.ingestion_max_page_size)
     all_jobs = orchestrator.list_jobs() if tab == "boards" else scanner.list_jobs()
 
     candidate_skills, candidate_summary = await _gather_profile(profile_service)

--- a/backend/src/hiresense/ingestion/domain/__init__.py
+++ b/backend/src/hiresense/ingestion/domain/__init__.py
@@ -4,6 +4,7 @@ from hiresense.ingestion.domain.content_hash import content_hash
 from hiresense.ingestion.domain.identity import identity_key
 from hiresense.ingestion.domain.job_embedding_indexer import JobEmbeddingIndexer
 from hiresense.ingestion.domain.job_filter import JobQueryParams, PaginatedResult, filter_and_paginate
+from hiresense.ingestion.domain.job_list_criteria import JobListCriteria
 from hiresense.ingestion.domain.job_quality import JobQuality
 from hiresense.ingestion.domain.job_quality_classifier import JobQualityClassifier
 from hiresense.ingestion.domain.job_quality_verdict import JobQualityVerdict
@@ -26,6 +27,7 @@ __all__ = [
     "JobQuality",
     "JobQualityClassifier",
     "JobQualityVerdict",
+    "JobListCriteria",
     "JobQueryParams",
     "PaginatedResult",
     "PortalScanner",

--- a/backend/src/hiresense/ingestion/domain/embedding_backfill_service.py
+++ b/backend/src/hiresense/ingestion/domain/embedding_backfill_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
+from hiresense.ingestion.domain.job_list_criteria import JobListCriteria
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.ports.jobs_repository import JobsRepositoryPort
 from hiresense.ports.embedding import EmbeddingPort
@@ -59,8 +60,11 @@ class EmbeddingBackfillService:
             return BackfillResult(boards=0, portals=0)
 
         # NOTE: single-batch embed; chunk if corpus grows large
-        boards_jobs = [j for j in self._boards_repo.list_all() if j.status == "open"]
-        portals_jobs = [j for j in self._portals_repo.list_all() if j.status == "open"]
+        # Open-only, filtered DB-side; low-quality jobs are still indexed
+        # (quality is a display concern, not an embedding one).
+        open_only = JobListCriteria(include_closed=False, include_low_quality=True)
+        boards_jobs = self._boards_repo.list_filtered(open_only)
+        portals_jobs = self._portals_repo.list_filtered(open_only)
 
         boards_count = await self._backfill_bucket(boards_jobs, bucket="boards")
         portals_count = await self._backfill_bucket(portals_jobs, bucket="portals")

--- a/backend/src/hiresense/ingestion/domain/job_list_criteria.py
+++ b/backend/src/hiresense/ingestion/domain/job_list_criteria.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import dataclasses
+from datetime import datetime
+
+from hiresense.ingestion.domain.models import NormalizedJob
+
+
+@dataclasses.dataclass(frozen=True)
+class JobListCriteria:
+    """Cheap, selective predicates a repository can evaluate DB-side.
+
+    Deliberately limited to filters with direct column equivalents — the
+    Python-only heuristics (keyword, seniority detection, years extraction,
+    strict_location, the min_score semantic-None exemption) stay in
+    filter_and_paginate, which re-applies these predicates idempotently.
+    """
+
+    include_closed: bool = False
+    include_low_quality: bool = False
+    source: str | None = None
+    company: str | None = None
+    date_from: datetime | None = None
+    date_to: datetime | None = None
+
+    def matches(self, job: NormalizedJob) -> bool:
+        """In-memory equivalent of the SQL predicates (used by the in-memory repo)."""
+        if not self.include_closed and job.status == "closed":
+            return False
+        if not self.include_low_quality and (job.quality or "ok") != "ok":
+            return False
+        if self.source and job.source != self.source:
+            return False
+        if self.company and job.company.strip().lower() != self.company.strip().lower():
+            return False
+        if self.date_from and (job.posted_date is None or job.posted_date < self.date_from):
+            return False
+        if self.date_to and (job.posted_date is None or job.posted_date > self.date_to):
+            return False
+        return True

--- a/backend/src/hiresense/ingestion/domain/job_revalidation_service.py
+++ b/backend/src/hiresense/ingestion/domain/job_revalidation_service.py
@@ -60,7 +60,10 @@ class JobRevalidationService:
         async with self._sem:
             try:
                 resp = await self._http.get(job.url, follow_redirects=True)
-            except Exception:
+            except Exception as exc:
+                # Transient transport failures must never close a job, but a
+                # silently swallowed probe makes sweeps undebuggable — log it.
+                logger.warning("Revalidation probe failed for %s: %s", job.url, exc)
                 return Verdict.UNKNOWN
             finally:
                 if self._delay:

--- a/backend/src/hiresense/ingestion/domain/job_revalidation_service.py
+++ b/backend/src/hiresense/ingestion/domain/job_revalidation_service.py
@@ -41,14 +41,14 @@ class JobRevalidationService:
         self._delay = delay
 
     async def sweep(self) -> list[str]:
-        jobs = self._repo.find_open_stale(self._sources, self._batch)
+        jobs = await asyncio.to_thread(self._repo.find_open_stale, self._sources, self._batch)
         if not jobs:
             return []
         verdicts = await asyncio.gather(*(self._probe(j) for j in jobs))
         to_close = [j.id for j, v in zip(jobs, verdicts) if v == Verdict.CLOSED]
-        self._repo.mark_checked([j.id for j in jobs])
+        await asyncio.to_thread(self._repo.mark_checked, [j.id for j in jobs])
         if to_close:
-            self._repo.mark_closed(to_close)
+            await asyncio.to_thread(self._repo.mark_closed, to_close)
             if self._indexer is not None:
                 await self._indexer.remove(to_close)
         logger.info(

--- a/backend/src/hiresense/ingestion/domain/portal_scanner.py
+++ b/backend/src/hiresense/ingestion/domain/portal_scanner.py
@@ -146,8 +146,7 @@ class PortalScanner:
                 )
                 continue
 
-            seen_keys: set[str] = set()
-            touched: list[NormalizedJob] = []
+            normalized: list[NormalizedJob] = []
             for raw in raw_jobs:
                 total_fetched += 1
                 normalized_data = normalizer.normalize(raw)
@@ -164,20 +163,22 @@ class PortalScanner:
                     kw = filters.keyword.lower()
                     if kw not in job.title.lower() and kw not in job.description.lower():
                         continue
+                normalized.append(job)
 
-                existing_id = self._repository.get_id_by_identity(portal.name, job)
-                if existing_id:
-                    job = job.model_copy(update={"id": existing_id})
-                seen_keys.add(identity_key(job))
-                result = self._repository.upsert(job)
-                if result in (
+            # One bulk identity lookup + one commit per portal (was 2 queries
+            # per job). Outcomes carry the resolved ids.
+            outcomes = self._repository.bulk_upsert(normalized)
+            seen_keys = {identity_key(o.job) for o in outcomes}
+            touched: list[NormalizedJob] = []
+            for outcome in outcomes:
+                if outcome.result in (
                     UpsertResult.INSERTED,
                     UpsertResult.UPDATED,
                     UpsertResult.REOPENED,
                 ):
-                    touched.append(job)
-                    if result == UpsertResult.INSERTED:
-                        new_jobs.append(job)
+                    touched.append(outcome.job)
+                    if outcome.result == UpsertResult.INSERTED:
+                        new_jobs.append(outcome.job)
 
             if touched and self._indexer is not None:
                 await self._indexer.index(touched)

--- a/backend/src/hiresense/ingestion/domain/portal_scanner.py
+++ b/backend/src/hiresense/ingestion/domain/portal_scanner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -106,7 +107,7 @@ class PortalScanner:
             return
         cutoff = datetime.now(timezone.utc) - timedelta(days=self._retention_days)
         try:
-            removed_ids = self._repository.prune_older_than(cutoff)
+            removed_ids = await asyncio.to_thread(self._repository.prune_older_than, cutoff)
         except Exception:
             logger.exception("Job pruning failed")
             return
@@ -172,7 +173,7 @@ class PortalScanner:
 
             # One bulk identity lookup + one commit per portal (was 2 queries
             # per job). Outcomes carry the resolved ids.
-            outcomes = self._repository.bulk_upsert(normalized)
+            outcomes = await asyncio.to_thread(self._repository.bulk_upsert, normalized)
             seen_keys = {identity_key(o.job) for o in outcomes}
             touched: list[NormalizedJob] = []
             for outcome in outcomes:
@@ -191,8 +192,11 @@ class PortalScanner:
             # Disappearance closure: snapshot portals only, and never during a
             # keyword-filtered scan (that is not a complete snapshot of the board).
             if adapter.supports_snapshot_closure() and not filters.keyword:
-                closed_ids = self._repository.bump_missed_and_close(
-                    portal.name, seen_keys, self._closure_miss_threshold
+                closed_ids = await asyncio.to_thread(
+                    self._repository.bump_missed_and_close,
+                    portal.name,
+                    seen_keys,
+                    self._closure_miss_threshold,
                 )
                 if closed_ids and self._indexer is not None:
                     await self._indexer.remove(closed_ids)

--- a/backend/src/hiresense/ingestion/domain/portal_scanner.py
+++ b/backend/src/hiresense/ingestion/domain/portal_scanner.py
@@ -8,6 +8,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from hiresense.ingestion.domain.identity import identity_key
+from hiresense.ingestion.domain.job_list_criteria import JobListCriteria
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.normalizer import JobNormalizer
 from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
@@ -60,8 +61,12 @@ class PortalScanner:
         self._indexer = indexer
         self._closure_miss_threshold = closure_miss_threshold
 
-    def list_jobs(self) -> list[NormalizedJob]:
-        return self._repository.list_all()
+    def list_jobs(self, criteria: JobListCriteria | None = None) -> list[NormalizedJob]:
+        """Full corpus, or — given criteria — only rows matching the cheap
+        selective predicates (filtered DB-side by the SQL repository)."""
+        if criteria is None:
+            return self._repository.list_all()
+        return self._repository.list_filtered(criteria)
 
     def get_job_by_id(self, job_id: str) -> NormalizedJob | None:
         return self._repository.get_by_id(job_id)

--- a/backend/src/hiresense/ingestion/domain/semantic_pre_ranker.py
+++ b/backend/src/hiresense/ingestion/domain/semantic_pre_ranker.py
@@ -30,6 +30,7 @@ from typing import Any
 
 from hiresense.ingestion.domain.job_scorer import combine_fit_score
 from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.kernel import LRUCache
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,7 @@ class SemanticPreRanker:
         skill_weight: float,
         semantic_weight: float,
         preference: Any = None,
+        profile_cache_size: int = 8,
     ) -> None:
         self._vector_store = vector_store
         self._embedding = embedding
@@ -73,8 +75,9 @@ class SemanticPreRanker:
         self._skill_weight = skill_weight
         self._semantic_weight = semantic_weight
         self._preference = preference
-        # In-process profile embedding cache: sha256(profile_text) → vector
-        self._profile_cache: dict[str, list[float]] = {}
+        # In-process profile embedding cache: sha256(profile_text) → vector.
+        # Bounded — distinct profile texts would otherwise accumulate forever.
+        self._profile_cache: LRUCache[str, list[float]] = LRUCache(profile_cache_size)
         self._lock = asyncio.Lock()
 
     async def rerank(

--- a/backend/src/hiresense/ingestion/domain/semantic_scoring_service.py
+++ b/backend/src/hiresense/ingestion/domain/semantic_scoring_service.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any
 
 from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.kernel import LRUCache
 from hiresense.matching.domain.semantic_scorer import SemanticScorer
 
 logger = logging.getLogger(__name__)
@@ -36,11 +37,20 @@ class SemanticScoringService:
     on first use, batched per request.
     """
 
-    def __init__(self, embedding_port: Any, scorer: SemanticScorer | None = None) -> None:
+    def __init__(
+        self,
+        embedding_port: Any,
+        scorer: SemanticScorer | None = None,
+        *,
+        job_cache_size: int = 2000,
+        profile_cache_size: int = 8,
+    ) -> None:
         self._embedding = embedding_port
         self._scorer = scorer or SemanticScorer()
-        self._job_cache: dict[str, list[float]] = {}
-        self._profile_cache: dict[str, list[float]] = {}
+        # Bounded: embeddings are ~3 KB each; unbounded dicts grow for the
+        # lifetime of the process.
+        self._job_cache: LRUCache[str, list[float]] = LRUCache(job_cache_size)
+        self._profile_cache: LRUCache[str, list[float]] = LRUCache(profile_cache_size)
         self._lock = asyncio.Lock()
 
     async def score_jobs(

--- a/backend/src/hiresense/ingestion/domain/services.py
+++ b/backend/src/hiresense/ingestion/domain/services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 import uuid
@@ -104,7 +105,7 @@ class IngestionOrchestrator:
 
                     # One bulk identity lookup + one commit per source instead
                     # of 2 queries per job. Outcomes carry the resolved ids.
-                    outcomes = self._repository.bulk_upsert(normalized)
+                    outcomes = await asyncio.to_thread(self._repository.bulk_upsert, normalized)
                     seen_keys = {identity_key(o.job) for o in outcomes}
                     touched: list[NormalizedJob] = []
                     for outcome in outcomes:
@@ -130,8 +131,11 @@ class IngestionOrchestrator:
                     # Disappearance-based closure: only for snapshot sources, only after a
                     # successful fetch (errored fetches `continue` above and never reach here).
                     if source.supports_snapshot_closure():
-                        closed_ids = self._repository.bump_missed_and_close(
-                            source_name, seen_keys, self._closure_miss_threshold
+                        closed_ids = await asyncio.to_thread(
+                            self._repository.bump_missed_and_close,
+                            source_name,
+                            seen_keys,
+                            self._closure_miss_threshold,
                         )
                         if closed_ids and self._indexer is not None:
                             await self._indexer.remove(closed_ids)
@@ -143,11 +147,12 @@ class IngestionOrchestrator:
                     try:
                         verdicts = await self._quality_classifier.classify(all_touched)
                         if verdicts:
-                            self._repository.bulk_update_quality(
+                            await asyncio.to_thread(
+                                self._repository.bulk_update_quality,
                                 [
                                     QualityUpdate(v.job_id, v.quality.value, v.reason)
                                     for v in verdicts.values()
-                                ]
+                                ],
                             )
                     except Exception:
                         logger.exception("Job-quality classification failed; left as 'ok'")
@@ -207,7 +212,7 @@ class IngestionOrchestrator:
             return
         cutoff = datetime.now(timezone.utc) - timedelta(days=self._retention_days)
         try:
-            removed_ids = self._repository.prune_older_than(cutoff)
+            removed_ids = await asyncio.to_thread(self._repository.prune_older_than, cutoff)
         except Exception:
             logger.exception("Job pruning failed")
             return

--- a/backend/src/hiresense/ingestion/domain/services.py
+++ b/backend/src/hiresense/ingestion/domain/services.py
@@ -9,6 +9,7 @@ from typing import Any
 from opentelemetry import trace
 
 from hiresense.ingestion.domain.identity import identity_key
+from hiresense.ingestion.domain.job_list_criteria import JobListCriteria
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.normalizer import JobNormalizer
 from hiresense.ingestion.domain.upsert_result import UpsertResult
@@ -178,8 +179,12 @@ class IngestionOrchestrator:
     def get_job_by_id(self, job_id: str) -> NormalizedJob | None:
         return self._repository.get_by_id(job_id)
 
-    def list_jobs(self) -> list[NormalizedJob]:
-        return self._repository.list_all()
+    def list_jobs(self, criteria: JobListCriteria | None = None) -> list[NormalizedJob]:
+        """Full corpus, or — given criteria — only rows matching the cheap
+        selective predicates (filtered DB-side by the SQL repository)."""
+        if criteria is None:
+            return self._repository.list_all()
+        return self._repository.list_filtered(criteria)
 
     def persist_scores(
         self,

--- a/backend/src/hiresense/ingestion/domain/services.py
+++ b/backend/src/hiresense/ingestion/domain/services.py
@@ -88,32 +88,35 @@ class IngestionOrchestrator:
                     fetched_count = len(raw_jobs)
                     _metrics.jobs_fetched_total.add(fetched_count, {"source": source_name})
 
-                    seen_keys: set[str] = set()
-                    touched: list[NormalizedJob] = []
+                    normalized: list[NormalizedJob] = []
                     for raw in raw_jobs:
                         normalized_data = normalizer.normalize(raw)
-                        job = NormalizedJob(
-                            id=str(uuid.uuid4()),
-                            source=source_name,
-                            source_type=source.source_type().value,
-                            source_id=raw.source_id,
-                            **normalized_data,
+                        normalized.append(
+                            NormalizedJob(
+                                id=str(uuid.uuid4()),
+                                source=source_name,
+                                source_type=source.source_type().value,
+                                source_id=raw.source_id,
+                                **normalized_data,
+                            )
                         )
-                        existing_id = self._repository.get_id_by_identity(source_name, job)
-                        if existing_id:
-                            job = job.model_copy(update={"id": existing_id})
-                        seen_keys.add(identity_key(job))
-                        result = self._repository.upsert(job)
+
+                    # One bulk identity lookup + one commit per source instead
+                    # of 2 queries per job. Outcomes carry the resolved ids.
+                    outcomes = self._repository.bulk_upsert(normalized)
+                    seen_keys = {identity_key(o.job) for o in outcomes}
+                    touched: list[NormalizedJob] = []
+                    for outcome in outcomes:
                         # INSERTED/UPDATED/REOPENED all need (re-)indexing; REOPENED matters
                         # because closure removed the job from the vector store.
-                        if result in (
+                        if outcome.result in (
                             UpsertResult.INSERTED,
                             UpsertResult.UPDATED,
                             UpsertResult.REOPENED,
                         ):
-                            touched.append(job)
-                            if result == UpsertResult.INSERTED:
-                                new_jobs.append(job)
+                            touched.append(outcome.job)
+                            if outcome.result == UpsertResult.INSERTED:
+                                new_jobs.append(outcome.job)
 
                     indexed_count = len(touched)
                     _metrics.jobs_indexed_total.add(indexed_count, {"source": source_name})

--- a/backend/src/hiresense/ingestion/infrastructure/in_memory_jobs_repository.py
+++ b/backend/src/hiresense/ingestion/infrastructure/in_memory_jobs_repository.py
@@ -7,7 +7,7 @@ from hiresense.ingestion.domain.content_hash import content_hash
 from hiresense.ingestion.domain.identity import identity_key
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.upsert_result import UpsertResult
-from hiresense.ingestion.ports.jobs_repository import QualityUpdate, ScoreUpdate
+from hiresense.ingestion.ports.jobs_repository import QualityUpdate, ScoreUpdate, UpsertOutcome
 
 
 class InMemoryJobsRepository:
@@ -76,6 +76,16 @@ class InMemoryJobsRepository:
 
     def get_id_by_identity(self, source: str, job: NormalizedJob) -> str | None:
         return self._identity_to_id.get((source, identity_key(job)))
+
+    def bulk_upsert(self, jobs: list[NormalizedJob]) -> list[UpsertOutcome]:
+        """Batch wrapper over upsert(); resolves each job's stored id first."""
+        outcomes: list[UpsertOutcome] = []
+        for job in jobs:
+            existing_id = self.get_id_by_identity(job.source, job)
+            if existing_id:
+                job = job.model_copy(update={"id": existing_id})
+            outcomes.append(UpsertOutcome(job=job, result=self.upsert(job)))
+        return outcomes
 
     def mark_closed(self, job_ids: list[str]) -> None:
         for jid in job_ids:

--- a/backend/src/hiresense/ingestion/infrastructure/in_memory_jobs_repository.py
+++ b/backend/src/hiresense/ingestion/infrastructure/in_memory_jobs_repository.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 from hiresense.ingestion.domain.closure_detector import OpenJob, detect_closures
 from hiresense.ingestion.domain.content_hash import content_hash
 from hiresense.ingestion.domain.identity import identity_key
+from hiresense.ingestion.domain.job_list_criteria import JobListCriteria
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.upsert_result import UpsertResult
 from hiresense.ingestion.ports.jobs_repository import QualityUpdate, ScoreUpdate, UpsertOutcome
@@ -133,6 +134,9 @@ class InMemoryJobsRepository:
 
     def list_all(self) -> list[NormalizedJob]:
         return list(self._jobs.values())
+
+    def list_filtered(self, criteria: JobListCriteria) -> list[NormalizedJob]:
+        return [j for j in self._jobs.values() if criteria.matches(j)]
 
     def get_by_id(self, job_id: str) -> NormalizedJob | None:
         return self._jobs.get(job_id)

--- a/backend/src/hiresense/ingestion/infrastructure/jobs_repository.py
+++ b/backend/src/hiresense/ingestion/infrastructure/jobs_repository.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, func, select, update
 
 from hiresense.ingestion.domain.closure_detector import OpenJob, detect_closures
 from hiresense.ingestion.domain.content_hash import content_hash
 from hiresense.ingestion.domain.identity import identity_key
+from hiresense.ingestion.domain.job_list_criteria import JobListCriteria
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.upsert_result import UpsertResult
 from hiresense.ingestion.infrastructure.models import IngestedJob
@@ -263,6 +264,33 @@ class JobsRepository:
     def list_all(self) -> list[NormalizedJob]:
         with self._session_factory() as session:
             stmt = select(IngestedJob).where(IngestedJob.bucket == self._bucket)
+            return [_to_domain(r) for r in session.scalars(stmt).all()]
+
+    def list_filtered(self, criteria: JobListCriteria) -> list[NormalizedJob]:
+        """Selective predicates pushed into the WHERE clause (see port docstring)."""
+        with self._session_factory() as session:
+            stmt = select(IngestedJob).where(IngestedJob.bucket == self._bucket)
+            if not criteria.include_closed:
+                stmt = stmt.where(IngestedJob.status != "closed")
+            if not criteria.include_low_quality:
+                stmt = stmt.where(
+                    (IngestedJob.quality.is_(None)) | (IngestedJob.quality == "ok")
+                )
+            if criteria.source:
+                stmt = stmt.where(IngestedJob.source == criteria.source)
+            if criteria.company:
+                target = criteria.company.strip().lower()
+                stmt = stmt.where(func.lower(func.trim(IngestedJob.company)) == target)
+            if criteria.date_from:
+                stmt = stmt.where(
+                    IngestedJob.posted_date.is_not(None),
+                    IngestedJob.posted_date >= criteria.date_from,
+                )
+            if criteria.date_to:
+                stmt = stmt.where(
+                    IngestedJob.posted_date.is_not(None),
+                    IngestedJob.posted_date <= criteria.date_to,
+                )
             return [_to_domain(r) for r in session.scalars(stmt).all()]
 
     def list_since(self, cutoff: datetime, *, status: str = "open") -> list[NormalizedJob]:

--- a/backend/src/hiresense/ingestion/infrastructure/jobs_repository.py
+++ b/backend/src/hiresense/ingestion/infrastructure/jobs_repository.py
@@ -11,7 +11,7 @@ from hiresense.ingestion.domain.identity import identity_key
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.upsert_result import UpsertResult
 from hiresense.ingestion.infrastructure.models import IngestedJob
-from hiresense.ingestion.ports.jobs_repository import QualityUpdate, ScoreUpdate
+from hiresense.ingestion.ports.jobs_repository import QualityUpdate, ScoreUpdate, UpsertOutcome
 
 
 def _to_orm(job: NormalizedJob, bucket: str) -> IngestedJob:
@@ -86,6 +86,36 @@ class JobsRepository:
         self._session_factory = session_factory
         self._bucket = bucket
 
+    @staticmethod
+    def _apply_to_row(row: IngestedJob, job: NormalizedJob, new_hash: str, now: datetime) -> UpsertResult:
+        """Apply one job's upsert semantics to an existing row (no commit)."""
+        row.last_seen_at = now
+        row.missed_count = 0
+        reopened = row.status == "closed"
+        if reopened:
+            row.status = "open"
+            row.closed_at = None
+
+        changed = row.content_hash != new_hash
+        if changed:
+            row.title = job.title
+            row.company = job.company
+            row.description = job.description
+            row.location = job.location
+            row.salary_range = job.salary_range
+            row.skills = list(job.skills)
+            row.categories = list(job.categories)
+            row.countries = list(job.countries)
+            row.remote_modality = job.remote_modality
+            row.content_hash = new_hash
+            row.updated_at = now
+
+        if reopened:
+            return UpsertResult.REOPENED
+        if changed:
+            return UpsertResult.UPDATED
+        return UpsertResult.UNCHANGED
+
     def upsert(self, job: NormalizedJob) -> UpsertResult:
         ident = identity_key(job)
         new_hash = content_hash(job)
@@ -103,36 +133,47 @@ class JobsRepository:
                 session.commit()
                 return UpsertResult.INSERTED
 
-            row.last_seen_at = now
-            row.missed_count = 0
-            reopened = row.status == "closed"
-            if reopened:
-                row.status = "open"
-                row.closed_at = None
-
-            changed = row.content_hash != new_hash
-            if changed:
-                row.title = job.title
-                row.company = job.company
-                row.description = job.description
-                row.location = job.location
-                row.salary_range = job.salary_range
-                row.skills = list(job.skills)
-                row.categories = list(job.categories)
-                row.countries = list(job.countries)
-                row.remote_modality = job.remote_modality
-                row.content_hash = new_hash
-                row.updated_at = now
-
-            if reopened:
-                session.commit()
-                return UpsertResult.REOPENED
-            if changed:
-                session.commit()
-                return UpsertResult.UPDATED
-
+            result = self._apply_to_row(row, job, new_hash, now)
             session.commit()
-            return UpsertResult.UNCHANGED
+            return result
+
+    def bulk_upsert(self, jobs: list[NormalizedJob]) -> list[UpsertOutcome]:
+        """One bulk identity SELECT + one commit for the whole batch.
+
+        Preserves upsert()'s per-job semantics via _apply_to_row. In-batch
+        duplicate identities resolve against the row created/updated earlier
+        in the same batch.
+        """
+        if not jobs:
+            return []
+        now = datetime.now(timezone.utc)
+        idents = [identity_key(j) for j in jobs]
+        with self._session_factory() as session:
+            rows = session.scalars(
+                select(IngestedJob).where(
+                    IngestedJob.bucket == self._bucket,
+                    IngestedJob.source.in_({j.source for j in jobs}),
+                    IngestedJob.identity_key.in_(idents),
+                )
+            ).all()
+            by_key: dict[tuple[str, str], IngestedJob] = {
+                (r.source, r.identity_key): r for r in rows
+            }
+            outcomes: list[UpsertOutcome] = []
+            for job, ident in zip(jobs, idents):
+                key = (job.source, ident)
+                row = by_key.get(key)
+                if row is None:
+                    orm = _to_orm(job, self._bucket)
+                    session.add(orm)
+                    by_key[key] = orm
+                    outcomes.append(UpsertOutcome(job=job, result=UpsertResult.INSERTED))
+                    continue
+                resolved = job.model_copy(update={"id": row.id})
+                result = self._apply_to_row(row, resolved, content_hash(resolved), now)
+                outcomes.append(UpsertOutcome(job=resolved, result=result))
+            session.commit()
+        return outcomes
 
     def get_id_by_identity(self, source: str, job: NormalizedJob) -> str | None:
         with self._session_factory() as session:

--- a/backend/src/hiresense/ingestion/ports/__init__.py
+++ b/backend/src/hiresense/ingestion/ports/__init__.py
@@ -1,5 +1,10 @@
 """HireSense - AI-powered job matching and CV optimization."""
 
-from hiresense.ingestion.ports.jobs_repository import JobsRepositoryPort
+from hiresense.ingestion.ports.jobs_repository import (
+    JobsRepositoryPort,
+    QualityUpdate,
+    ScoreUpdate,
+    UpsertOutcome,
+)
 
-__all__ = ["JobsRepositoryPort"]
+__all__ = ["JobsRepositoryPort", "QualityUpdate", "ScoreUpdate", "UpsertOutcome"]

--- a/backend/src/hiresense/ingestion/ports/jobs_repository.py
+++ b/backend/src/hiresense/ingestion/ports/jobs_repository.py
@@ -32,6 +32,19 @@ class QualityUpdate:
     quality_reason: str | None
 
 
+@dataclasses.dataclass(frozen=True)
+class UpsertOutcome:
+    """Result of one job inside a bulk_upsert call.
+
+    `job` carries the RESOLVED id: when the identity already existed, the
+    stored row's id replaces the caller's freshly generated one (absorbing the
+    old get_id_by_identity pre-lookup).
+    """
+
+    job: NormalizedJob
+    result: "UpsertResult"
+
+
 class JobsRepositoryPort(Protocol):
     def upsert(self, job: NormalizedJob) -> "UpsertResult":
         """Insert, update-in-place (preserving id), reopen, or no-op a job,
@@ -40,6 +53,16 @@ class JobsRepositoryPort(Protocol):
 
     def get_id_by_identity(self, source: str, job: NormalizedJob) -> str | None:
         """Stored row id for this job's identity, or None if absent."""
+        ...
+
+    def bulk_upsert(self, jobs: list[NormalizedJob]) -> list["UpsertOutcome"]:
+        """Upsert a batch of jobs, preserving upsert()'s per-job semantics.
+
+        Returns one outcome per input job, in order, with the resolved row id
+        on each outcome's job. SQL implementations MUST do one bulk identity
+        lookup + one commit for the whole batch (not 2 queries per job);
+        in-batch duplicate identities resolve against the earlier row.
+        """
         ...
 
     def mark_closed(self, job_ids: list[str]) -> None:

--- a/backend/src/hiresense/ingestion/ports/jobs_repository.py
+++ b/backend/src/hiresense/ingestion/ports/jobs_repository.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 from hiresense.ingestion.domain.models import NormalizedJob
 
 if TYPE_CHECKING:
+    from hiresense.ingestion.domain.job_list_criteria import JobListCriteria
     from hiresense.ingestion.domain.upsert_result import UpsertResult
 
 
@@ -87,6 +88,15 @@ class JobsRepositoryPort(Protocol):
         ...
 
     def list_all(self) -> list[NormalizedJob]: ...
+
+    def list_filtered(self, criteria: "JobListCriteria") -> list[NormalizedJob]:
+        """Jobs matching the cheap selective predicates in `criteria`.
+
+        SQL implementations push these into the WHERE clause so unfiltered
+        rows never leave the database; in-memory implementations apply
+        criteria.matches(). Ordering is unspecified (callers re-sort).
+        """
+        ...
 
     def get_by_id(self, job_id: str) -> NormalizedJob | None: ...
 

--- a/backend/src/hiresense/kernel/__init__.py
+++ b/backend/src/hiresense/kernel/__init__.py
@@ -1,3 +1,4 @@
+from hiresense.kernel.lru_cache import LRUCache
 from hiresense.kernel.rate_limit import SlidingWindowRateLimiter
 
-__all__ = ["SlidingWindowRateLimiter"]
+__all__ = ["LRUCache", "SlidingWindowRateLimiter"]

--- a/backend/src/hiresense/kernel/__init__.py
+++ b/backend/src/hiresense/kernel/__init__.py
@@ -1,1 +1,3 @@
-"""HireSense - AI-powered job matching and CV optimization."""
+from hiresense.kernel.rate_limit import SlidingWindowRateLimiter
+
+__all__ = ["SlidingWindowRateLimiter"]

--- a/backend/src/hiresense/kernel/lru_cache.py
+++ b/backend/src/hiresense/kernel/lru_cache.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Generic, TypeVar
+
+K = TypeVar("K")
+V = TypeVar("V")
+
+
+class LRUCache(Generic[K, V]):
+    """Minimal bounded mapping with least-recently-used eviction.
+
+    Drop-in for the dict-style `get`/`__setitem__`/`__contains__` usage of the
+    embedding caches; not thread-safe on its own (callers already serialize
+    behind an asyncio.Lock where it matters).
+    """
+
+    def __init__(self, max_size: int) -> None:
+        if max_size < 1:
+            raise ValueError("max_size must be >= 1")
+        self._max_size = max_size
+        self._data: OrderedDict[K, V] = OrderedDict()
+
+    def get(self, key: K, default: V | None = None) -> V | None:
+        if key not in self._data:
+            return default
+        self._data.move_to_end(key)
+        return self._data[key]
+
+    def __setitem__(self, key: K, value: V) -> None:
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = value
+        if len(self._data) > self._max_size:
+            self._data.popitem(last=False)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)

--- a/backend/src/hiresense/kernel/rate_limit.py
+++ b/backend/src/hiresense/kernel/rate_limit.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+
+
+class SlidingWindowRateLimiter:
+    """Thread-safe in-process sliding-window rate limiter.
+
+    Counts are per limiter instance (single-process deployment) and reset on
+    restart — deliberate for a self-hosted single-user app; no external store.
+    """
+
+    def __init__(self, max_requests: int, window_seconds: float) -> None:
+        self._max = max_requests
+        self._window = window_seconds
+        self._events: dict[str, deque[float]] = {}
+        self._lock = threading.Lock()
+
+    @property
+    def window_seconds(self) -> float:
+        return self._window
+
+    def allow(self, key: str) -> bool:
+        """Record one request for `key`; False when the window is exhausted."""
+        now = time.monotonic()
+        cutoff = now - self._window
+        with self._lock:
+            events = self._events.setdefault(key, deque())
+            while events and events[0] < cutoff:
+                events.popleft()
+            if len(events) >= self._max:
+                return False
+            events.append(now)
+            return True

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -33,6 +33,7 @@ from hiresense.config import Settings
 from hiresense.observability import setup_telemetry
 from hiresense.cover_letter_templates.api import router as cover_letter_templates_router
 from hiresense.identity.api import router as auth_router
+from hiresense.kernel import SlidingWindowRateLimiter
 from hiresense.ingestion.api import router as ingestion_router
 from hiresense.interview.api import router as interview_router
 from hiresense.matching.api import router as matching_router
@@ -74,6 +75,17 @@ def create_app() -> FastAPI:
     )
 
     app.state.settings = settings
+
+    # Per-client-IP limiter for LLM/network-heavy endpoints (see
+    # enforce_expensive_rate_limit). None disables enforcement.
+    app.state.rate_limiter = (
+        SlidingWindowRateLimiter(
+            max_requests=settings.rate_limit_max_requests,
+            window_seconds=settings.rate_limit_window_seconds,
+        )
+        if settings.rate_limit_enabled
+        else None
+    )
 
     # Initialize observability (traces/metrics/logs) before any engine/client
     # is built so auto-instrumentation can hook them. No-op when disabled.

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -52,6 +52,11 @@ def create_app() -> FastAPI:
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         yield
+        # Drain in-flight event handlers before tearing infrastructure down so
+        # events published late in a request aren't silently dropped.
+        event_bus = getattr(app.state, "event_bus", None)
+        if event_bus is not None:
+            await event_bus.aclose(timeout=settings.event_bus_drain_timeout_seconds)
         await http_client.aclose()
         # Flush and shut down any OTel providers set up by setup_telemetry. No-op
         # when telemetry is disabled (no providers were stored). Guarded so a
@@ -92,6 +97,8 @@ def create_app() -> FastAPI:
     setup_telemetry(app, settings)
 
     infra = build_shared_infra(settings, http_client)
+    # Exposed for the lifespan drain above.
+    app.state.event_bus = infra.event_bus
 
     # --- Admin (owns the tracked-LLM factory the other modules share) ---
     admin = build_admin(infra)

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -69,8 +69,8 @@ def create_app() -> FastAPI:
         CORSMiddleware,
         allow_origins=settings.cors_origins,
         allow_credentials=True,
-        allow_methods=["*"],
-        allow_headers=["*"],
+        allow_methods=settings.cors_allow_methods,
+        allow_headers=settings.cors_allow_headers,
     )
 
     app.state.settings = settings

--- a/backend/src/hiresense/matching/api/routes.py
+++ b/backend/src/hiresense/matching/api/routes.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from hiresense.identity.api.dependencies import require_auth
+from hiresense.identity.api.dependencies import enforce_expensive_rate_limit, require_auth
 from hiresense.matching.api.dependencies import (
     get_batch_evaluation_service,
     get_ingestion_orchestrator_for_matching,
@@ -36,7 +36,7 @@ class AnalyzeRequest(BaseModel):
     job_embedding: list[float] | None = None
 
 
-@router.post("/evaluate", response_model=EvaluationResponse)
+@router.post("/evaluate", response_model=EvaluationResponse, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def evaluate_job(
     body: EvaluateRequest,
     orchestrator: Annotated[object, Depends(get_matching_orchestrator)],
@@ -60,7 +60,7 @@ async def evaluate_job(
     )
 
 
-@router.post("/analyze", response_model=MatchResult)
+@router.post("/analyze", response_model=MatchResult, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def analyze_match(
     body: AnalyzeRequest,
     orchestrator: Annotated[object, Depends(get_matching_orchestrator)],
@@ -77,7 +77,7 @@ async def analyze_match(
     )
 
 
-@router.post("/batch-evaluate", response_model=BatchEvaluationResponse)
+@router.post("/batch-evaluate", response_model=BatchEvaluationResponse, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def batch_evaluate(
     body: BatchEvaluateRequest,
     batch_service: Annotated[object, Depends(get_batch_evaluation_service)],

--- a/backend/src/hiresense/matching/api/routes.py
+++ b/backend/src/hiresense/matching/api/routes.py
@@ -22,7 +22,7 @@ from hiresense.matching.api.schemas import (
 )
 from hiresense.matching.domain.models import MatchResult
 
-router = APIRouter(prefix="/matching", tags=["matching"])
+router = APIRouter(prefix="/matching", tags=["matching"], dependencies=[Depends(require_auth)])
 
 
 class AnalyzeRequest(BaseModel):
@@ -77,7 +77,7 @@ async def analyze_match(
     )
 
 
-@router.post("/batch-evaluate", response_model=BatchEvaluationResponse, dependencies=[Depends(require_auth)])
+@router.post("/batch-evaluate", response_model=BatchEvaluationResponse)
 async def batch_evaluate(
     body: BatchEvaluateRequest,
     batch_service: Annotated[object, Depends(get_batch_evaluation_service)],

--- a/backend/src/hiresense/optimization/api/routes.py
+++ b/backend/src/hiresense/optimization/api/routes.py
@@ -5,10 +5,13 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.optimization.api.dependencies import get_cv_optimizer
 from hiresense.optimization.domain.models import OptimizationResult
 
-router = APIRouter(prefix="/optimization", tags=["optimization"])
+router = APIRouter(
+    prefix="/optimization", tags=["optimization"], dependencies=[Depends(require_auth)]
+)
 
 
 class OptimizeRequest(BaseModel):

--- a/backend/src/hiresense/optimization/api/routes.py
+++ b/backend/src/hiresense/optimization/api/routes.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from hiresense.identity.api.dependencies import require_auth
+from hiresense.identity.api.dependencies import enforce_expensive_rate_limit, require_auth
 from hiresense.optimization.api.dependencies import get_cv_optimizer
 from hiresense.optimization.domain.models import OptimizationResult
 
@@ -25,7 +25,7 @@ class OptimizeRequest(BaseModel):
     recommendations: list[str] = []
 
 
-@router.post("/optimize", response_model=OptimizationResult)
+@router.post("/optimize", response_model=OptimizationResult, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def optimize_cv(
     body: OptimizeRequest,
     optimizer: Annotated[object, Depends(get_cv_optimizer)],

--- a/backend/src/hiresense/profile/api/routes.py
+++ b/backend/src/hiresense/profile/api/routes.py
@@ -6,10 +6,11 @@ from typing import Annotated, Literal
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Request, UploadFile, status
 from pydantic import BaseModel
 
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.profile.api.dependencies import get_profile_service
 from hiresense.profile.domain.models import CandidateProfile
 
-router = APIRouter(prefix="/profile", tags=["profile"])
+router = APIRouter(prefix="/profile", tags=["profile"], dependencies=[Depends(require_auth)])
 
 _ALLOWED_EXTENSIONS = {".pdf", ".tex"}
 

--- a/backend/src/hiresense/profile/api/routes.py
+++ b/backend/src/hiresense/profile/api/routes.py
@@ -15,6 +15,28 @@ router = APIRouter(prefix="/profile", tags=["profile"], dependencies=[Depends(re
 _ALLOWED_EXTENSIONS = {".pdf", ".tex"}
 
 
+def _validate_upload_content(ext: str, file_bytes: bytes) -> None:
+    """Cheap content sniffing so the declared extension matches the payload.
+
+    A `.tex` upload flows into the LaTeX pipeline, so a binary blob renamed to
+    .tex (or a TeX file renamed to .pdf) is rejected up front instead of
+    failing deeper in parsing/compilation.
+    """
+    if ext == ".pdf" and not file_bytes.startswith(b"%PDF-"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File content does not match the .pdf extension",
+        )
+    if ext == ".tex":
+        try:
+            file_bytes.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="File content is not valid UTF-8 text for a .tex upload",
+            ) from exc
+
+
 class UploadCVRequest(BaseModel):
     tex_content: str
     language: str = "en"
@@ -64,6 +86,7 @@ async def upload_file(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail=f"File too large. Maximum size: {max_bytes // (1024 * 1024)} MB",
         )
+    _validate_upload_content(ext, file_bytes)
     return await service.parse_file_and_create(file_bytes, filename, language)
 
 

--- a/backend/tests/integration/test_ingestion_to_api_flow.py
+++ b/backend/tests/integration/test_ingestion_to_api_flow.py
@@ -82,7 +82,7 @@ class _FakeProfileService:
 
 
 class _EmptyScanner:
-    def list_jobs(self):
+    def list_jobs(self, criteria=None):
         return []
 
     def get_job_by_id(self, job_id):  # noqa: ARG002

--- a/backend/tests/integration/test_ingestion_to_api_flow.py
+++ b/backend/tests/integration/test_ingestion_to_api_flow.py
@@ -16,6 +16,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
 
 from hiresense.identity.api.dependencies import require_auth
@@ -91,7 +92,9 @@ class _EmptyScanner:
 
 @pytest.mark.asyncio
 async def test_ingested_jobs_persist_and_surface_via_api() -> None:
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
     Base.metadata.create_all(engine)
     session_factory = sessionmaker(bind=engine, expire_on_commit=False)
     repo = JobsRepository(session_factory=session_factory, bucket="boards")

--- a/backend/tests/integration/test_ingestion_to_api_flow.py
+++ b/backend/tests/integration/test_ingestion_to_api_flow.py
@@ -18,6 +18,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.infrastructure.database import Base
 from hiresense.ingestion.api import (
     get_ingestion_orchestrator,
@@ -113,6 +114,7 @@ async def test_ingested_jobs_persist_and_surface_via_api() -> None:
     app.dependency_overrides[get_portal_scanner] = lambda: _EmptyScanner()
     app.dependency_overrides[get_profile_service] = lambda: _FakeProfileService()
     app.dependency_overrides[get_semantic_scoring] = lambda: None
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/backend/tests/integration/test_jobs_company_filter.py
+++ b/backend/tests/integration/test_jobs_company_filter.py
@@ -7,6 +7,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.infrastructure.database import Base
 from hiresense.ingestion.api import (
     get_ingestion_orchestrator,
@@ -95,6 +96,7 @@ async def test_company_query_param_narrows_results() -> None:
     app.dependency_overrides[get_portal_scanner] = lambda: _EmptyScanner()
     app.dependency_overrides[get_profile_service] = lambda: _FakeProfileService()
     app.dependency_overrides[get_semantic_scoring] = lambda: None
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:

--- a/backend/tests/integration/test_jobs_company_filter.py
+++ b/backend/tests/integration/test_jobs_company_filter.py
@@ -5,6 +5,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
+from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
 
 from hiresense.identity.api.dependencies import require_auth
@@ -78,7 +79,9 @@ class _EmptyScanner:
 
 @pytest.mark.asyncio
 async def test_company_query_param_narrows_results() -> None:
-    engine = create_engine("sqlite:///:memory:")
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
     Base.metadata.create_all(engine)
     session_factory = sessionmaker(bind=engine, expire_on_commit=False)
     repo = JobsRepository(session_factory=session_factory, bucket="boards")

--- a/backend/tests/integration/test_jobs_company_filter.py
+++ b/backend/tests/integration/test_jobs_company_filter.py
@@ -69,7 +69,7 @@ class _FakeProfileService:
 
 
 class _EmptyScanner:
-    def list_jobs(self):
+    def list_jobs(self, criteria=None):
         return []
 
     def get_job_by_id(self, job_id):  # noqa: ARG002

--- a/backend/tests/unit/ingestion/test_backfill_endpoint.py
+++ b/backend/tests/unit/ingestion/test_backfill_endpoint.py
@@ -71,6 +71,9 @@ class _FakeRepo:
     def list_all(self) -> list[NormalizedJob]:
         return list(self._jobs.values())
 
+    def list_filtered(self, criteria) -> list[NormalizedJob]:
+        return [j for j in self._jobs.values() if criteria.matches(j)]
+
 
 def _make_auth_service() -> AuthService:
     return AuthService(username="admin", password="secret", jwt_secret="test-secret")

--- a/backend/tests/unit/ingestion/test_csv_import.py
+++ b/backend/tests/unit/ingestion/test_csv_import.py
@@ -1,29 +1,45 @@
-import tempfile
-from pathlib import Path
-
 import pytest
 
-from hiresense.ingestion.adapters.csv_import import CSVImportAdapter
+from hiresense.ingestion.adapters import CSVImportAdapter
 from hiresense.kernel.value_objects import SourceType
 
 
 @pytest.mark.asyncio
-async def test_csv_import_reads_file() -> None:
+async def test_csv_import_reads_file(tmp_path) -> None:
     csv_content = (
         "title,company,description,skills,location,url\n"
         'Backend Engineer,Acme,"Build APIs",python;fastapi,Remote,https://example.com/1\n'
         'Frontend Dev,Beta,"Build UIs",angular;typescript,Remote,https://example.com/2\n'
     )
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".csv", delete=False) as f:
-        f.write(csv_content)
-        csv_path = f.name
-    adapter = CSVImportAdapter()
-    jobs = await adapter.fetch_jobs(filters={"file_path": csv_path})
+    (tmp_path / "jobs.csv").write_text(csv_content, encoding="utf-8")
+    adapter = CSVImportAdapter(import_dir=str(tmp_path))
+    jobs = await adapter.fetch_jobs(filters={"file_path": "jobs.csv"})
     assert len(jobs) == 2
     assert jobs[0].source == "csv"
     assert jobs[0].raw_data["title"] == "Backend Engineer"
     assert jobs[1].raw_data["company"] == "Beta"
-    Path(csv_path).unlink()
+
+
+@pytest.mark.asyncio
+async def test_csv_import_rejects_path_traversal(tmp_path) -> None:
+    outside = tmp_path / "outside.csv"
+    outside.write_text("title\nEscape\n", encoding="utf-8")
+    import_dir = tmp_path / "imports"
+    import_dir.mkdir()
+    adapter = CSVImportAdapter(import_dir=str(import_dir))
+    with pytest.raises(ValueError, match="escapes the import directory"):
+        await adapter.fetch_jobs(filters={"file_path": "../outside.csv"})
+
+
+@pytest.mark.asyncio
+async def test_csv_import_rejects_absolute_path_outside_dir(tmp_path) -> None:
+    outside = tmp_path / "outside.csv"
+    outside.write_text("title\nEscape\n", encoding="utf-8")
+    import_dir = tmp_path / "imports"
+    import_dir.mkdir()
+    adapter = CSVImportAdapter(import_dir=str(import_dir))
+    with pytest.raises(ValueError, match="escapes the import directory"):
+        await adapter.fetch_jobs(filters={"file_path": str(outside)})
 
 
 def test_csv_source_name() -> None:

--- a/backend/tests/unit/ingestion/test_jobs_repository.py
+++ b/backend/tests/unit/ingestion/test_jobs_repository.py
@@ -253,6 +253,40 @@ def test_bulk_upsert_in_memory_parity():
     assert outcomes[0].job.id == "a"
 
 
+def test_list_filtered_pushes_predicates_to_sql(repo):
+    from hiresense.ingestion.domain import JobListCriteria
+
+    repo.upsert(_job("a", source_id="n1", url="https://e.com/1", company="Acme"))
+    repo.upsert(_job("b", source_id="n2", url="https://e.com/2", company="Beta", source="other"))
+    repo.upsert(_job("c", source_id="n3", url="https://e.com/3", company="Acme"))
+    repo.mark_closed(["c"])
+
+    open_jobs = repo.list_filtered(JobListCriteria())
+    assert {j.id for j in open_jobs} == {"a", "b"}
+
+    closed_included = repo.list_filtered(JobListCriteria(include_closed=True))
+    assert {j.id for j in closed_included} == {"a", "b", "c"}
+
+    by_source = repo.list_filtered(JobListCriteria(source="other"))
+    assert [j.id for j in by_source] == ["b"]
+
+    by_company = repo.list_filtered(JobListCriteria(company="  ACME "))
+    assert {j.id for j in by_company} == {"a"}
+
+
+def test_list_filtered_in_memory_parity():
+    from hiresense.ingestion.domain import JobListCriteria
+
+    mem = InMemoryJobsRepository()
+    mem.upsert(_job("a", source_id="n1", url="https://e.com/1", company="Acme"))
+    mem.upsert(_job("b", source_id="n2", url="https://e.com/2", company="Beta", source="other"))
+    mem.mark_closed(["a"])
+
+    assert [j.id for j in mem.list_filtered(JobListCriteria())] == ["b"]
+    assert {j.id for j in mem.list_filtered(JobListCriteria(include_closed=True))} == {"a", "b"}
+    assert [j.id for j in mem.list_filtered(JobListCriteria(company="beta"))] == ["b"]
+
+
 def test_bump_missed_and_close_persists_per_row(repo):
     from hiresense.ingestion.domain.identity import identity_key
 

--- a/backend/tests/unit/ingestion/test_jobs_repository.py
+++ b/backend/tests/unit/ingestion/test_jobs_repository.py
@@ -194,6 +194,65 @@ def test_in_memory_repo_upsert_parity():
     assert mem.list_all()[0].status == "open"
 
 
+def test_bulk_upsert_mixes_insert_update_reopen_unchanged(repo):
+    repo.upsert(_job("a", source_id="n1", url="https://e.com/1"))          # → UNCHANGED
+    repo.upsert(_job("b", source_id="n2", url="https://e.com/2"))          # → UPDATED
+    repo.upsert(_job("c", source_id="n3", url="https://e.com/3"))          # → REOPENED
+    repo.mark_closed(["c"])
+
+    outcomes = repo.bulk_upsert(
+        [
+            _job("x1", source_id="n1", url="https://e.com/1"),
+            _job("x2", source_id="n2", url="https://e.com/2", salary_range="$200k"),
+            _job("x3", source_id="n3", url="https://e.com/3"),
+            _job("x4", source_id="n4", url="https://e.com/4"),               # → INSERTED
+        ]
+    )
+
+    assert [o.result for o in outcomes] == [
+        UpsertResult.UNCHANGED,
+        UpsertResult.UPDATED,
+        UpsertResult.REOPENED,
+        UpsertResult.INSERTED,
+    ]
+    # Existing identities resolve to their stored ids; the new one keeps its own.
+    assert [o.job.id for o in outcomes] == ["a", "b", "c", "x4"]
+    stored = {j.source_id: j for j in repo.list_all()}
+    assert stored["n2"].salary_range == "$200k"
+    assert stored["n3"].status == "open"
+    assert len(stored) == 4
+
+
+def test_bulk_upsert_handles_in_batch_duplicate_identity(repo):
+    outcomes = repo.bulk_upsert(
+        [
+            _job("d1", source_id="n1", url="https://e.com/1"),
+            _job("d2", source_id="n1", url="https://e.com/1"),  # same identity in batch
+        ]
+    )
+    assert outcomes[0].result == UpsertResult.INSERTED
+    assert outcomes[1].result == UpsertResult.UNCHANGED
+    assert outcomes[1].job.id == "d1"
+    assert len(repo.list_all()) == 1
+
+
+def test_bulk_upsert_empty_is_noop(repo):
+    assert repo.bulk_upsert([]) == []
+
+
+def test_bulk_upsert_in_memory_parity():
+    mem = InMemoryJobsRepository()
+    mem.upsert(_job("a", source_id="n1", url="https://e.com/1"))
+    outcomes = mem.bulk_upsert(
+        [
+            _job("y1", source_id="n1", url="https://e.com/1", salary_range="$150k"),
+            _job("y2", source_id="n2", url="https://e.com/2"),
+        ]
+    )
+    assert [o.result for o in outcomes] == [UpsertResult.UPDATED, UpsertResult.INSERTED]
+    assert outcomes[0].job.id == "a"
+
+
 def test_bump_missed_and_close_persists_per_row(repo):
     from hiresense.ingestion.domain.identity import identity_key
 

--- a/backend/tests/unit/ingestion/test_routes.py
+++ b/backend/tests/unit/ingestion/test_routes.py
@@ -50,7 +50,7 @@ class FakeOrchestrator:
         self.called = True
         return [BOARD_JOB]
 
-    def list_jobs(self) -> list[NormalizedJob]:
+    def list_jobs(self, criteria=None) -> list[NormalizedJob]:
         return [BOARD_JOB]
 
     def persist_scores(self, job_id, match_score, semantic_score) -> None:
@@ -61,7 +61,7 @@ class FakeOrchestrator:
 
 
 class FakeScanner:
-    def list_jobs(self) -> list[NormalizedJob]:
+    def list_jobs(self, criteria=None) -> list[NormalizedJob]:
         return [PORTAL_JOB]
 
     def get_job_by_id(self, job_id):
@@ -216,7 +216,7 @@ async def test_list_jobs_strict_location_filters_non_matching() -> None:
         async def run(self, filters=None) -> list[NormalizedJob]:
             return []
 
-        def list_jobs(self) -> list[NormalizedJob]:
+        def list_jobs(self, criteria=None) -> list[NormalizedJob]:
             return [chile_job, restricted_job, ambiguous_remote_job, worldwide_job]
 
         def persist_scores(self, job_id, match_score, semantic_score) -> None:
@@ -345,7 +345,7 @@ async def test_pre_ranker_promotes_job_to_page_one_before_pagination() -> None:
 
     class _Orch:
         async def run(self, filters=None): return []
-        def list_jobs(self): return list(jobs)
+        def list_jobs(self, criteria=None): return list(jobs)
         def persist_scores(self, *a): pass
         def persist_scores_batch(self, updates): pass
 
@@ -428,7 +428,7 @@ def _make_rescore_app(pre_ranker, quick_scoring):
         async def run(self, filters=None):
             return []
 
-        def list_jobs(self):
+        def list_jobs(self, criteria=None):
             return list(jobs)
 
         def persist_scores(self, *a):
@@ -557,7 +557,7 @@ async def test_cached_llm_score_ranks_globally_before_pagination() -> None:
         async def run(self, filters=None):
             return []
 
-        def list_jobs(self):
+        def list_jobs(self, criteria=None):
             return [job_hn, job_gob]  # heuristic order: hn first
 
         def persist_scores(self, *a):

--- a/backend/tests/unit/ingestion/test_routes.py
+++ b/backend/tests/unit/ingestion/test_routes.py
@@ -1,6 +1,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.ingestion.api import get_ingestion_orchestrator, get_portal_scanner, router
 from hiresense.ingestion.api.dependencies import get_semantic_scoring
 from hiresense.ingestion.domain.models import NormalizedJob
@@ -81,6 +82,7 @@ def _make_app() -> tuple[FastAPI, FakeOrchestrator, FakeScanner]:
     app.dependency_overrides[get_portal_scanner] = lambda: scanner
     app.dependency_overrides[get_profile_service] = lambda: FakeProfileService()
     app.dependency_overrides[get_semantic_scoring] = lambda: None
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
     return app, orch, scanner
 
@@ -228,6 +230,7 @@ async def test_list_jobs_strict_location_filters_non_matching() -> None:
     app.dependency_overrides[get_portal_scanner] = lambda: FakeScanner()
     app.dependency_overrides[get_profile_service] = lambda: FakeProfileService()
     app.dependency_overrides[get_semantic_scoring] = lambda: None
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -306,6 +309,7 @@ async def test_revalidate_endpoint_returns_closed_count() -> None:
 
     app = FastAPI()
     app.dependency_overrides[get_revalidation_service] = lambda: FakeRevalidation()
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -318,6 +322,7 @@ async def test_revalidate_endpoint_returns_closed_count() -> None:
 @pytest.mark.asyncio
 async def test_revalidate_endpoint_503_when_unconfigured() -> None:
     app = FastAPI()  # no override -> dependency returns None (no app.state.ingestion)
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.post("/ingestion/revalidate")
@@ -356,6 +361,7 @@ async def test_pre_ranker_promotes_job_to_page_one_before_pagination() -> None:
     app.dependency_overrides[get_profile_service] = lambda: FakeProfileService()
     app.dependency_overrides[get_semantic_scoring] = lambda: None
     app.dependency_overrides[get_pre_ranker] = lambda: _PreRanker()
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -438,6 +444,7 @@ def _make_rescore_app(pre_ranker, quick_scoring):
     app.dependency_overrides[get_semantic_scoring] = lambda: None
     app.dependency_overrides[get_pre_ranker] = lambda: pre_ranker
     app.dependency_overrides[get_quick_scoring] = lambda: quick_scoring
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
     return app
 
@@ -565,6 +572,7 @@ async def test_cached_llm_score_ranks_globally_before_pagination() -> None:
     app.dependency_overrides[get_profile_service] = lambda: FakeProfileSummaryOnly()
     app.dependency_overrides[get_semantic_scoring] = lambda: None
     app.dependency_overrides[get_quick_scoring] = lambda: _CachedQuickScoring()
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -579,3 +587,13 @@ async def test_cached_llm_score_ranks_globally_before_pagination() -> None:
     assert body["total"] == 2
     assert body["jobs"][0]["id"] == "job-gob"  # cached LLM 0.82 outranks heuristic 0.78
     assert body["jobs"][0]["match_score"] == 0.82
+
+
+@pytest.mark.asyncio
+async def test_requires_auth_without_token() -> None:
+    """Router-level auth: requests with no bearer token are rejected."""
+    app = FastAPI()
+    app.include_router(router)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/ingestion/jobs")
+    assert resp.status_code == 401

--- a/backend/tests/unit/ingestion/test_scan_routes.py
+++ b/backend/tests/unit/ingestion/test_scan_routes.py
@@ -4,6 +4,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.ingestion.api import get_portal_scanner, get_portals_config, router
 from hiresense.ingestion.domain.models import NormalizedJob
 from hiresense.ingestion.domain.portal_config import PortalEntry, PortalsConfig
@@ -54,6 +55,7 @@ def _make_app(scanner: FakePortalScanner, config: PortalsConfig = _SAMPLE_PORTAL
     app = FastAPI()
     app.dependency_overrides[get_portal_scanner] = lambda: scanner
     app.dependency_overrides[get_portals_config] = lambda: config
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
     return app
 

--- a/backend/tests/unit/matching/test_evaluate_route.py
+++ b/backend/tests/unit/matching/test_evaluate_route.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.matching.api.dependencies import get_matching_orchestrator
 from hiresense.matching.api.routes import router
 from hiresense.matching.domain.scorers.base import DimensionResult
@@ -23,6 +24,7 @@ class FakeOrchestrator:
 
 def _make_app():
     app = FastAPI()
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
     app.dependency_overrides[get_matching_orchestrator] = lambda: FakeOrchestrator()
     return app

--- a/backend/tests/unit/matching/test_routes.py
+++ b/backend/tests/unit/matching/test_routes.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
 
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.matching.api.routes import get_matching_orchestrator, router
 from hiresense.matching.domain.models import MatchResult, ScoreBreakdown
 
@@ -32,6 +33,7 @@ async def test_analyze_endpoint() -> None:
     app = FastAPI()
     fake = FakeMatchingOrchestrator()
     app.dependency_overrides[get_matching_orchestrator] = lambda: fake
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(
@@ -54,3 +56,13 @@ async def test_analyze_endpoint() -> None:
     assert "python" in data["matched_skills"]
     assert "kubernetes" in data["missing_skills"]
     assert len(data["pros"]) > 0
+
+
+@pytest.mark.asyncio
+async def test_requires_auth_without_token() -> None:
+    """Router-level auth: requests with no bearer token are rejected."""
+    app = FastAPI()
+    app.include_router(router)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/matching/analyze")
+    assert resp.status_code == 401

--- a/backend/tests/unit/optimization/test_routes.py
+++ b/backend/tests/unit/optimization/test_routes.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
 
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.optimization.api.routes import get_cv_optimizer, router
 from hiresense.optimization.domain.models import OptimizationResult, SectionChange
 
@@ -32,6 +33,7 @@ async def test_optimize_endpoint() -> None:
     app = FastAPI()
     fake = FakeCVOptimizer()
     app.dependency_overrides[get_cv_optimizer] = lambda: fake
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(
@@ -57,3 +59,13 @@ async def test_optimize_endpoint() -> None:
     assert data["changes"][0]["section_name"] == "SUMMARY"
     assert data["improvement_summary"] == "Improved summary section"
     assert data["optimized_tex"] != data["original_tex"]
+
+
+@pytest.mark.asyncio
+async def test_requires_auth_without_token() -> None:
+    """Router-level auth: requests with no bearer token are rejected."""
+    app = FastAPI()
+    app.include_router(router)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post("/optimization/optimize")
+    assert resp.status_code == 401

--- a/backend/tests/unit/profile/test_routes.py
+++ b/backend/tests/unit/profile/test_routes.py
@@ -1,6 +1,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
+from hiresense.identity.api.dependencies import require_auth
 from hiresense.profile.api.routes import router, get_profile_service
 from hiresense.profile.domain.models import CandidateProfile, CVSection
 
@@ -36,6 +37,7 @@ async def test_upload_cv() -> None:
     app = FastAPI()
     fake = FakeProfileService()
     app.dependency_overrides[get_profile_service] = lambda: fake
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -55,6 +57,7 @@ async def test_get_profile_found() -> None:
     app = FastAPI()
     fake = FakeProfileService()
     app.dependency_overrides[get_profile_service] = lambda: fake
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
@@ -68,8 +71,19 @@ async def test_get_profile_not_found() -> None:
     app = FastAPI()
     fake = FakeProfileService()
     app.dependency_overrides[get_profile_service] = lambda: fake
+    app.dependency_overrides[require_auth] = lambda: "test-user"
     app.include_router(router)
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/profile/nonexistent")
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_requires_auth_without_token() -> None:
+    """Router-level auth: requests with no bearer token are rejected."""
+    app = FastAPI()
+    app.include_router(router)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/profile/current")
+    assert resp.status_code == 401

--- a/backend/tests/unit/profile/test_routes.py
+++ b/backend/tests/unit/profile/test_routes.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
@@ -77,6 +79,39 @@ async def test_get_profile_not_found() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         resp = await client.get("/profile/nonexistent")
     assert resp.status_code == 404
+
+
+def _upload_app() -> FastAPI:
+    app = FastAPI()
+    app.state.settings = SimpleNamespace(max_upload_bytes=10 * 1024 * 1024)
+    app.dependency_overrides[get_profile_service] = lambda: FakeProfileService()
+    app.dependency_overrides[require_auth] = lambda: "test-user"
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_upload_file_rejects_pdf_with_wrong_magic() -> None:
+    app = _upload_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/profile/upload-file",
+            files={"file": ("cv.pdf", b"not really a pdf", "application/pdf")},
+        )
+    assert resp.status_code == 400
+    assert "does not match" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_upload_file_rejects_binary_tex() -> None:
+    app = _upload_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.post(
+            "/profile/upload-file",
+            files={"file": ("cv.tex", b"\xff\xfe\x00binary", "text/x-tex")},
+        )
+    assert resp.status_code == 400
+    assert "not valid UTF-8" in resp.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -35,6 +35,29 @@ def test_settings_enabled_sources_parsed(monkeypatch: pytest.MonkeyPatch) -> Non
     assert settings.enabled_job_sources == ["remotive", "remoteok"]
 
 
+@pytest.mark.parametrize(
+    ("env_var", "placeholder"),
+    [
+        ("AUTH_PASSWORD", "changeme"),
+        ("JWT_SECRET_KEY", "change-this-to-a-random-secret"),
+    ],
+)
+def test_settings_rejects_placeholder_secrets(
+    monkeypatch: pytest.MonkeyPatch, env_var: str, placeholder: str
+) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+    monkeypatch.setenv("AUTH_USERNAME", "admin")
+    monkeypatch.setenv("AUTH_PASSWORD", "pass")
+    monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+    monkeypatch.setenv("LLM_API_KEY", "sk-test")
+    monkeypatch.setenv(env_var, placeholder)
+
+    from hiresense.config import Settings
+
+    with pytest.raises(ValueError, match="placeholder"):
+        Settings()
+
+
 def test_embedding_device_configurable(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
     monkeypatch.setenv("AUTH_USERNAME", "admin")

--- a/backend/tests/unit/test_event_bus.py
+++ b/backend/tests/unit/test_event_bus.py
@@ -58,6 +58,63 @@ async def test_failing_handler_is_isolated_and_logged(caplog) -> None:
 
 
 @pytest.mark.asyncio
+async def test_publish_holds_strong_task_references() -> None:
+    """In-flight handler tasks are referenced by the bus (GC safety) and
+    discarded once done."""
+    bus = InMemoryEventBus()
+    release = asyncio.Event()
+
+    async def slow_handler(event: DomainEvent) -> None:
+        await release.wait()
+
+    bus.subscribe("slow.event", slow_handler)
+    await bus.publish(DomainEvent(event_type="slow.event"))
+    assert len(bus._tasks) == 1
+    release.set()
+    await asyncio.sleep(0.05)
+    assert len(bus._tasks) == 0
+
+
+@pytest.mark.asyncio
+async def test_aclose_waits_for_in_flight_handlers() -> None:
+    bus = InMemoryEventBus()
+    finished: list[str] = []
+
+    async def handler(event: DomainEvent) -> None:
+        await asyncio.sleep(0.05)
+        finished.append("done")
+
+    bus.subscribe("drain.event", handler)
+    await bus.publish(DomainEvent(event_type="drain.event"))
+    await bus.aclose(timeout=2.0)
+    assert finished == ["done"]
+
+
+@pytest.mark.asyncio
+async def test_aclose_cancels_stragglers_after_timeout() -> None:
+    bus = InMemoryEventBus()
+    cancelled: list[str] = []
+
+    async def hung_handler(event: DomainEvent) -> None:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.append("cancelled")
+            raise
+
+    bus.subscribe("hung.event", hung_handler)
+    await bus.publish(DomainEvent(event_type="hung.event"))
+    await bus.aclose(timeout=0.05)
+    assert cancelled == ["cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_aclose_noop_when_idle() -> None:
+    bus = InMemoryEventBus()
+    await bus.aclose(timeout=0.01)
+
+
+@pytest.mark.asyncio
 async def test_multiple_subscribers() -> None:
     bus = InMemoryEventBus()
     calls: list[str] = []

--- a/backend/tests/unit/test_lru_cache.py
+++ b/backend/tests/unit/test_lru_cache.py
@@ -1,0 +1,38 @@
+import pytest
+
+from hiresense.kernel import LRUCache
+
+
+def test_get_and_set() -> None:
+    cache: LRUCache[str, int] = LRUCache(2)
+    cache["a"] = 1
+    assert cache.get("a") == 1
+    assert cache.get("missing") is None
+    assert cache.get("missing", 0) == 0
+
+
+def test_evicts_least_recently_used() -> None:
+    cache: LRUCache[str, int] = LRUCache(2)
+    cache["a"] = 1
+    cache["b"] = 2
+    cache.get("a")  # refresh "a" — "b" is now LRU
+    cache["c"] = 3
+    assert "a" in cache
+    assert "b" not in cache
+    assert "c" in cache
+    assert len(cache) == 2
+
+
+def test_overwrite_refreshes_recency() -> None:
+    cache: LRUCache[str, int] = LRUCache(2)
+    cache["a"] = 1
+    cache["b"] = 2
+    cache["a"] = 10
+    cache["c"] = 3
+    assert cache.get("a") == 10
+    assert "b" not in cache
+
+
+def test_rejects_non_positive_size() -> None:
+    with pytest.raises(ValueError, match="max_size"):
+        LRUCache(0)

--- a/backend/tests/unit/test_rate_limit.py
+++ b/backend/tests/unit/test_rate_limit.py
@@ -1,0 +1,60 @@
+import pytest
+from fastapi import Depends, FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from hiresense.identity.api.dependencies import enforce_expensive_rate_limit
+from hiresense.kernel import SlidingWindowRateLimiter
+
+
+def test_allows_up_to_max_requests() -> None:
+    limiter = SlidingWindowRateLimiter(max_requests=3, window_seconds=60.0)
+    assert all(limiter.allow("client") for _ in range(3))
+    assert limiter.allow("client") is False
+
+
+def test_keys_are_independent() -> None:
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
+    assert limiter.allow("a") is True
+    assert limiter.allow("a") is False
+    assert limiter.allow("b") is True
+
+
+def test_window_expiry_frees_slots(monkeypatch: pytest.MonkeyPatch) -> None:
+    clock = {"now": 1000.0}
+    monkeypatch.setattr("hiresense.kernel.rate_limit.time.monotonic", lambda: clock["now"])
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=10.0)
+    assert limiter.allow("client") is True
+    assert limiter.allow("client") is False
+    clock["now"] += 11.0
+    assert limiter.allow("client") is True
+
+
+def _app_with_limiter(limiter: SlidingWindowRateLimiter | None) -> FastAPI:
+    app = FastAPI()
+    app.state.rate_limiter = limiter
+
+    @app.get("/expensive", dependencies=[Depends(enforce_expensive_rate_limit)])
+    async def expensive() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+@pytest.mark.asyncio
+async def test_dependency_returns_429_when_exhausted() -> None:
+    app = _app_with_limiter(SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        first = await client.get("/expensive")
+        second = await client.get("/expensive")
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert second.headers["Retry-After"] == "60"
+
+
+@pytest.mark.asyncio
+async def test_dependency_noops_without_limiter() -> None:
+    app = _app_with_limiter(None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        for _ in range(5):
+            resp = await client.get("/expensive")
+            assert resp.status_code == 200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
       interval: 5s
       timeout: 3s
       retries: 5
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 1G
 
   otel-lgtm:
     image: grafana/otel-lgtm
@@ -26,6 +31,11 @@ services:
       # HireSense Grafana dashboards (provisioned, read-only mounts).
       - ./observability/grafana/provisioning/dashboards/hiresense.yaml:/otel-lgtm/grafana/conf/provisioning/dashboards/hiresense.yaml:ro
       - ./observability/grafana/dashboards:/var/lib/grafana/dashboards/hiresense:ro
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
 
   app:
     build: ./backend
@@ -45,6 +55,11 @@ services:
         condition: service_started
     volumes:
       - ./cvs:/app/cvs
+    deploy:
+      resources:
+        limits:
+          cpus: "2.0"
+          memory: 2G
 
   frontend:
     build: ./frontend
@@ -52,6 +67,11 @@ services:
       - "${FRONTEND_PORT:-4200}:80"
     depends_on:
       - app
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 256M
 
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary

Full-project audit (security / stability / performance / scalability) and remediation, in 12 commits across three phases. Findings were verified individually before fixing.

### Security
- **Router auth (high):** all of `/ingestion/*`, `/profile/*`, `/matching/evaluate|analyze`, and `/optimization/optimize` were unauthenticated while the rest of the API required a JWT. Router-level `require_auth` now covers them; each router has a 401 regression test. Frontend unchanged (global auth interceptor).
- **Secrets:** startup now rejects the `.env.example` placeholder secrets; local `.env` regenerated with strong values; CI password moved off the rejected placeholder.
- **CORS:** explicit config-driven method/header allow-lists instead of `*` with credentials.
- **Input hardening:** `page`/`page_size` validated + clamped (`INGESTION_MAX_PAGE_SIZE`); profile uploads content-sniffed (PDF magic, UTF-8 for `.tex`); CSV imports confined to `CSV_IMPORT_DIR` (path-traversal guard).
- **Rate limiting:** in-process sliding-window limiter (no new dependency) on LLM/network-heavy endpoints, keyed by client IP, config-driven, no-op when disabled.

### Stability
- **Event bus:** `publish()` held no strong task references (GC could drop handlers mid-run) and shutdown orphaned in-flight handlers — now tracked and drained in the lifespan.
- **DB pool:** explicit `pool_size`/`max_overflow`/`pre_ping`/`recycle` on the sync engine; deleted the dead async engine factories.
- **Memory:** the three unbounded embedding caches now use a bounded `LRUCache`.

### Performance
- **Bulk upsert:** ingestion/portal-scan went from 2 queries per job to one bulk identity SELECT + one commit per source, preserving exact upsert semantics (shared `_apply_to_row`); closure detection untouched.
- **DB-side filtering:** `JobListCriteria` pushes status/quality/source/company/date predicates into SQL so `/ingestion/jobs` no longer loads the whole table when filters apply; `filter_and_paginate` re-applies them idempotently.
- **Event-loop offload:** coarse-grained sync repository calls now run via `asyncio.to_thread`; two integration fixtures moved to `StaticPool` sqlite for thread safety.
- **pgvector:** migration 025 adds an expression index on `metadata->>'bucket'` for the filtered ANN search.

## Test plan
- [x] `uv run python -m pytest` — 890 passed, 6 skipped (baseline was 861)
- [x] `uv run ruff check .` clean
- [x] `uv run python -m alembic upgrade head` against the compose DB (024 → 025)
- [x] `uv run python -m pytest -m pgvector` against live pgvector — 6 passed
- [x] Smoke test on :8001 — `/health` 200, unauthenticated `/ingestion/jobs` + `/profile/current` → 401, login with new credentials → 200, burst → 429 with `Retry-After`

🤖 Generated with [Claude Code](https://claude.com/claude-code)