### PR TITLE
feat(portfolio): cite relevant projects in artifacts (Phase 3)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -263,6 +263,12 @@ PORTFOLIO_GITHUB_API_URL=https://api.github.com
 PORTFOLIO_GITHUB_MAX_REPOS=30
 # Char cap for the profile-enrichment text block.
 PORTFOLIO_PROFILE_CHAR_CAP=1200
+# Public portfolio site linked from generated artifacts (empty disables the link).
+PORTFOLIO_PUBLIC_URL=
+# Tracked-link slug prefix: ?ref=<prefix>-<application_id>
+PORTFOLIO_REF_PREFIX=hiresense
+# Relevant projects cited per generated artifact.
+PORTFOLIO_RELEVANT_PROJECTS_TOP_N=2
 
 # --- Observability (OpenTelemetry) ---
 # Master switch for the telemetry stack.

--- a/backend/src/hiresense/applications/domain/apply_service.py
+++ b/backend/src/hiresense/applications/domain/apply_service.py
@@ -26,12 +26,15 @@ class ApplyService:
         latex_compiler: LatexCompilerPort,
         profile_service: Any,
         tracking_service: Any,
+        *,
+        portfolio_citation: Any = None,
     ) -> None:
         self._repo = repository
         self._generator = cover_letter_generator
         self._latex = latex_compiler
         self._profiles = profile_service
         self._tracking = tracking_service
+        self._portfolio_citation = portfolio_citation
 
     async def generate_cover_letter(
         self,
@@ -52,6 +55,15 @@ class ApplyService:
         missing = list(latest_match.missing_skills) if latest_match else []
         match_id = latest_match.id if latest_match else None
 
+        portfolio_section = None
+        if self._portfolio_citation is not None:
+            portfolio_section = await self._portfolio_citation.citation_for(
+                job_skills=list(snapshot.required_skills or []),
+                job_text=snapshot.description or "",
+                application_id=str(application_id),
+                language=cv_language,
+            )
+
         body = await self._generator.generate(
             title=tracked.title,
             company=tracked.company,
@@ -62,6 +74,7 @@ class ApplyService:
             pros=pros,
             missing_skills=missing,
             tone=tone,
+            portfolio_section=portfolio_section,
         )
 
         row = ApplicationCoverLetter(

--- a/backend/src/hiresense/applications/domain/cover_letter_generator.py
+++ b/backend/src/hiresense/applications/domain/cover_letter_generator.py
@@ -73,12 +73,19 @@ class CoverLetterGenerator:
         if portfolio_section:
             # Insert the portfolio block + weave instruction immediately before
             # the "Constraints:" section so the LLM sees them as context before
-            # the structural instructions.
+            # the structural instructions. Anchor on the LAST occurrence: the
+            # formatted {description} is external job-board data and may itself
+            # contain "Constraints:\n", which must not hijack the splice point.
             portfolio_block = (
                 f"{portfolio_section}\n"
                 f"{_PORTFOLIO_WEAVE_INSTRUCTION}\n\n"
             )
-            prompt = prompt.replace("Constraints:\n", f"{portfolio_block}Constraints:\n", 1)
+            marker = "Constraints:\n"
+            idx = prompt.rfind(marker)
+            if idx != -1:
+                prompt = prompt[:idx] + portfolio_block + prompt[idx:]
+            else:
+                prompt += "\n" + portfolio_block
 
         try:
             response = await self._llm.complete(prompt, system=SYSTEM_PROMPT)

--- a/backend/src/hiresense/applications/domain/cover_letter_generator.py
+++ b/backend/src/hiresense/applications/domain/cover_letter_generator.py
@@ -30,6 +30,12 @@ USER_PROMPT_TEMPLATE = (
     "Return only the cover letter body."
 )
 
+_PORTFOLIO_WEAVE_INSTRUCTION = (
+    "Weave at most two of these projects into the middle paragraphs only where they "
+    "genuinely match the job's needs; if a portfolio link is given above, include it "
+    "verbatim exactly once."
+)
+
 
 class CoverLetterGenerator:
     def __init__(self, llm: Any | None) -> None:
@@ -47,6 +53,7 @@ class CoverLetterGenerator:
         pros: list[str],
         missing_skills: list[str],
         tone: str = "professional",
+        portfolio_section: str | None = None,
     ) -> str:
         if self._llm is None:
             raise RuntimeError("LLM not configured — cover letter generation unavailable")
@@ -62,6 +69,17 @@ class CoverLetterGenerator:
             missing_skills=", ".join(missing_skills) or "(none)",
             tone=tone,
         )
+
+        if portfolio_section:
+            # Insert the portfolio block + weave instruction immediately before
+            # the "Constraints:" section so the LLM sees them as context before
+            # the structural instructions.
+            portfolio_block = (
+                f"{portfolio_section}\n"
+                f"{_PORTFOLIO_WEAVE_INSTRUCTION}\n\n"
+            )
+            prompt = prompt.replace("Constraints:\n", f"{portfolio_block}Constraints:\n", 1)
+
         try:
             response = await self._llm.complete(prompt, system=SYSTEM_PROMPT)
         except Exception:

--- a/backend/src/hiresense/bootstrap/applications.py
+++ b/backend/src/hiresense/bootstrap/applications.py
@@ -23,6 +23,7 @@ def build_applications(
     cv_optimizer: Any,
     interview_prep_service: Any,
     profile_service: Any,
+    portfolio_citation: Any = None,
 ) -> ApplicationsProvider:
     s = infra.settings
     application_repo = ApplicationRepository(session_factory=infra.sync_session_factory)
@@ -54,6 +55,7 @@ def build_applications(
         latex_compiler=latex_compiler,
         profile_service=profile_service,
         tracking_service=tracking_service,
+        portfolio_citation=portfolio_citation,
     )
     return ApplicationsProvider(
         application_service=application_service,

--- a/backend/src/hiresense/bootstrap/outreach.py
+++ b/backend/src/hiresense/bootstrap/outreach.py
@@ -21,6 +21,8 @@ def build_outreach(
     tracking_service: Any,
     profile_service: Any,
     research_service: Any,
+    *,
+    portfolio_citation: Any = None,
 ) -> OutreachBuild:
     s = infra.settings
     service = OutreachService(
@@ -33,5 +35,6 @@ def build_outreach(
         followup_cadence_days=s.outreach_followup_cadence_days,
         max_chars=s.outreach_max_chars,
         language=s.default_language,
+        portfolio_citation=portfolio_citation,
     )
     return OutreachBuild(provider=OutreachProvider(outreach_service=service), service=service)

--- a/backend/src/hiresense/bootstrap/portfolio.py
+++ b/backend/src/hiresense/bootstrap/portfolio.py
@@ -5,7 +5,12 @@ from dataclasses import dataclass
 from hiresense.bootstrap.shared_infra import SharedInfra
 from hiresense.portfolio.adapters import GitHubPortfolioAdapter, SupabasePortfolioAdapter
 from hiresense.portfolio.api.provider import PortfolioProvider
-from hiresense.portfolio.domain import PortfolioEnrichmentService, PortfolioSyncService
+from hiresense.portfolio.domain import (
+    PortfolioCitationService,
+    PortfolioEnrichmentService,
+    PortfolioSyncService,
+    RelevantProjectSelector,
+)
 from hiresense.portfolio.infrastructure import PortfolioProjectsRepository
 
 
@@ -61,6 +66,14 @@ def build_portfolio(infra: SharedInfra) -> PortfolioBuild | None:
             repository=repository,
             language=s.default_language,
             char_cap=s.portfolio_profile_char_cap,
+        ),
+        citation_service=PortfolioCitationService(
+            repository=repository,
+            selector=RelevantProjectSelector(),
+            language=s.default_language,
+            top_n=s.portfolio_relevant_projects_top_n,
+            public_url=s.portfolio_public_url,
+            ref_prefix=s.portfolio_ref_prefix,
         ),
     )
     return PortfolioBuild(provider=provider)

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -431,6 +431,13 @@ class Settings(BaseSettings):
     # Char cap for the "Portfolio projects" block appended to the matching
     # profile summary.
     portfolio_profile_char_cap: int = 1200
+    # Public portfolio site linked from generated artifacts. Empty disables
+    # the tracked link (project citations still work).
+    portfolio_public_url: str = ""
+    # Slug prefix for per-application tracked links: ?ref=<prefix>-<application_id>.
+    portfolio_ref_prefix: str = "hiresense"
+    # How many relevant projects get cited per generated artifact.
+    portfolio_relevant_projects_top_n: int = 2
 
     @classmethod
     def settings_customise_sources(

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -194,6 +194,7 @@ def create_app() -> FastAPI:
         cv_optimizer=optimization.cv_optimizer,
         interview_prep_service=interview.prep_service,
         profile_service=profile.service,
+        portfolio_citation=portfolio.provider.get_citation_service() if portfolio is not None else None,
     )
     app.include_router(applications_router)
 

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -209,7 +209,12 @@ def create_app() -> FastAPI:
 
     # --- Outreach (generation + outreach-event tracking + follow-up nudges) ---
     outreach = build_outreach(
-        infra, tracked, tracking.service, profile.service, research.get_research_service()
+        infra,
+        tracked,
+        tracking.service,
+        profile.service,
+        research.get_research_service(),
+        portfolio_citation=portfolio.provider.get_citation_service() if portfolio is not None else None,
     )
     app.state.outreach = outreach.provider
     app.include_router(outreach_router)

--- a/backend/src/hiresense/outreach/domain/message_generator.py
+++ b/backend/src/hiresense/outreach/domain/message_generator.py
@@ -37,6 +37,7 @@ class OutreachMessageGenerator:
         style_guide: str,
         channel: str | None,
         max_chars: int,
+        portfolio_section: str | None = None,
     ) -> str:
         if self._llm is None:
             raise OutreachUnavailableError("no LLM configured")
@@ -56,6 +57,12 @@ class OutreachMessageGenerator:
             parts.append(f"Address it to: {contact_name}")
         if channel:
             parts.append(f"Channel: {channel}")
+        if portfolio_section:
+            parts.append(portfolio_section)
+            parts.append(
+                "Mention at most ONE of these projects, only if it strengthens the hook; "
+                "if a portfolio link is given above, include it verbatim."
+            )
         parts.append(
             f"Keep it under ~{max_chars} characters. Greet (use the contact name "
             "if given), state the role and one specific genuine hook tying the "

--- a/backend/src/hiresense/outreach/domain/outreach_service.py
+++ b/backend/src/hiresense/outreach/domain/outreach_service.py
@@ -25,6 +25,7 @@ class OutreachService:
         followup_cadence_days: int,
         max_chars: int,
         language: str,
+        portfolio_citation: Any = None,
     ) -> None:
         self._tracking = tracking_service
         self._profile = profile_service
@@ -35,6 +36,7 @@ class OutreachService:
         self._cadence = followup_cadence_days
         self._max_chars = max_chars
         self._language = language
+        self._portfolio_citation = portfolio_citation
 
     async def generate(
         self, application_id: uuid.UUID, *, contact_name: str | None = None, channel: str | None = None
@@ -43,10 +45,19 @@ class OutreachService:
         profile = await self._profile.get_current_profile(self._language)
         view = self._profile.get_for_language(self._language)
         research = self._research.get(app.company)
+        job_description = getattr(app, "notes", "") or ""
+        portfolio_section = None
+        if self._portfolio_citation is not None:
+            portfolio_section = await self._portfolio_citation.citation_for(
+                job_skills=[],
+                job_text=job_description,
+                application_id=str(application_id),
+                language=self._language,
+            )
         return await self._generator.generate(
             company=app.company,
             title=getattr(app, "title", ""),
-            job_description=getattr(app, "notes", "") or "",
+            job_description=job_description,
             candidate_name=(profile.name if profile is not None else ""),
             candidate_summary=(view.summary if view is not None else ""),
             candidate_skills=(list(view.skills) if view is not None else []),
@@ -55,6 +66,7 @@ class OutreachService:
             style_guide=load_style_guide(self._style_guide_path),
             channel=channel,
             max_chars=self._max_chars,
+            portfolio_section=portfolio_section,
         )
 
     def record(

--- a/backend/src/hiresense/portfolio/api/provider.py
+++ b/backend/src/hiresense/portfolio/api/provider.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
-from hiresense.portfolio.domain import PortfolioEnrichmentService, PortfolioSyncService
+from hiresense.portfolio.domain import (
+    PortfolioCitationService,
+    PortfolioEnrichmentService,
+    PortfolioSyncService,
+)
 from hiresense.portfolio.ports import PortfolioProjectsRepositoryPort
 
 
@@ -10,10 +14,12 @@ class PortfolioProvider:
         sync_service: PortfolioSyncService,
         repository: PortfolioProjectsRepositoryPort,
         enrichment_service: PortfolioEnrichmentService,
+        citation_service: PortfolioCitationService,
     ) -> None:
         self._sync_service = sync_service
         self._repository = repository
         self._enrichment_service = enrichment_service
+        self._citation_service = citation_service
 
     def get_sync_service(self) -> PortfolioSyncService:
         return self._sync_service
@@ -23,3 +29,6 @@ class PortfolioProvider:
 
     def get_enrichment_service(self) -> PortfolioEnrichmentService:
         return self._enrichment_service
+
+    def get_citation_service(self) -> PortfolioCitationService:
+        return self._citation_service

--- a/backend/src/hiresense/portfolio/domain/__init__.py
+++ b/backend/src/hiresense/portfolio/domain/__init__.py
@@ -2,6 +2,7 @@ from hiresense.portfolio.domain.enrichment_service import PortfolioEnrichmentSer
 from hiresense.portfolio.domain.portfolio_project import PortfolioProject
 from hiresense.portfolio.domain.profile_text import portfolio_profile_text
 from hiresense.portfolio.domain.project_text import ProjectText
+from hiresense.portfolio.domain.relevant_project_selector import RelevantProjectSelector
 from hiresense.portfolio.domain.sync_result import SyncResult
 from hiresense.portfolio.domain.sync_service import PortfolioSyncService
 
@@ -10,6 +11,7 @@ __all__ = [
     "PortfolioProject",
     "PortfolioSyncService",
     "ProjectText",
+    "RelevantProjectSelector",
     "SyncResult",
     "portfolio_profile_text",
 ]

--- a/backend/src/hiresense/portfolio/domain/__init__.py
+++ b/backend/src/hiresense/portfolio/domain/__init__.py
@@ -1,3 +1,4 @@
+from hiresense.portfolio.domain.citation_service import PortfolioCitationService
 from hiresense.portfolio.domain.enrichment_service import PortfolioEnrichmentService
 from hiresense.portfolio.domain.portfolio_project import PortfolioProject
 from hiresense.portfolio.domain.profile_text import portfolio_profile_text
@@ -7,6 +8,7 @@ from hiresense.portfolio.domain.sync_result import SyncResult
 from hiresense.portfolio.domain.sync_service import PortfolioSyncService
 
 __all__ = [
+    "PortfolioCitationService",
     "PortfolioEnrichmentService",
     "PortfolioProject",
     "PortfolioSyncService",

--- a/backend/src/hiresense/portfolio/domain/citation_service.py
+++ b/backend/src/hiresense/portfolio/domain/citation_service.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from hiresense.portfolio.domain.relevant_project_selector import RelevantProjectSelector
+
+if TYPE_CHECKING:
+    from hiresense.portfolio.ports import PortfolioProjectsRepositoryPort
+
+
+class PortfolioCitationService:
+    """Builds the optional 'relevant portfolio projects' prompt block for
+    generated artifacts (cover letters, outreach), including the
+    per-application tracked link. Returns None when there is nothing
+    relevant to cite — consumers then behave exactly as before."""
+
+    def __init__(
+        self,
+        repository: PortfolioProjectsRepositoryPort,
+        selector: RelevantProjectSelector,
+        *,
+        language: str,
+        top_n: int,
+        public_url: str,
+        ref_prefix: str,
+    ) -> None:
+        self._repository = repository
+        self._selector = selector
+        self._language = language
+        self._top_n = top_n
+        self._public_url = public_url.rstrip("/")
+        self._ref_prefix = ref_prefix
+
+    async def citation_for(
+        self,
+        *,
+        job_skills: list[str],
+        job_text: str,
+        application_id: str,
+        language: str | None = None,
+    ) -> str | None:
+        projects = await asyncio.to_thread(self._repository.list_all)
+        if not projects:
+            return None
+        picked = self._selector.select(
+            job_skills=job_skills, job_text=job_text, projects=projects, top_n=self._top_n
+        )
+        if not picked:
+            return None
+        lang = language or self._language
+        lines = [
+            "Relevant portfolio projects (mention 1-2 naturally where they strengthen the case):"
+        ]
+        for project in picked:
+            text = project.text_for(lang)
+            if text is None:
+                continue
+            line = f"- {text.title}"
+            if project.tech:
+                line += f" [{', '.join(project.tech)}]"
+            first_desc = (text.description or "").strip().splitlines()
+            if first_desc and first_desc[0]:
+                line += f": {first_desc[0]}"
+            links = [link for link in (project.url, project.demo_url) if link]
+            if links:
+                line += f" ({' | '.join(links)})"
+            lines.append(line)
+        if len(lines) == 1:
+            return None
+        if self._public_url:
+            lines.append(
+                "Include this exact portfolio link once, near the close: "
+                f"{self._public_url}/?ref={self._ref_prefix}-{application_id}"
+            )
+        return "\n".join(lines)

--- a/backend/src/hiresense/portfolio/domain/relevant_project_selector.py
+++ b/backend/src/hiresense/portfolio/domain/relevant_project_selector.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import re
+
+from hiresense.portfolio.domain.portfolio_project import PortfolioProject
+
+_TOKEN_RE = re.compile(r"[a-z0-9_+#.]+")
+_UNPOSITIONED = 1_000_000
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+class RelevantProjectSelector:
+    """Ranks portfolio projects against a job, deterministically (no LLM).
+
+    Score = overlap between the job's terms (skills + description tokens) and
+    the project's terms (tech + title tokens). Zero-score projects are never
+    cited; ties break pinned-first, then by position.
+    """
+
+    def select(
+        self,
+        *,
+        job_skills: list[str],
+        job_text: str,
+        projects: list[PortfolioProject],
+        top_n: int,
+    ) -> list[PortfolioProject]:
+        job_terms = {skill.lower() for skill in job_skills} | _tokens(job_text)
+        scored: list[tuple[int, PortfolioProject]] = []
+        for project in projects:
+            title = project.text_for("en")
+            project_terms = {tech.lower() for tech in project.tech}
+            if title is not None:
+                project_terms |= _tokens(title.title)
+            score = len(project_terms & job_terms)
+            if score > 0:
+                scored.append((score, project))
+        scored.sort(
+            key=lambda pair: (
+                -pair[0],
+                not pair[1].pinned,
+                pair[1].position if pair[1].position is not None else _UNPOSITIONED,
+            )
+        )
+        return [project for _, project in scored[:top_n]]

--- a/backend/tests/unit/applications/test_cover_letter_citation.py
+++ b/backend/tests/unit/applications/test_cover_letter_citation.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from hiresense.applications.domain.cover_letter_generator import (
+    USER_PROMPT_TEMPLATE,
+    CoverLetterGenerator,
+)
+from hiresense.applications.domain.apply_service import ApplyService
+from hiresense.applications.domain.models import (
+    ApplicationCoverLetter,
+    ApplicationJobSnapshot,
+    JobSnapshotSource,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes (adapted from existing test files in this package)
+# ---------------------------------------------------------------------------
+
+class FakeLLM:
+    """Captures the prompt sent and returns a canned response."""
+
+    def __init__(self, response: str = "COVER_LETTER") -> None:
+        self.response = response
+        self.last_prompt: str | None = None
+
+    async def complete(self, prompt: str, *, system: str = "") -> str:
+        self.last_prompt = prompt
+        return self.response
+
+
+class FakeCitationService:
+    """Simulates PortfolioCitationService; records call kwargs and returns text."""
+
+    def __init__(self, text: str | None = "Portfolio: https://example.com/portfolio") -> None:
+        self.text = text
+        self.last_kwargs: dict | None = None
+
+    async def citation_for(self, *, job_skills, job_text, application_id, language=None) -> str | None:
+        self.last_kwargs = {
+            "job_skills": job_skills,
+            "job_text": job_text,
+            "application_id": application_id,
+            "language": language,
+        }
+        return self.text
+
+
+class FakeRepo:
+    def __init__(self, snapshot: ApplicationJobSnapshot | None = None) -> None:
+        self._snapshot = snapshot
+        self._covers: list[ApplicationCoverLetter] = []
+
+    def get_snapshot(self, application_id):
+        return self._snapshot
+
+    def get_latest_match(self, application_id):
+        return None
+
+    def create_cover_letter(self, row: ApplicationCoverLetter) -> ApplicationCoverLetter:
+        row.id = row.id or uuid.uuid4()
+        self._covers.append(row)
+        return row
+
+
+class FakeTracked:
+    title = "Software Engineer"
+    company = "Fieldguide"
+
+
+class FakeTrackingService:
+    def get(self, _):
+        return FakeTracked()
+
+
+class FakeProfile:
+    language = "en"
+    summary = "Experienced engineer."
+    skills = ["python", "fastapi"]
+    raw_tex = ""
+
+
+class FakeProfileService:
+    def get_for_language(self, language: str) -> FakeProfile:
+        return FakeProfile()
+
+
+# ---------------------------------------------------------------------------
+# Generator tests
+# ---------------------------------------------------------------------------
+
+_COMMON_KWARGS = dict(
+    title="Software Engineer",
+    company="Acme",
+    description="Build microservices.",
+    candidate_summary="5 years Python.",
+    candidate_skills=["python"],
+    required_skills=["python", "docker"],
+    pros=["strong python"],
+    missing_skills=["k8s"],
+    tone="professional",
+)
+
+
+@pytest.mark.asyncio
+async def test_generator_appends_portfolio_section_and_weave_instruction() -> None:
+    """When portfolio_section is provided, it appears in the prompt followed by the weave instruction."""
+    llm = FakeLLM()
+    gen = CoverLetterGenerator(llm=llm)
+    portfolio_text = "Portfolio: https://example.com/projects"
+
+    await gen.generate(**_COMMON_KWARGS, portfolio_section=portfolio_text)
+
+    assert llm.last_prompt is not None
+    assert portfolio_text in llm.last_prompt
+    assert "Weave at most two of these projects" in llm.last_prompt
+    assert "include it verbatim exactly once" in llm.last_prompt
+
+
+@pytest.mark.asyncio
+async def test_generator_portfolio_section_inserted_before_constraints() -> None:
+    """Portfolio block must appear BEFORE the Constraints: section in the prompt."""
+    llm = FakeLLM()
+    gen = CoverLetterGenerator(llm=llm)
+    portfolio_text = "Portfolio: https://example.com/projects"
+
+    await gen.generate(**_COMMON_KWARGS, portfolio_section=portfolio_text)
+
+    prompt = llm.last_prompt
+    assert prompt is not None
+    portfolio_pos = prompt.index(portfolio_text)
+    constraints_pos = prompt.index("Constraints:")
+    assert portfolio_pos < constraints_pos, (
+        "Portfolio section should appear before Constraints: block"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generator_prompt_byte_identical_when_no_portfolio() -> None:
+    """When portfolio_section is omitted (None), the prompt must equal USER_PROMPT_TEMPLATE.format(...)."""
+    llm = FakeLLM()
+    gen = CoverLetterGenerator(llm=llm)
+
+    await gen.generate(**_COMMON_KWARGS)  # no portfolio_section
+
+    expected = USER_PROMPT_TEMPLATE.format(
+        title=_COMMON_KWARGS["title"],
+        company=_COMMON_KWARGS["company"],
+        description=_COMMON_KWARGS["description"],
+        candidate_summary=_COMMON_KWARGS["candidate_summary"],
+        candidate_skills=", ".join(_COMMON_KWARGS["candidate_skills"]),
+        required_skills=", ".join(_COMMON_KWARGS["required_skills"]),
+        pros=", ".join(_COMMON_KWARGS["pros"]),
+        missing_skills=", ".join(_COMMON_KWARGS["missing_skills"]),
+        tone=_COMMON_KWARGS["tone"],
+    )
+    assert llm.last_prompt == expected, (
+        "Prompt must be byte-identical to USER_PROMPT_TEMPLATE.format(...) when no portfolio_section"
+    )
+
+
+@pytest.mark.asyncio
+async def test_generator_no_portfolio_mention_when_omitted() -> None:
+    """No 'portfolio' word (case-insensitive) should appear when portfolio_section is None."""
+    llm = FakeLLM()
+    gen = CoverLetterGenerator(llm=llm)
+
+    await gen.generate(**_COMMON_KWARGS)
+
+    assert "portfolio" not in (llm.last_prompt or "").lower()
+
+
+# ---------------------------------------------------------------------------
+# ApplyService tests
+# ---------------------------------------------------------------------------
+
+def _make_apply_service(
+    snapshot: ApplicationJobSnapshot,
+    *,
+    citation_service=None,
+    llm_response: str = "Generated cover letter body.",
+) -> tuple[ApplyService, FakeLLM]:
+    llm = FakeLLM(response=llm_response)
+    generator = CoverLetterGenerator(llm=llm)
+    service = ApplyService(
+        repository=FakeRepo(snapshot=snapshot),
+        cover_letter_generator=generator,
+        latex_compiler=None,  # type: ignore[arg-type]
+        profile_service=FakeProfileService(),
+        tracking_service=FakeTrackingService(),
+        portfolio_citation=citation_service,
+    )
+    return service, llm
+
+
+@pytest.mark.asyncio
+async def test_apply_service_passes_snapshot_fields_to_citation_service() -> None:
+    """ApplyService forwards snapshot.required_skills, .description, application_id, cv_language."""
+    app_id = uuid.uuid4()
+    snap = ApplicationJobSnapshot(
+        application_id=app_id,
+        description="We need Python and FastAPI expertise.",
+        required_skills=["python", "fastapi"],
+        source=JobSnapshotSource.MANUAL.value,
+    )
+    citation = FakeCitationService(text="Portfolio: https://example.com")
+    service, _ = _make_apply_service(snap, citation_service=citation)
+
+    await service.generate_cover_letter(app_id, cv_language="en", tone="professional")
+
+    assert citation.last_kwargs is not None
+    assert citation.last_kwargs["job_skills"] == ["python", "fastapi"]
+    assert citation.last_kwargs["job_text"] == "We need Python and FastAPI expertise."
+    assert citation.last_kwargs["application_id"] == str(app_id)
+    assert citation.last_kwargs["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_apply_service_forwards_citation_text_to_generator() -> None:
+    """The text returned by citation_for ends up in the LLM prompt."""
+    app_id = uuid.uuid4()
+    snap = ApplicationJobSnapshot(
+        application_id=app_id,
+        description="Build distributed systems.",
+        required_skills=["go", "kafka"],
+        source=JobSnapshotSource.MANUAL.value,
+    )
+    portfolio_text = "Portfolio: https://example.com/work"
+    citation = FakeCitationService(text=portfolio_text)
+    service, llm = _make_apply_service(snap, citation_service=citation)
+
+    await service.generate_cover_letter(app_id, cv_language="en")
+
+    assert llm.last_prompt is not None
+    assert portfolio_text in llm.last_prompt
+    assert "Weave at most two of these projects" in llm.last_prompt
+
+
+@pytest.mark.asyncio
+async def test_apply_service_none_citation_result_no_portfolio_in_prompt() -> None:
+    """When citation_for returns None, the prompt contains no portfolio mention."""
+    app_id = uuid.uuid4()
+    snap = ApplicationJobSnapshot(
+        application_id=app_id,
+        description="Frontend work.",
+        required_skills=["react"],
+        source=JobSnapshotSource.MANUAL.value,
+    )
+    citation = FakeCitationService(text=None)  # returns None
+    service, llm = _make_apply_service(snap, citation_service=citation)
+
+    await service.generate_cover_letter(app_id, cv_language="fr")
+
+    assert "portfolio" not in (llm.last_prompt or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_apply_service_no_portfolio_citation_behaves_as_before() -> None:
+    """With portfolio_citation=None (default), the prompt is byte-identical to no-portfolio path."""
+    app_id = uuid.uuid4()
+    snap = ApplicationJobSnapshot(
+        application_id=app_id,
+        description="Backend work.",
+        required_skills=["python"],
+        source=JobSnapshotSource.MANUAL.value,
+    )
+    service, llm = _make_apply_service(snap, citation_service=None)
+
+    await service.generate_cover_letter(app_id, cv_language="en")
+
+    assert "portfolio" not in (llm.last_prompt or "").lower()
+    assert "Weave at most two" not in (llm.last_prompt or "")

--- a/backend/tests/unit/applications/test_cover_letter_citation.py
+++ b/backend/tests/unit/applications/test_cover_letter_citation.py
@@ -139,6 +139,36 @@ async def test_generator_portfolio_section_inserted_before_constraints() -> None
 
 
 @pytest.mark.asyncio
+async def test_generator_splices_at_template_constraints_not_description_decoy() -> None:
+    """A job description containing a literal "Constraints:\\n" must NOT hijack
+    the splice point — the portfolio block anchors to the template's trailing
+    Constraints section (last occurrence), not the description's decoy."""
+    llm = FakeLLM()
+    gen = CoverLetterGenerator(llm=llm)
+    portfolio_text = "Relevant portfolio: https://example.com/projects"
+    kwargs = dict(_COMMON_KWARGS)
+    kwargs["description"] = (
+        "Build microservices.\n"
+        "Constraints:\n"
+        "- must pass a background check\n"
+    )
+
+    await gen.generate(**kwargs, portfolio_section=portfolio_text)
+
+    prompt = llm.last_prompt
+    assert prompt is not None
+    # Description's fake Constraints occurrence comes BEFORE the portfolio block.
+    assert prompt.rindex("Relevant portfolio") > prompt.index("Constraints:")
+    # The block sits immediately before the LAST (template) Constraints section.
+    marker = "Constraints:\n"
+    last_constraints = prompt.rindex(marker)
+    portfolio_block_end = prompt.rindex("verbatim exactly once.") + len("verbatim exactly once.")
+    assert prompt[portfolio_block_end:last_constraints] == "\n\n"
+    # And the template's real Constraints body follows it intact.
+    assert prompt[last_constraints:].startswith("Constraints:\n- Tone:")
+
+
+@pytest.mark.asyncio
 async def test_generator_prompt_byte_identical_when_no_portfolio() -> None:
     """When portfolio_section is omitted (None), the prompt must equal USER_PROMPT_TEMPLATE.format(...)."""
     llm = FakeLLM()

--- a/backend/tests/unit/outreach/test_outreach_citation.py
+++ b/backend/tests/unit/outreach/test_outreach_citation.py
@@ -1,0 +1,239 @@
+"""Tests: portfolio citation integration in outreach generation.
+
+Covers:
+- OutreachMessageGenerator.generate appends portfolio section + mention-instruction
+  when portfolio_section is given; prompt is unchanged (no "portfolio" text) when omitted.
+- OutreachService.generate calls citation_for with the correct job_text / application_id /
+  language and forwards the returned section to the generator.
+- The existing suite (test_outreach_service.py) implicitly covers the default-None
+  portfolio_citation path — no test here is needed for that case.
+"""
+from __future__ import annotations
+
+import uuid as uuid_mod
+
+import pytest
+
+from hiresense.outreach.domain.message_generator import OutreachMessageGenerator
+from hiresense.outreach.domain.outreach_service import OutreachService
+
+
+# ---------------------------------------------------------------------------
+# Fakes shared across both test groups
+# ---------------------------------------------------------------------------
+
+
+class _FakeLLM:
+    def __init__(self, text: str = "drafted") -> None:
+        self.calls: list[tuple[str, str]] = []
+        self.text = text
+
+    async def complete(self, prompt: str, system: str) -> str:
+        self.calls.append((prompt, system))
+        return self.text
+
+
+class _App:
+    def __init__(self, app_id: uuid_mod.UUID) -> None:
+        self.id = app_id
+        self.company = "Acme"
+        self.title = "Backend Engineer"
+        self.status = "applied"
+        self.notes = "We build fast APIs for fintech clients."
+        self.url = None
+
+
+class _Tracking:
+    def __init__(self, app: _App) -> None:
+        self._app = app
+
+    def get(self, app_id: uuid_mod.UUID) -> _App:
+        if app_id != self._app.id:
+            raise ValueError("not found")
+        return self._app
+
+
+class _Profile:
+    async def get_current_profile(self, language: str | None = None):
+        return type("P", (), {"name": "Bryan"})()
+
+    def get_for_language(self, language: str | None):
+        return type("V", (), {"skills": ["python"], "summary": "dev"})()
+
+
+class _Research:
+    def get(self, company: str):
+        return None
+
+
+class _CapturingGen:
+    """Records the kwargs it was called with."""
+
+    def __init__(self) -> None:
+        self.kwargs: dict | None = None
+
+    async def generate(self, **kwargs) -> str:
+        self.kwargs = kwargs
+        return "outreach body"
+
+
+class _Repo:
+    def add(self, event):
+        return event
+
+    def list_for(self, app_id):
+        return []
+
+    def latest_per_application(self):
+        return []
+
+
+class _FakeCitationService:
+    """Mimics PortfolioCitationService.citation_for."""
+
+    def __init__(self, result: str | None = "See my widget at https://example.com") -> None:
+        self.result = result
+        self.calls: list[dict] = []
+
+    async def citation_for(
+        self,
+        *,
+        job_skills: list[str],
+        job_text: str,
+        application_id: str,
+        language: str | None,
+    ) -> str | None:
+        self.calls.append(
+            {"job_skills": job_skills, "job_text": job_text,
+             "application_id": application_id, "language": language}
+        )
+        return self.result
+
+
+# ---------------------------------------------------------------------------
+# Generator tests
+# ---------------------------------------------------------------------------
+
+
+def _gen(llm):
+    return OutreachMessageGenerator(llm=llm)
+
+
+_COMMON_KWARGS = dict(
+    company="Acme",
+    title="Backend Engineer",
+    job_description="Build APIs for fintech",
+    candidate_name="Bryan",
+    candidate_summary="FastAPI dev",
+    candidate_skills=["python"],
+    company_research=None,
+    contact_name=None,
+    style_guide="BE CONCISE",
+    channel=None,
+    max_chars=500,
+)
+
+
+@pytest.mark.asyncio
+async def test_generator_includes_portfolio_section_and_instruction():
+    llm = _FakeLLM()
+    section = "Portfolio: built a job-board scraper (https://example.com)"
+    await _gen(llm).generate(**_COMMON_KWARGS, portfolio_section=section)
+    prompt, _ = llm.calls[0]
+    assert section in prompt
+    assert "Mention at most ONE of these projects" in prompt
+    assert "portfolio link" in prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_generator_omits_portfolio_when_none():
+    llm = _FakeLLM()
+    await _gen(llm).generate(**_COMMON_KWARGS, portfolio_section=None)
+    prompt, _ = llm.calls[0]
+    assert "portfolio" not in prompt.lower()
+
+
+@pytest.mark.asyncio
+async def test_generator_omits_portfolio_when_empty_string():
+    llm = _FakeLLM()
+    await _gen(llm).generate(**_COMMON_KWARGS, portfolio_section="")
+    prompt, _ = llm.calls[0]
+    assert "portfolio" not in prompt.lower()
+
+
+# ---------------------------------------------------------------------------
+# Service tests
+# ---------------------------------------------------------------------------
+
+
+def _svc(app: _App, gen, citation=None) -> OutreachService:
+    return OutreachService(
+        tracking_service=_Tracking(app),
+        profile_service=_Profile(),
+        research_service=_Research(),
+        generator=gen,
+        repo=_Repo(),
+        style_guide_path="does/not/exist.md",
+        followup_cadence_days=7,
+        max_chars=500,
+        language="en",
+        portfolio_citation=citation,
+    )
+
+
+@pytest.mark.asyncio
+async def test_service_passes_portfolio_section_to_generator():
+    app_id = uuid_mod.uuid4()
+    app = _App(app_id)
+    citation_svc = _FakeCitationService("Portfolio: https://example.com")
+    gen = _CapturingGen()
+    svc = _svc(app, gen, citation=citation_svc)
+
+    await svc.generate(app_id)
+
+    assert gen.kwargs is not None
+    assert gen.kwargs["portfolio_section"] == "Portfolio: https://example.com"
+
+
+@pytest.mark.asyncio
+async def test_service_calls_citation_with_correct_args():
+    app_id = uuid_mod.uuid4()
+    app = _App(app_id)
+    citation_svc = _FakeCitationService("some section")
+    gen = _CapturingGen()
+    svc = _svc(app, gen, citation=citation_svc)
+
+    await svc.generate(app_id)
+
+    assert len(citation_svc.calls) == 1
+    call = citation_svc.calls[0]
+    # job_text must equal what the service passes as job_description to the generator
+    assert call["job_text"] == gen.kwargs["job_description"]
+    assert call["application_id"] == str(app_id)
+    assert call["language"] == "en"
+
+
+@pytest.mark.asyncio
+async def test_service_passes_none_section_when_citation_returns_none():
+    app_id = uuid_mod.uuid4()
+    app = _App(app_id)
+    citation_svc = _FakeCitationService(result=None)
+    gen = _CapturingGen()
+    svc = _svc(app, gen, citation=citation_svc)
+
+    await svc.generate(app_id)
+
+    assert gen.kwargs["portfolio_section"] is None
+
+
+@pytest.mark.asyncio
+async def test_service_with_no_citation_passes_none_section():
+    """Mirrors the default-None path covered implicitly by the existing suite."""
+    app_id = uuid_mod.uuid4()
+    app = _App(app_id)
+    gen = _CapturingGen()
+    svc = _svc(app, gen, citation=None)
+
+    await svc.generate(app_id)
+
+    assert gen.kwargs["portfolio_section"] is None

--- a/backend/tests/unit/portfolio/test_bootstrap.py
+++ b/backend/tests/unit/portfolio/test_bootstrap.py
@@ -12,6 +12,9 @@ class _Settings:
     portfolio_github_api_url = "https://api.github.com"
     portfolio_github_max_repos = 30
     portfolio_profile_char_cap = 1200
+    portfolio_public_url = ""
+    portfolio_ref_prefix = "hiresense"
+    portfolio_relevant_projects_top_n = 2
     default_language = "en"
 
 
@@ -49,6 +52,7 @@ def test_builds_provider_with_supabase() -> None:
     assert build is not None
     assert build.provider.get_sync_service() is not None
     assert build.provider.get_enrichment_service() is not None
+    assert build.provider.get_citation_service() is not None
 
 
 def test_raises_when_github_enabled_without_username() -> None:

--- a/backend/tests/unit/portfolio/test_citation_service.py
+++ b/backend/tests/unit/portfolio/test_citation_service.py
@@ -1,0 +1,79 @@
+import pytest
+
+from hiresense.portfolio.domain import (
+    PortfolioCitationService,
+    PortfolioProject,
+    ProjectText,
+    RelevantProjectSelector,
+)
+
+
+class _FakeRepo:
+    def __init__(self, projects):
+        self._projects = projects
+
+    def list_all(self):
+        return self._projects
+
+
+def _project(key, tech, *, demo=None):
+    return PortfolioProject(
+        id=key,
+        source="supabase",
+        source_key=key,
+        tech=tech,
+        url=f"https://github.com/x/{key}",
+        demo_url=demo,
+        translations={
+            "en": ProjectText(title=key.title(), description="Did things."),
+            "es": ProjectText(title=f"{key.title()} ES", description="Hizo cosas."),
+        },
+    )
+
+
+def _service(projects, *, public_url="https://site.dev", ref_prefix="hiresense"):
+    return PortfolioCitationService(
+        repository=_FakeRepo(projects),
+        selector=RelevantProjectSelector(),
+        language="en",
+        top_n=2,
+        public_url=public_url,
+        ref_prefix=ref_prefix,
+    )
+
+
+@pytest.mark.asyncio
+async def test_citation_includes_projects_and_tracked_link() -> None:
+    service = _service([_project("api", ["fastapi", "python"], demo="https://demo.x")])
+    text = await service.citation_for(
+        job_skills=["python"], job_text="", application_id="app-1"
+    )
+    assert text is not None
+    assert "Api [fastapi, python]: Did things." in text
+    assert "https://github.com/x/api" in text
+    assert "https://site.dev/?ref=hiresense-app-1" in text
+
+
+@pytest.mark.asyncio
+async def test_citation_none_when_no_relevant_projects_or_empty_snapshot() -> None:
+    service = _service([_project("api", ["fastapi"])])
+    assert (
+        await service.citation_for(job_skills=["unity"], job_text="", application_id="a")
+        is None
+    )
+    empty = _service([])
+    assert (
+        await empty.citation_for(job_skills=["python"], job_text="", application_id="a")
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_language_override_and_linkless_mode() -> None:
+    service = _service([_project("api", ["python"])], public_url="")
+    text = await service.citation_for(
+        job_skills=["python"], job_text="", application_id="a", language="es"
+    )
+    assert text is not None
+    assert "Api ES" in text
+    assert "?ref=" not in text

--- a/backend/tests/unit/portfolio/test_relevant_project_selector.py
+++ b/backend/tests/unit/portfolio/test_relevant_project_selector.py
@@ -1,0 +1,48 @@
+from hiresense.portfolio.domain import PortfolioProject, ProjectText, RelevantProjectSelector
+
+
+def _project(key, *, tech=None, title=None, pinned=False, position=None):
+    return PortfolioProject(
+        id=key, source="supabase", source_key=key, pinned=pinned, position=position,
+        tech=tech or [],
+        translations={"en": ProjectText(title=title or key, description="d")},
+    )
+
+
+def test_ranks_by_term_overlap_and_drops_irrelevant() -> None:
+    selector = RelevantProjectSelector()
+    projects = [
+        _project("nest", tech=["nestjs", "kafka"]),
+        _project("ai", tech=["fastapi", "langchain", "postgresql"]),
+        _project("unrelated", tech=["unity", "csharp"]),
+    ]
+    picked = selector.select(
+        job_skills=["FastAPI", "PostgreSQL"],
+        job_text="We use LangChain agents over Postgres.",
+        projects=projects,
+        top_n=2,
+    )
+    assert [p.source_key for p in picked] == ["ai"]  # zero-overlap projects are dropped
+
+
+def test_title_tokens_count_and_pinned_breaks_ties() -> None:
+    selector = RelevantProjectSelector()
+    projects = [
+        _project("b", tech=["python"], position=2),
+        _project("a", tech=["python"], pinned=True, position=9),
+    ]
+    picked = selector.select(job_skills=["python"], job_text="", projects=projects, top_n=2)
+    assert [p.source_key for p in picked] == ["a", "b"]  # equal score -> pinned first
+
+    titled = selector.select(
+        job_skills=[], job_text="building a kafka pipeline",
+        projects=[_project("k", title="kafka-dashboard"), _project("x", title="todo-app")],
+        top_n=2,
+    )
+    assert [p.source_key for p in titled] == ["k"]
+
+
+def test_top_n_caps_results() -> None:
+    selector = RelevantProjectSelector()
+    projects = [_project(f"p{i}", tech=["python"]) for i in range(5)]
+    assert len(selector.select(job_skills=["python"], job_text="", projects=projects, top_n=2)) == 2

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -109,3 +109,19 @@ def test_portfolio_github_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> 
     assert settings.portfolio_github_token == ""
     assert settings.portfolio_github_api_url == "https://api.github.com"
     assert settings.portfolio_github_max_repos == 30
+
+
+def test_portfolio_citation_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+    monkeypatch.setenv("AUTH_USERNAME", "admin")
+    monkeypatch.setenv("AUTH_PASSWORD", "pass")
+    monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+    monkeypatch.setenv("LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("PORTFOLIO_PUBLIC_URL", "")
+
+    from hiresense.config import Settings
+
+    settings = Settings()
+    assert settings.portfolio_public_url == ""
+    assert settings.portfolio_ref_prefix == "hiresense"
+    assert settings.portfolio_relevant_projects_top_n == 2

--- a/docs/superpowers/plans/2026-06-10-portfolio-phase3-citation.md
+++ b/docs/superpowers/plans/2026-06-10-portfolio-phase3-citation.md
@@ -1,0 +1,469 @@
+# Portfolio Phase 3 (Artifact Citation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cover letters and outreach messages cite the 1–2 most relevant portfolio projects for the specific job and include a per-application tracked portfolio link (`{PORTFOLIO_PUBLIC_URL}/?ref={PORTFOLIO_REF_PREFIX}-{application_id}`).
+
+**Architecture:** Pure `RelevantProjectSelector` + `PortfolioCitationService` in the portfolio domain, exposed via the provider; `ApplyService` (cover letters) and `OutreachService` gain an OPTIONAL `portfolio_citation` collaborator wired in `main.py`/bootstrap — None ⇒ byte-identical prompts to today. The generated text itself shows the citations (no new persistence/UI; structured "which projects were cited" display deferred — the letter body is visible in the existing UI).
+
+**Working directory:** `C:\Users\Bryan\worktrees\hiresense-portfolio` (branch `feat/portfolio-citation`, stacked on `feat/portfolio-github`; PR base = that branch). Backend from `backend/`. **Quirks:** `uv run python -m pytest` only (never bare `uv run pytest`); no repo-wide `ruff format`; commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+**Codebase facts (verified):**
+- Cover letter: `applications/domain/apply_service.py:36-80` (`generate_cover_letter(application_id, cv_language, tone)`; has `snapshot.description` + `snapshot.required_skills`); prompt in `applications/domain/cover_letter_generator.py` (`USER_PROMPT_TEMPLATE`, "Constraints:" section). Built in `bootstrap/applications.py` (`CoverLetterGenerator(llm=tracked("cover_letter"))`, `ApplyService(...)`).
+- Outreach: `outreach/domain/outreach_service.py:39-58` (`generate(application_id, *, contact_name, channel)`; has `app.notes` as job text, NO skills); prompt parts list in `outreach/domain/message_generator.py:44-65` with existing `if x: parts.append(...)` optional-section pattern; service holds `self._language` from config. Built in `bootstrap/outreach.py`.
+- `main.py` builds portfolio BEFORE applications and outreach — pass `portfolio.provider.get_citation_service() if portfolio is not None else None` into both builders.
+- Portfolio domain already has `PortfolioProject.text_for(language)`, `PortfolioProjectsRepositoryPort.list_all`, provider with getters, bootstrap `build_portfolio`.
+
+---
+
+### Task 1: Config + env
+
+**Files:** `backend/src/hiresense/config.py`, `backend/.env`, `backend/.env.example`, `backend/tests/unit/test_config.py`
+
+- [ ] **Step 1: failing test** — append to `test_config.py`:
+
+```python
+def test_portfolio_citation_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+    monkeypatch.setenv("AUTH_USERNAME", "admin")
+    monkeypatch.setenv("AUTH_PASSWORD", "pass")
+    monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+    monkeypatch.setenv("LLM_API_KEY", "sk-test")
+    monkeypatch.setenv("PORTFOLIO_PUBLIC_URL", "")
+
+    from hiresense.config import Settings
+
+    settings = Settings()
+    assert settings.portfolio_public_url == ""
+    assert settings.portfolio_ref_prefix == "hiresense"
+    assert settings.portfolio_relevant_projects_top_n == 2
+```
+
+- [ ] **Step 2:** run it → FAIL. **Step 3:** add to the portfolio block in `config.py` (after `portfolio_github_max_repos`):
+
+```python
+    # Public portfolio site linked from generated artifacts. Empty disables
+    # the tracked link (project citations still work).
+    portfolio_public_url: str = ""
+    # Slug prefix for per-application tracked links: ?ref=<prefix>-<application_id>.
+    portfolio_ref_prefix: str = "hiresense"
+    # How many relevant projects get cited per generated artifact.
+    portfolio_relevant_projects_top_n: int = 2
+```
+
+- [ ] **Step 4:** test file green. **Step 5:** `.env.example` gains the three vars (commented, `PORTFOLIO_PUBLIC_URL=` empty placeholder); local `backend/.env` gains them with `PORTFOLIO_PUBLIC_URL=https://stevsant.vercel.app`, others default.
+- [ ] **Step 6: commit** — `feat(portfolio): citation settings`.
+
+---
+
+### Task 2: RelevantProjectSelector (pure)
+
+**Files:** create `backend/src/hiresense/portfolio/domain/relevant_project_selector.py`; modify `domain/__init__.py`; test `backend/tests/unit/portfolio/test_relevant_project_selector.py`
+
+- [ ] **Step 1: failing test:**
+
+```python
+from hiresense.portfolio.domain import PortfolioProject, ProjectText, RelevantProjectSelector
+
+
+def _project(key, *, tech=None, title=None, pinned=False, position=None):
+    return PortfolioProject(
+        id=key, source="supabase", source_key=key, pinned=pinned, position=position,
+        tech=tech or [],
+        translations={"en": ProjectText(title=title or key, description="d")},
+    )
+
+
+def test_ranks_by_term_overlap_and_drops_irrelevant() -> None:
+    selector = RelevantProjectSelector()
+    projects = [
+        _project("nest", tech=["nestjs", "kafka"]),
+        _project("ai", tech=["fastapi", "langchain", "postgresql"]),
+        _project("unrelated", tech=["unity", "csharp"]),
+    ]
+    picked = selector.select(
+        job_skills=["FastAPI", "PostgreSQL"],
+        job_text="We use LangChain agents over Postgres.",
+        projects=projects,
+        top_n=2,
+    )
+    assert [p.source_key for p in picked] == ["ai"]  # zero-overlap projects are dropped
+
+
+def test_title_tokens_count_and_pinned_breaks_ties() -> None:
+    selector = RelevantProjectSelector()
+    projects = [
+        _project("b", tech=["python"], position=2),
+        _project("a", tech=["python"], pinned=True, position=9),
+    ]
+    picked = selector.select(job_skills=["python"], job_text="", projects=projects, top_n=2)
+    assert [p.source_key for p in picked] == ["a", "b"]  # equal score -> pinned first
+
+    titled = selector.select(
+        job_skills=[], job_text="building a kafka pipeline",
+        projects=[_project("k", title="kafka-dashboard"), _project("x", title="todo-app")],
+        top_n=2,
+    )
+    assert [p.source_key for p in titled] == ["k"]
+
+
+def test_top_n_caps_results() -> None:
+    selector = RelevantProjectSelector()
+    projects = [_project(f"p{i}", tech=["python"]) for i in range(5)]
+    assert len(selector.select(job_skills=["python"], job_text="", projects=projects, top_n=2)) == 2
+```
+
+- [ ] **Step 2:** run → FAIL. **Step 3: implement** `relevant_project_selector.py`:
+
+```python
+from __future__ import annotations
+
+import re
+
+from hiresense.portfolio.domain.portfolio_project import PortfolioProject
+
+_TOKEN_RE = re.compile(r"[a-z0-9_+#.]+")
+_UNPOSITIONED = 1_000_000
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_TOKEN_RE.findall(text.lower()))
+
+
+class RelevantProjectSelector:
+    """Ranks portfolio projects against a job, deterministically (no LLM).
+
+    Score = overlap between the job's terms (skills + description tokens) and
+    the project's terms (tech + title tokens). Zero-score projects are never
+    cited; ties break pinned-first, then by position.
+    """
+
+    def select(
+        self,
+        *,
+        job_skills: list[str],
+        job_text: str,
+        projects: list[PortfolioProject],
+        top_n: int,
+    ) -> list[PortfolioProject]:
+        job_terms = {skill.lower() for skill in job_skills} | _tokens(job_text)
+        scored: list[tuple[int, PortfolioProject]] = []
+        for project in projects:
+            title = project.text_for("en")
+            project_terms = {tech.lower() for tech in project.tech}
+            if title is not None:
+                project_terms |= _tokens(title.title)
+            score = len(project_terms & job_terms)
+            if score > 0:
+                scored.append((score, project))
+        scored.sort(
+            key=lambda pair: (
+                -pair[0],
+                not pair[1].pinned,
+                pair[1].position if pair[1].position is not None else _UNPOSITIONED,
+            )
+        )
+        return [project for _, project in scored[:top_n]]
+```
+
+Re-export from `domain/__init__.py` (alphabetical + `__all__`).
+
+- [ ] **Step 4:** portfolio tests pass; ruff clean. **Step 5: commit** — `feat(portfolio): relevant project selector`.
+
+---
+
+### Task 3: PortfolioCitationService + provider + bootstrap
+
+**Files:** create `backend/src/hiresense/portfolio/domain/citation_service.py`; modify `domain/__init__.py`, `portfolio/api/provider.py`, `bootstrap/portfolio.py`; tests `backend/tests/unit/portfolio/test_citation_service.py` (+ extend `test_bootstrap.py`)
+
+- [ ] **Step 1: failing test:**
+
+```python
+import pytest
+
+from hiresense.portfolio.domain import (
+    PortfolioCitationService,
+    PortfolioProject,
+    ProjectText,
+    RelevantProjectSelector,
+)
+
+
+class _FakeRepo:
+    def __init__(self, projects):
+        self._projects = projects
+
+    def list_all(self):
+        return self._projects
+
+
+def _project(key, tech, *, demo=None):
+    return PortfolioProject(
+        id=key, source="supabase", source_key=key, tech=tech,
+        url=f"https://github.com/x/{key}", demo_url=demo,
+        translations={
+            "en": ProjectText(title=key.title(), description="Did things."),
+            "es": ProjectText(title=f"{key.title()} ES", description="Hizo cosas."),
+        },
+    )
+
+
+def _service(projects, *, public_url="https://site.dev", ref_prefix="hiresense"):
+    return PortfolioCitationService(
+        repository=_FakeRepo(projects),
+        selector=RelevantProjectSelector(),
+        language="en",
+        top_n=2,
+        public_url=public_url,
+        ref_prefix=ref_prefix,
+    )
+
+
+@pytest.mark.asyncio
+async def test_citation_includes_projects_and_tracked_link() -> None:
+    service = _service([_project("api", ["fastapi", "python"], demo="https://demo.x")])
+    text = await service.citation_for(
+        job_skills=["python"], job_text="", application_id="app-1"
+    )
+    assert text is not None
+    assert "Api [fastapi, python]: Did things." in text
+    assert "https://github.com/x/api" in text
+    assert "https://site.dev/?ref=hiresense-app-1" in text
+
+
+@pytest.mark.asyncio
+async def test_citation_none_when_no_relevant_projects_or_empty_snapshot() -> None:
+    service = _service([_project("api", ["fastapi"])])
+    assert await service.citation_for(job_skills=["unity"], job_text="", application_id="a") is None
+    empty = _service([])
+    assert await empty.citation_for(job_skills=["python"], job_text="", application_id="a") is None
+
+
+@pytest.mark.asyncio
+async def test_language_override_and_linkless_mode() -> None:
+    service = _service([_project("api", ["python"])], public_url="")
+    text = await service.citation_for(
+        job_skills=["python"], job_text="", application_id="a", language="es"
+    )
+    assert text is not None
+    assert "Api ES" in text
+    assert "?ref=" not in text
+```
+
+- [ ] **Step 2:** run → FAIL. **Step 3: implement** `citation_service.py`:
+
+```python
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from hiresense.portfolio.domain.relevant_project_selector import RelevantProjectSelector
+
+if TYPE_CHECKING:
+    from hiresense.portfolio.ports import PortfolioProjectsRepositoryPort
+
+
+class PortfolioCitationService:
+    """Builds the optional 'relevant portfolio projects' prompt block for
+    generated artifacts (cover letters, outreach), including the
+    per-application tracked link. Returns None when there is nothing
+    relevant to cite — consumers then behave exactly as before."""
+
+    def __init__(
+        self,
+        repository: "PortfolioProjectsRepositoryPort",
+        selector: RelevantProjectSelector,
+        *,
+        language: str,
+        top_n: int,
+        public_url: str,
+        ref_prefix: str,
+    ) -> None:
+        self._repository = repository
+        self._selector = selector
+        self._language = language
+        self._top_n = top_n
+        self._public_url = public_url.rstrip("/")
+        self._ref_prefix = ref_prefix
+
+    async def citation_for(
+        self,
+        *,
+        job_skills: list[str],
+        job_text: str,
+        application_id: str,
+        language: str | None = None,
+    ) -> str | None:
+        projects = await asyncio.to_thread(self._repository.list_all)
+        if not projects:
+            return None
+        picked = self._selector.select(
+            job_skills=job_skills, job_text=job_text, projects=projects, top_n=self._top_n
+        )
+        if not picked:
+            return None
+        lang = language or self._language
+        lines = ["Relevant portfolio projects (mention 1-2 naturally where they strengthen the case):"]
+        for project in picked:
+            text = project.text_for(lang)
+            if text is None:
+                continue
+            line = f"- {text.title}"
+            if project.tech:
+                line += f" [{', '.join(project.tech)}]"
+            first_desc = (text.description or "").strip().splitlines()
+            if first_desc and first_desc[0]:
+                line += f": {first_desc[0]}"
+            links = [link for link in (project.url, project.demo_url) if link]
+            if links:
+                line += f" ({' | '.join(links)})"
+            lines.append(line)
+        if len(lines) == 1:
+            return None
+        if self._public_url:
+            lines.append(
+                "Include this exact portfolio link once, near the close: "
+                f"{self._public_url}/?ref={self._ref_prefix}-{application_id}"
+            )
+        return "\n".join(lines)
+```
+
+Re-export; add `get_citation_service()` to `PortfolioProvider` (constructor gains `citation_service`); in `bootstrap/portfolio.py` build it:
+
+```python
+        citation_service=PortfolioCitationService(
+            repository=repository,
+            selector=RelevantProjectSelector(),
+            language=s.default_language,
+            top_n=s.portfolio_relevant_projects_top_n,
+            public_url=s.portfolio_public_url,
+            ref_prefix=s.portfolio_ref_prefix,
+        ),
+```
+
+Extend `test_bootstrap.py`'s `_Settings` with `portfolio_public_url = ""`, `portfolio_ref_prefix = "hiresense"`, `portfolio_relevant_projects_top_n = 2`, and assert `build.provider.get_citation_service() is not None` in the existing supabase build test.
+
+- [ ] **Step 4:** portfolio tests + full suite pass; ruff clean. **Step 5: commit** — `feat(portfolio): citation service`.
+
+---
+
+### Task 4: Cover letter integration
+
+**Files:** modify `backend/src/hiresense/applications/domain/cover_letter_generator.py`, `applications/domain/apply_service.py`, `bootstrap/applications.py`, `main.py`; test `backend/tests/unit/applications/test_cover_letter_citation.py` (new; study existing tests in `tests/unit/applications/` for the fakes/fixtures already available and reuse them)
+
+- [ ] **Step 1: failing test** (adapt fake names to what exists in `tests/unit/applications/` — the test must cover: (a) generator prompt contains the citation block when provided, (b) ApplyService passes job snapshot skills/description + application_id + cv_language to the citation service, (c) everything unchanged when citation service is None):
+
+```python
+import pytest
+
+from hiresense.applications.domain.cover_letter_generator import CoverLetterGenerator
+
+
+class _FakeLLM:
+    def __init__(self):
+        self.prompts: list[str] = []
+
+    async def complete(self, prompt: str, system: str | None = None) -> str:
+        self.prompts.append(prompt)
+        return "letter body"
+
+
+@pytest.mark.asyncio
+async def test_generator_appends_portfolio_section_when_given() -> None:
+    llm = _FakeLLM()
+    generator = CoverLetterGenerator(llm=llm)
+    await generator.generate(
+        title="SWE", company="Acme", description="d", candidate_summary="s",
+        candidate_skills=["python"], required_skills=["python"], pros=[],
+        missing_skills=[], tone="professional",
+        portfolio_section="Relevant portfolio projects:\n- Api [python]",
+    )
+    assert "Relevant portfolio projects:" in llm.prompts[0]
+    assert "- Api [python]" in llm.prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_generator_prompt_unchanged_without_portfolio_section() -> None:
+    llm = _FakeLLM()
+    generator = CoverLetterGenerator(llm=llm)
+    await generator.generate(
+        title="SWE", company="Acme", description="d", candidate_summary="s",
+        candidate_skills=["python"], required_skills=["python"], pros=[],
+        missing_skills=[], tone="professional",
+    )
+    assert "portfolio" not in llm.prompts[0].lower()
+```
+
+IMPORTANT: first READ `cover_letter_generator.py` and the existing tests to match the actual `generate(...)` signature/LLM port call — adapt the fake to the real interface (e.g., if the LLM port method is `complete(prompt, system=...)` or different). Keep the two behavioral assertions.
+
+- [ ] **Step 2:** run → FAIL. **Step 3: implement:**
+  - `cover_letter_generator.py`: `generate(...)` gains `portfolio_section: str | None = None`. When set, insert into the user prompt BEFORE the "Constraints:" line:
+
+```python
+        if portfolio_section:
+            prompt += (
+                "\n" + portfolio_section + "\n"
+                "Weave at most two of these projects into the middle paragraphs "
+                "only where they genuinely match the job's needs; if a portfolio "
+                "link is given above, include it verbatim exactly once.\n"
+            )
+```
+
+  (Adapt mechanically to how the prompt string is actually assembled — if it's a single `.format()` template, append the section after formatting, before sending to the LLM, keeping the "Return only the cover letter body." line LAST. Read the file first.)
+  - `apply_service.py`: constructor gains `portfolio_citation: Any = None`. In `generate_cover_letter`, after loading `snapshot`:
+
+```python
+        portfolio_section = None
+        if self._portfolio_citation is not None:
+            portfolio_section = await self._portfolio_citation.citation_for(
+                job_skills=list(snapshot.required_skills or []),
+                job_text=snapshot.description or "",
+                application_id=str(application_id),
+                language=cv_language,
+            )
+```
+
+  and pass `portfolio_section=portfolio_section` to the generator.
+  - `bootstrap/applications.py`: `build_applications(..., portfolio_citation: Any = None)` → into `ApplyService`.
+  - `main.py`: pass `portfolio_citation=portfolio.provider.get_citation_service() if portfolio is not None else None` to `build_applications`.
+
+- [ ] **Step 4:** new tests + FULL suite pass (existing apply-service tests construct ApplyService without the new kwarg — default None keeps them green); ruff clean. **Step 5: commit** — `feat(portfolio): cite relevant projects in cover letters`.
+
+---
+
+### Task 5: Outreach integration
+
+**Files:** modify `backend/src/hiresense/outreach/domain/message_generator.py`, `outreach/domain/outreach_service.py`, `bootstrap/outreach.py`, `main.py`; test `backend/tests/unit/outreach/test_outreach_citation.py` (new; reuse existing outreach test fakes — read `tests/unit/outreach/` first)
+
+- [ ] **Step 1: failing test** — mirrors Task 4: (a) generator appends `portfolio_section` as a conditional part (following the existing `if company_research:` pattern), (b) `OutreachService.generate` calls `citation_for(job_skills=[], job_text=<the job description it already extracts from the tracked app>, application_id=str(application_id))` when the collaborator is set, (c) None ⇒ prompts byte-identical. Write concrete tests after reading the real signatures.
+
+- [ ] **Step 2:** FAIL. **Step 3: implement:**
+  - `message_generator.py`: `generate(...)` gains `portfolio_section: str | None = None`; before the final instruction part:
+
+```python
+        if portfolio_section:
+            parts.append(portfolio_section)
+            parts.append(
+                "Mention at most ONE of these projects, only if it strengthens the hook; "
+                "if a portfolio link is given above, include it verbatim."
+            )
+```
+
+  - `outreach_service.py`: constructor gains `portfolio_citation: Any = None`; in `generate()`, before calling the generator, compute the section (job_skills=[], job_text = the same job-description string it already passes to the generator, language=self._language) and pass it through.
+  - `bootstrap/outreach.py` + `main.py`: same optional-wiring pattern as Task 4.
+
+- [ ] **Step 4:** new tests + FULL suite pass; ruff clean. **Step 5: commit** — `feat(portfolio): cite relevant projects in outreach messages`.
+
+---
+
+### Task 6: Verification + smoke + stacked PR
+
+- [ ] **Step 1:** `uv run python -m pytest -q` (expect ~930+ passed, 0 failed) + `uv run ruff check .`. Frontend untouched.
+- [ ] **Step 2: smoke** (compose db up; real `.env`): start app on a free port, login. Pick/create a tracked application with a job snapshot (use existing data if present: `GET /tracking` to find an application id). Generate a cover letter (`POST /applications/{id}/cover-letter` with `{"cv_language": "en", "tone": "professional"}`) → response body should mention a real project (e.g. mesaYA/HireSense-adjacent) AND contain `https://stevsant.vercel.app/?ref=hiresense-<id>` when relevant; if the corpus has no relevant project the section is absent — that's correct behavior, note which case occurred. Same for `POST /outreach/generate`.
+- [ ] **Step 3:** push `feat/portfolio-citation`; `gh auth switch --user StevSant`; `gh pr create --base feat/portfolio-github --title "feat(portfolio): cite relevant projects in artifacts (Phase 3)"` with summary (selector + citation service, optional wiring, ref-link format, smoke evidence, note: structured citation display deferred — the letter body shows citations). Claude Code footer.
+
+## Self-review notes (applied)
+- Spec coverage: selector, citation in both artifact types, tracked ref link, config — covered. Deferred consciously: storing/displaying structured citations (body text is visible in existing UI); engagement readback is Phase 5.
+- Selector keys on terms, not project ids — the id-instability note from Phase 1 doesn't bite here (no persistence of selections).
+- Both integrations are optional-collaborator (None default) so every existing test stays green without changes.


### PR DESCRIPTION
## Summary

Phase 3 of the external-sources integration — **stacked on #85**: cover letters and outreach messages now cite the candidate's most relevant portfolio projects for the specific job and carry a per-application tracked portfolio link.

- **`RelevantProjectSelector`** (pure, deterministic): ranks projects by term overlap between job skills/description and project tech/title tokens; zero-overlap projects are never cited; pinned wins ties.
- **`PortfolioCitationService`**: builds the optional prompt block (top-N projects with tech, first description line, code/demo links) plus the tracked link `{PORTFOLIO_PUBLIC_URL}/?ref={PORTFOLIO_REF_PREFIX}-{application_id}` — the portfolio's existing analytics records this with zero changes on its side (Phase 5 will read it back). Returns None when nothing is relevant → consumers behave exactly as before.
- **Cover letters**: `ApplyService` feeds the job snapshot (skills + description, language-aware EN/ES) to the citation service; the generator splices the block before its Constraints section — anchored to the LAST occurrence after review caught that job descriptions containing "Constraints:" could hijack a first-occurrence splice (regression-tested).
- **Outreach**: same optional-collaborator pattern via the existing conditional-parts prompt assembly; "mention at most ONE project" instruction.
- Wiring is optional end-to-end (`portfolio_citation=None` default everywhere); config: `PORTFOLIO_PUBLIC_URL`, `PORTFOLIO_REF_PREFIX`, `PORTFOLIO_RELEVANT_PROJECTS_TOP_N`.

Deferred deliberately: structured "which projects were cited" persistence/UI — the generated body itself shows citations in the existing views.

## Test plan
- [x] `uv run python -m pytest -q` — 947 passed, 6 skipped; `ruff check` clean
- [x] Live smoke (real LLM): cover letter for a real tracked application cited an actual project ("StreamFlow Music Backend" + GitHub URL) and included `https://stevsant.vercel.app/?ref=hiresense-<application-id>` exactly once near the close
- [x] Negative path verified live: applications with no snapshot/notes text produce NO citation section (selector returns nothing — by design)
- [x] Splice-hijack regression test (description containing literal "Constraints:")

🤖 Generated with [Claude Code](https://claude.com/claude-code)