### PR TITLE
feat(network): LinkedIn connections import with company-match badges (Phase 4)

### DIFF
--- a/backend/alembic/versions/027_add_network_contacts.py
+++ b/backend/alembic/versions/027_add_network_contacts.py
@@ -1,0 +1,44 @@
+"""add network_contacts table
+
+Revision ID: 027
+Revises: 026
+Create Date: 2026-06-09
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "027"
+down_revision: Union[str, None] = "026"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "network_contacts",
+        sa.Column("id", sa.String(length=64), nullable=False),
+        sa.Column("first_name", sa.String(length=256), nullable=False),
+        sa.Column("last_name", sa.String(length=256), nullable=False),
+        sa.Column("company", sa.String(length=512), nullable=False),
+        sa.Column("position", sa.String(length=512), nullable=False),
+        sa.Column("company_normalized", sa.String(length=512), nullable=False),
+        sa.Column("linkedin_url", sa.String(length=2048), nullable=True),
+        sa.Column("email", sa.String(length=512), nullable=True),
+        sa.Column("connected_on", sa.String(length=64), nullable=True),
+        sa.Column("imported_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "ix_network_contacts_company_normalized",
+        "network_contacts",
+        ["company_normalized"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_network_contacts_company_normalized", table_name="network_contacts")
+    op.drop_table("network_contacts")

--- a/backend/src/hiresense/bootstrap/__init__.py
+++ b/backend/src/hiresense/bootstrap/__init__.py
@@ -15,6 +15,7 @@ from hiresense.bootstrap.identity import build_identity
 from hiresense.bootstrap.ingestion import IngestionBuild, build_ingestion
 from hiresense.bootstrap.interview import InterviewBuild, build_interview
 from hiresense.bootstrap.matching import MatchingBuild, build_matching
+from hiresense.bootstrap.network import NetworkBuild, build_network
 from hiresense.bootstrap.optimization import OptimizationBuild, build_optimization
 from hiresense.bootstrap.outreach import OutreachBuild, build_outreach
 from hiresense.bootstrap.portfolio import PortfolioBuild, build_portfolio
@@ -33,6 +34,7 @@ __all__ = [
     "InterviewBuild",
     "MatchingDimensionScorerAdapter",
     "MatchingBuild",
+    "NetworkBuild",
     "OptimizationBuild",
     "OutreachBuild",
     "PortfolioBuild",
@@ -49,6 +51,7 @@ __all__ = [
     "build_ingestion",
     "build_interview",
     "build_matching",
+    "build_network",
     "build_optimization",
     "build_outreach",
     "build_portfolio",

--- a/backend/src/hiresense/bootstrap/network.py
+++ b/backend/src/hiresense/bootstrap/network.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from hiresense.bootstrap.shared_infra import SharedInfra
+from hiresense.network.api.provider import NetworkProvider
+from hiresense.network.domain import NetworkImportService
+from hiresense.network.infrastructure import ContactsRepository
+
+
+@dataclass(frozen=True)
+class NetworkBuild:
+    provider: NetworkProvider
+
+
+def build_network(infra: SharedInfra) -> NetworkBuild:
+    """Always built — the module is upload-driven, no external config."""
+    repository = ContactsRepository(session_factory=infra.sync_session_factory)
+    provider = NetworkProvider(
+        import_service=NetworkImportService(repository=repository),
+        repository=repository,
+    )
+    return NetworkBuild(provider=provider)

--- a/backend/src/hiresense/infrastructure/registry.py
+++ b/backend/src/hiresense/infrastructure/registry.py
@@ -17,6 +17,7 @@ from hiresense.autohunt.infrastructure import DigestOrm  # noqa: F401
 from hiresense.cover_letter_templates.infrastructure import CoverLetterTemplateOrm  # noqa: F401
 from hiresense.ingestion.infrastructure import IngestedJob, JobMatchCache  # noqa: F401
 from hiresense.interview.infrastructure import StoryOrm  # noqa: F401
+from hiresense.network.infrastructure import NetworkContactOrm  # noqa: F401
 from hiresense.outreach.infrastructure import OutreachEventOrm  # noqa: F401
 from hiresense.portfolio.infrastructure import PortfolioProjectOrm  # noqa: F401
 from hiresense.preference.infrastructure import FeedbackSignalOrm, PreferenceModelOrm  # noqa: F401

--- a/backend/src/hiresense/ingestion/api/routes.py
+++ b/backend/src/hiresense/ingestion/api/routes.py
@@ -41,6 +41,9 @@ from hiresense.ingestion.domain.services import IngestionCooldownError, Ingestio
 from hiresense.ingestion.ports.jobs_repository import ScoreUpdate
 from hiresense.matching.domain.deep_analysis_result import DeepAnalysisResult
 from hiresense.matching.domain.deep_analysis_service import DeepAnalysisService
+from hiresense.network.api.dependencies import get_contacts_repository
+from hiresense.network.domain import normalize_company
+from hiresense.network.ports import ContactsRepositoryPort
 from hiresense.portfolio.api.dependencies import get_portfolio_enrichment
 from hiresense.portfolio.domain import PortfolioEnrichmentService
 from hiresense.profile.api.dependencies import get_profile_service
@@ -164,6 +167,7 @@ async def list_jobs(
     semantic_scoring: Annotated[SemanticScoringService | None, Depends(get_semantic_scoring)],
     quick_scoring: Annotated[QuickScoringService | None, Depends(get_quick_scoring)],
     pre_ranker: Annotated[SemanticPreRanker | None, Depends(get_pre_ranker)],
+    network_repo: Annotated[ContactsRepositoryPort | None, Depends(get_contacts_repository)],
     page: Annotated[int, Query(ge=1)] = 1,
     page_size: Annotated[int, Query(ge=1)] = 20,
     source: str | None = None,
@@ -373,6 +377,20 @@ async def list_jobs(
             result.jobs = [_apply_quick(j, quick_results.get(j.id)) for j in result.jobs]
             if effective_sort.startswith("match_"):
                 result.jobs = sort_jobs(result.jobs, effective_sort)
+
+    # "You know someone here" badge data: one GROUP BY over the visible page's
+    # companies. Contacts never enter prompts — this is a display-only count.
+    if network_repo is not None and result.jobs:
+        company_key_by_job = {job.id: normalize_company(job.company) for job in result.jobs}
+        counts = await asyncio.to_thread(
+            network_repo.count_by_companies,
+            sorted({key for key in company_key_by_job.values() if key}),
+        )
+        result.connections_by_job = {
+            job_id: counts[key]
+            for job_id, key in company_key_by_job.items()
+            if counts.get(key)
+        }
 
     return result
 

--- a/backend/src/hiresense/ingestion/domain/job_filter.py
+++ b/backend/src/hiresense/ingestion/domain/job_filter.py
@@ -58,6 +58,9 @@ class PaginatedResult(BaseModel):
     page: int
     page_size: int
     total_pages: int
+    # Per-job count of imported LinkedIn connections at the job's company
+    # (normalized match). Only jobs with at least one connection appear.
+    connections_by_job: dict[str, int] = {}
 
 
 def filter_and_paginate(

--- a/backend/src/hiresense/main.py
+++ b/backend/src/hiresense/main.py
@@ -21,6 +21,7 @@ from hiresense.bootstrap import (
     build_ingestion,
     build_interview,
     build_matching,
+    build_network,
     build_optimization,
     build_outreach,
     build_portfolio,
@@ -40,6 +41,7 @@ from hiresense.interview.api import router as interview_router
 from hiresense.matching.api import router as matching_router
 from hiresense.optimization.api import router as optimization_router
 from hiresense.outreach.api import router as outreach_router
+from hiresense.network.api import router as network_router
 from hiresense.portfolio.api import router as portfolio_router
 from hiresense.preference.api import router as preference_router
 from hiresense.profile.api import router as profile_router
@@ -138,6 +140,11 @@ def create_app() -> FastAPI:
     # Router is always mounted: with no provider the endpoints degrade
     # (sync → 503, projects → empty) instead of 404ing the frontend card.
     app.include_router(portfolio_router)
+
+    # --- Network (LinkedIn connections import; always built — upload-driven) ---
+    network = build_network(infra)
+    app.state.network = network.provider
+    app.include_router(network_router)
 
     # --- Matching ---
     matching = build_matching(infra, tracked, preference=preference.service)

--- a/backend/src/hiresense/network/__init__.py
+++ b/backend/src/hiresense/network/__init__.py
@@ -1,0 +1,1 @@
+"""Network bounded context — contacts imported from LinkedIn exports."""

--- a/backend/src/hiresense/network/api/__init__.py
+++ b/backend/src/hiresense/network/api/__init__.py
@@ -1,0 +1,3 @@
+from hiresense.network.api.routes import router
+
+__all__ = ["router"]

--- a/backend/src/hiresense/network/api/dependencies.py
+++ b/backend/src/hiresense/network/api/dependencies.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from fastapi import Request
+
+from hiresense.network.domain import NetworkImportService
+from hiresense.network.ports import ContactsRepositoryPort
+
+
+def _provider(request: Request):
+    return getattr(request.app.state, "network", None)
+
+
+def get_import_service(request: Request) -> NetworkImportService | None:
+    provider = _provider(request)
+    return provider.get_import_service() if provider else None
+
+
+def get_contacts_repository(request: Request) -> ContactsRepositoryPort | None:
+    provider = _provider(request)
+    return provider.get_repository() if provider else None

--- a/backend/src/hiresense/network/api/provider.py
+++ b/backend/src/hiresense/network/api/provider.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from hiresense.network.domain import NetworkImportService
+from hiresense.network.ports import ContactsRepositoryPort
+
+
+class NetworkProvider:
+    def __init__(
+        self,
+        import_service: NetworkImportService,
+        repository: ContactsRepositoryPort,
+    ) -> None:
+        self._import_service = import_service
+        self._repository = repository
+
+    def get_import_service(self) -> NetworkImportService:
+        return self._import_service
+
+    def get_repository(self) -> ContactsRepositoryPort:
+        return self._repository

--- a/backend/src/hiresense/network/api/routes.py
+++ b/backend/src/hiresense/network/api/routes.py
@@ -81,14 +81,14 @@ async def import_connections(
     max_bytes = request.app.state.settings.max_upload_bytes
     if file.size and file.size > max_bytes:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"File too large. Maximum size: {max_bytes // (1024 * 1024)} MB",
         )
 
     file_bytes = await file.read()
     if len(file_bytes) > max_bytes:
         raise HTTPException(
-            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
             detail=f"File too large. Maximum size: {max_bytes // (1024 * 1024)} MB",
         )
 

--- a/backend/src/hiresense/network/api/routes.py
+++ b/backend/src/hiresense/network/api/routes.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
+from pydantic import BaseModel
+
+from hiresense.identity.api.dependencies import require_auth
+from hiresense.network.api.dependencies import get_contacts_repository, get_import_service
+from hiresense.network.domain import (
+    ConnectionsParseError,
+    Contact,
+    NetworkImportService,
+    normalize_company,
+)
+from hiresense.network.ports import ContactsRepositoryPort
+
+router = APIRouter(
+    prefix="/network",
+    tags=["network"],
+    dependencies=[Depends(require_auth)],
+)
+
+_ALLOWED_EXTENSIONS = {".zip", ".csv"}
+_ZIP_MAGIC = b"PK\x03\x04"
+
+
+class ImportResponse(BaseModel):
+    contacts: int
+    imported_at: str | None
+
+
+class ContactsResponse(BaseModel):
+    contacts: list[Contact]
+
+
+class MatchResponse(BaseModel):
+    company_normalized: str
+    contacts: list[Contact]
+
+
+def _validate_upload_content(ext: str, file_bytes: bytes) -> None:
+    """Cheap content sniffing so the declared extension matches the payload."""
+    if ext == ".zip" and not file_bytes.startswith(_ZIP_MAGIC):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="File content does not match the .zip extension",
+        )
+    if ext == ".csv":
+        try:
+            file_bytes.decode("utf-8-sig")
+        except UnicodeDecodeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="File content is not valid UTF-8 text for a .csv upload",
+            ) from exc
+
+
+@router.post("/import", response_model=ImportResponse)
+async def import_connections(
+    request: Request,
+    service: Annotated[NetworkImportService | None, Depends(get_import_service)],
+    file: UploadFile = File(...),
+) -> ImportResponse:
+    if service is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Network module is not available",
+        )
+
+    filename = file.filename or "unknown"
+    ext = Path(filename).suffix.lower()
+    if ext not in _ALLOWED_EXTENSIONS:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Unsupported file type: {ext}. Allowed: {', '.join(_ALLOWED_EXTENSIONS)}",
+        )
+
+    max_bytes = request.app.state.settings.max_upload_bytes
+    if file.size and file.size > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {max_bytes // (1024 * 1024)} MB",
+        )
+
+    file_bytes = await file.read()
+    if len(file_bytes) > max_bytes:
+        raise HTTPException(
+            status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
+            detail=f"File too large. Maximum size: {max_bytes // (1024 * 1024)} MB",
+        )
+
+    _validate_upload_content(ext, file_bytes)
+
+    try:
+        count = await service.import_upload(file_bytes, filename=filename)
+    except ConnectionsParseError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+
+    last = await service.last_imported_at()
+    return ImportResponse(
+        contacts=count,
+        imported_at=last.isoformat() if last is not None else None,
+    )
+
+
+@router.get("/contacts", response_model=ContactsResponse)
+async def list_contacts(
+    repository: Annotated[ContactsRepositoryPort | None, Depends(get_contacts_repository)],
+    company: str | None = None,
+) -> ContactsResponse:
+    if repository is None:
+        return ContactsResponse(contacts=[])
+    contacts = await asyncio.to_thread(repository.list_all, company)
+    return ContactsResponse(contacts=contacts)
+
+
+@router.get("/match", response_model=MatchResponse)
+async def match_contacts(
+    repository: Annotated[ContactsRepositoryPort | None, Depends(get_contacts_repository)],
+    company: str,
+) -> MatchResponse:
+    normalized = normalize_company(company)
+    if repository is None:
+        return MatchResponse(company_normalized=normalized, contacts=[])
+    contacts = await asyncio.to_thread(repository.find_by_company, normalized)
+    return MatchResponse(company_normalized=normalized, contacts=contacts)

--- a/backend/src/hiresense/network/domain/__init__.py
+++ b/backend/src/hiresense/network/domain/__init__.py
@@ -1,0 +1,4 @@
+from hiresense.network.domain.company_normalization import normalize_company
+from hiresense.network.domain.contact import Contact
+
+__all__ = ["Contact", "normalize_company"]

--- a/backend/src/hiresense/network/domain/__init__.py
+++ b/backend/src/hiresense/network/domain/__init__.py
@@ -1,4 +1,8 @@
 from hiresense.network.domain.company_normalization import normalize_company
+from hiresense.network.domain.connections_parser import (
+    ConnectionsParseError,
+    parse_connections,
+)
 from hiresense.network.domain.contact import Contact
 
-__all__ = ["Contact", "normalize_company"]
+__all__ = ["Contact", "ConnectionsParseError", "normalize_company", "parse_connections"]

--- a/backend/src/hiresense/network/domain/__init__.py
+++ b/backend/src/hiresense/network/domain/__init__.py
@@ -4,5 +4,12 @@ from hiresense.network.domain.connections_parser import (
     parse_connections,
 )
 from hiresense.network.domain.contact import Contact
+from hiresense.network.domain.import_service import NetworkImportService
 
-__all__ = ["Contact", "ConnectionsParseError", "normalize_company", "parse_connections"]
+__all__ = [
+    "Contact",
+    "ConnectionsParseError",
+    "NetworkImportService",
+    "normalize_company",
+    "parse_connections",
+]

--- a/backend/src/hiresense/network/domain/company_normalization.py
+++ b/backend/src/hiresense/network/domain/company_normalization.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import re
+
+# Legal-suffix tokens stripped from the END of company names, repeatedly
+# ("Acme Holdings Inc." -> "acme holdings"). Lowercase, dot-free forms.
+_LEGAL_SUFFIXES = frozenset(
+    {
+        "inc", "incorporated", "llc", "llp", "ltd", "limited", "corp",
+        "corporation", "co", "company", "gmbh", "sa", "sas", "srl", "sl",
+        "bv", "ag", "plc", "sa de cv", "cv", "de", "s", "a", "c", "v",
+    }
+)
+_PARENS_RE = re.compile(r"\([^)]*\)")
+_NON_WORD_RE = re.compile(r"[^a-z0-9 ]+")
+_SPACES_RE = re.compile(r"\s+")
+
+
+def normalize_company(raw: str) -> str:
+    """Canonical company key for matching contacts to job postings.
+
+    Lowercases, drops parentheticals and punctuation, collapses whitespace,
+    and strips trailing legal suffixes (inc/llc/s.a./gmbh/...).
+    """
+    text = _PARENS_RE.sub(" ", raw.lower())
+    text = _NON_WORD_RE.sub(" ", text)
+    text = _SPACES_RE.sub(" ", text).strip()
+    words = text.split(" ") if text else []
+    while words and words[-1] in _LEGAL_SUFFIXES:
+        words.pop()
+    return " ".join(words)

--- a/backend/src/hiresense/network/domain/company_normalization.py
+++ b/backend/src/hiresense/network/domain/company_normalization.py
@@ -4,12 +4,22 @@ import re
 
 # Legal-suffix tokens stripped from the END of company names, repeatedly
 # ("Acme Holdings Inc." -> "acme holdings"). Lowercase, dot-free forms.
+# Single letters are deliberately NOT in this set — "Studio C", "Plan A",
+# "Tesla Model S" must survive; dotted acronyms (S.A., C.V., ...) are
+# handled by _DOTTED_SUFFIX_RE while the dots still exist.
 _LEGAL_SUFFIXES = frozenset(
     {
         "inc", "incorporated", "llc", "llp", "ltd", "limited", "corp",
         "corporation", "co", "company", "gmbh", "sa", "sas", "srl", "sl",
-        "bv", "ag", "plc", "sa de cv", "cv", "de", "s", "a", "c", "v",
+        "bv", "ag", "plc", "cv",
     }
+)
+# Dotted legal-acronym suffixes ("Globant S.A.", "... S.A. de C.V.") removed
+# BEFORE punctuation stripping, so the dots disambiguate them from real
+# single-letter words in company names.
+_DOTTED_SUFFIX_RE = re.compile(
+    r"\b(s\.a\.\s+de\s+c\.v\.|s\.a\.s?\.?|s\.r\.l\.|s\.l\.|b\.v\.|a\.g\.|p\.l\.c\.|c\.v\.)\s*$",
+    re.IGNORECASE,
 )
 _PARENS_RE = re.compile(r"\([^)]*\)")
 _NON_WORD_RE = re.compile(r"[^a-z0-9 ]+")
@@ -23,6 +33,8 @@ def normalize_company(raw: str) -> str:
     and strips trailing legal suffixes (inc/llc/s.a./gmbh/...).
     """
     text = _PARENS_RE.sub(" ", raw.lower())
+    for _ in range(2):
+        text = _DOTTED_SUFFIX_RE.sub(" ", text)
     text = _NON_WORD_RE.sub(" ", text)
     text = _SPACES_RE.sub(" ", text).strip()
     words = text.split(" ") if text else []

--- a/backend/src/hiresense/network/domain/connections_parser.py
+++ b/backend/src/hiresense/network/domain/connections_parser.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import csv
+import io
+import zipfile
+
+from hiresense.network.domain.contact import Contact
+
+_EXPECTED_COLUMNS = {"First Name", "Last Name", "Company", "Position"}
+_ZIP_MAGIC = b"PK\x03\x04"
+
+
+class ConnectionsParseError(ValueError):
+    """Raised when the upload is not a parseable LinkedIn connections export."""
+
+
+def parse_connections(payload: bytes, *, filename: str) -> list[Contact]:
+    """Parse LinkedIn `Connections.csv` content — given directly or inside the
+    data-export ZIP. Tolerates LinkedIn's "Notes:" preamble before the header."""
+    if payload.startswith(_ZIP_MAGIC):
+        payload = _extract_connections_member(payload)
+    return _parse_csv(payload)
+
+
+def _extract_connections_member(payload: bytes) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        for name in archive.namelist():
+            if name.rsplit("/", 1)[-1].lower() == "connections.csv":
+                return archive.read(name)
+    raise ConnectionsParseError("ZIP does not contain a Connections.csv")
+
+
+def _parse_csv(payload: bytes) -> list[Contact]:
+    text = payload.decode("utf-8-sig", errors="replace")
+    lines = text.splitlines()
+    header_index = next(
+        (i for i, line in enumerate(lines) if line.startswith("First Name,")), None
+    )
+    if header_index is None:
+        raise ConnectionsParseError("No connections header row found")
+    reader = csv.DictReader(io.StringIO("\n".join(lines[header_index:])))
+    if not _EXPECTED_COLUMNS.issubset(set(reader.fieldnames or [])):
+        raise ConnectionsParseError("Connections header is missing expected columns")
+    contacts: list[Contact] = []
+    for row in reader:
+        first = (row.get("First Name") or "").strip()
+        last = (row.get("Last Name") or "").strip()
+        if not first and not last:
+            continue  # blank padding rows in real exports
+        contacts.append(
+            Contact(
+                first_name=first,
+                last_name=last,
+                company=(row.get("Company") or "").strip(),
+                position=(row.get("Position") or "").strip(),
+                linkedin_url=(row.get("URL") or "").strip() or None,
+                email=(row.get("Email Address") or "").strip() or None,
+                connected_on=(row.get("Connected On") or "").strip() or None,
+            )
+        )
+    return contacts

--- a/backend/src/hiresense/network/domain/connections_parser.py
+++ b/backend/src/hiresense/network/domain/connections_parser.py
@@ -22,10 +22,21 @@ def parse_connections(payload: bytes, *, filename: str) -> list[Contact]:
     return _parse_csv(payload)
 
 
+# Decompressed-size ceiling for the Connections.csv member. The route caps
+# the COMPRESSED upload; a crafted ZIP could still expand enormously in
+# memory without this gate (zip bomb). Real LinkedIn exports are far smaller.
+_MAX_MEMBER_BYTES = 50 * 1024 * 1024
+
+
 def _extract_connections_member(payload: bytes) -> bytes:
     with zipfile.ZipFile(io.BytesIO(payload)) as archive:
         for name in archive.namelist():
             if name.rsplit("/", 1)[-1].lower() == "connections.csv":
+                info = archive.getinfo(name)
+                if info.file_size > _MAX_MEMBER_BYTES:
+                    raise ConnectionsParseError(
+                        "Connections.csv decompresses beyond the allowed size"
+                    )
                 return archive.read(name)
     raise ConnectionsParseError("ZIP does not contain a Connections.csv")
 

--- a/backend/src/hiresense/network/domain/contact.py
+++ b/backend/src/hiresense/network/domain/contact.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, model_validator
+
+from hiresense.network.domain.company_normalization import normalize_company
+
+
+class Contact(BaseModel):
+    """One LinkedIn connection. company_normalized is derived, never set by hand."""
+
+    first_name: str
+    last_name: str
+    company: str = ""
+    position: str = ""
+    linkedin_url: str | None = None
+    email: str | None = None
+    connected_on: str | None = None
+    company_normalized: str = ""
+
+    @model_validator(mode="after")
+    def _derive_company_normalized(self) -> "Contact":
+        object.__setattr__(self, "company_normalized", normalize_company(self.company))
+        return self

--- a/backend/src/hiresense/network/domain/contact.py
+++ b/backend/src/hiresense/network/domain/contact.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from hiresense.network.domain.company_normalization import normalize_company
 
 
 class Contact(BaseModel):
     """One LinkedIn connection. company_normalized is derived, never set by hand."""
+
+    model_config = ConfigDict(frozen=True)
 
     first_name: str
     last_name: str

--- a/backend/src/hiresense/network/domain/import_service.py
+++ b/backend/src/hiresense/network/domain/import_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from hiresense.network.domain.connections_parser import parse_connections
+
+if TYPE_CHECKING:
+    from hiresense.network.ports import ContactsRepositoryPort
+
+
+class NetworkImportService:
+    """Parses a LinkedIn export upload and replaces the contacts snapshot."""
+
+    def __init__(self, repository: "ContactsRepositoryPort") -> None:
+        self._repository = repository
+
+    async def import_upload(self, payload: bytes, *, filename: str) -> int:
+        contacts = parse_connections(payload, filename=filename)
+        return await asyncio.to_thread(self._repository.replace_all, contacts)
+
+    async def last_imported_at(self) -> datetime | None:
+        return await asyncio.to_thread(self._repository.last_imported_at)

--- a/backend/src/hiresense/network/infrastructure/__init__.py
+++ b/backend/src/hiresense/network/infrastructure/__init__.py
@@ -1,0 +1,4 @@
+from hiresense.network.infrastructure.orm import NetworkContactOrm
+from hiresense.network.infrastructure.repository import ContactsRepository
+
+__all__ = ["ContactsRepository", "NetworkContactOrm"]

--- a/backend/src/hiresense/network/infrastructure/orm.py
+++ b/backend/src/hiresense/network/infrastructure/orm.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from hiresense.infrastructure.database import Base
+
+
+class NetworkContactOrm(Base):
+    """One imported LinkedIn connection (full-snapshot replacement model)."""
+
+    __tablename__ = "network_contacts"
+    __table_args__ = (
+        Index("ix_network_contacts_company_normalized", "company_normalized"),
+    )
+
+    id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    first_name: Mapped[str] = mapped_column(String(256), nullable=False)
+    last_name: Mapped[str] = mapped_column(String(256), nullable=False)
+    company: Mapped[str] = mapped_column(String(512), nullable=False, default="")
+    position: Mapped[str] = mapped_column(String(512), nullable=False, default="")
+    company_normalized: Mapped[str] = mapped_column(String(512), nullable=False)
+    linkedin_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    email: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    connected_on: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    imported_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/src/hiresense/network/infrastructure/repository.py
+++ b/backend/src/hiresense/network/infrastructure/repository.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import delete, func, select
+
+from hiresense.network.domain import Contact, normalize_company
+from hiresense.network.infrastructure.orm import NetworkContactOrm
+
+
+def _to_orm(contact: Contact, imported_at: datetime) -> NetworkContactOrm:
+    return NetworkContactOrm(
+        id=str(uuid.uuid4()),
+        first_name=contact.first_name,
+        last_name=contact.last_name,
+        company=contact.company,
+        position=contact.position,
+        company_normalized=contact.company_normalized,
+        linkedin_url=contact.linkedin_url,
+        email=contact.email,
+        connected_on=contact.connected_on,
+        imported_at=imported_at,
+    )
+
+
+def _to_domain(row: NetworkContactOrm) -> Contact:
+    return Contact(
+        first_name=row.first_name,
+        last_name=row.last_name,
+        company=row.company,
+        position=row.position,
+        linkedin_url=row.linkedin_url,
+        email=row.email,
+        connected_on=row.connected_on,
+    )
+
+
+class ContactsRepository:
+    """SQL snapshot store; replace_all is atomic — one full export replaces the previous."""
+
+    def __init__(self, session_factory: Any) -> None:
+        self._session_factory = session_factory
+
+    def replace_all(self, contacts: list[Contact]) -> int:
+        now = datetime.now(timezone.utc)
+        with self._session_factory() as session:
+            session.execute(delete(NetworkContactOrm))
+            for contact in contacts:
+                session.add(_to_orm(contact, now))
+            session.commit()
+        return len(contacts)
+
+    def list_all(self, company: str | None = None) -> list[Contact]:
+        with self._session_factory() as session:
+            stmt = select(NetworkContactOrm)
+            if company is not None:
+                key = normalize_company(company)
+                stmt = stmt.where(NetworkContactOrm.company_normalized == key)
+            rows = session.scalars(stmt).all()
+            return [_to_domain(r) for r in rows]
+
+    def find_by_company(self, company_normalized: str) -> list[Contact]:
+        with self._session_factory() as session:
+            rows = session.scalars(
+                select(NetworkContactOrm).where(
+                    NetworkContactOrm.company_normalized == company_normalized
+                )
+            ).all()
+            return [_to_domain(r) for r in rows]
+
+    def count_by_companies(self, companies_normalized: list[str]) -> dict[str, int]:
+        if not companies_normalized:
+            return {}
+        with self._session_factory() as session:
+            rows = session.execute(
+                select(
+                    NetworkContactOrm.company_normalized,
+                    func.count(NetworkContactOrm.id),
+                )
+                .where(NetworkContactOrm.company_normalized.in_(companies_normalized))
+                .group_by(NetworkContactOrm.company_normalized)
+            ).all()
+            return {key: count for key, count in rows}
+
+    def last_imported_at(self) -> datetime | None:
+        with self._session_factory() as session:
+            return session.scalar(select(func.max(NetworkContactOrm.imported_at)))

--- a/backend/src/hiresense/network/ports/__init__.py
+++ b/backend/src/hiresense/network/ports/__init__.py
@@ -1,0 +1,3 @@
+from hiresense.network.ports.contacts_repository import ContactsRepositoryPort
+
+__all__ = ["ContactsRepositoryPort"]

--- a/backend/src/hiresense/network/ports/contacts_repository.py
+++ b/backend/src/hiresense/network/ports/contacts_repository.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Protocol
+
+from hiresense.network.domain import Contact
+
+
+class ContactsRepositoryPort(Protocol):
+    """Snapshot store for imported LinkedIn connections."""
+
+    def replace_all(self, contacts: list[Contact]) -> int:
+        """Replace the whole snapshot (imports are full exports); returns count."""
+        ...
+
+    def list_all(self, company: str | None = None) -> list[Contact]:
+        """All contacts, optionally filtered by normalized company match."""
+        ...
+
+    def find_by_company(self, company_normalized: str) -> list[Contact]: ...
+
+    def count_by_companies(self, companies_normalized: list[str]) -> dict[str, int]:
+        """Counts per normalized-company key; keys with zero matches are absent."""
+        ...
+
+    def last_imported_at(self) -> datetime | None: ...

--- a/backend/tests/unit/ingestion/test_jobs_connections_badge.py
+++ b/backend/tests/unit/ingestion/test_jobs_connections_badge.py
@@ -1,0 +1,154 @@
+"""Tests for the "You know someone here" connections badge on the jobs list.
+
+Task 5, Phase 4 — connections count on the jobs list (backend).
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from hiresense.identity.api.dependencies import require_auth
+from hiresense.ingestion.api import get_ingestion_orchestrator, get_portal_scanner, router
+from hiresense.ingestion.api.dependencies import get_semantic_scoring
+from hiresense.ingestion.domain.models import NormalizedJob
+from hiresense.network.api.dependencies import get_contacts_repository
+from hiresense.profile.api.dependencies import get_profile_service
+
+
+class FakeProfileService:
+    async def list_profiles(self):
+        return []
+
+
+ACME_JOB = NormalizedJob(
+    id="acme-1",
+    title="Backend Engineer",
+    company="Acme Inc.",
+    description="Backend role at Acme",
+    skills=["python"],
+    location="Remote",
+    source="remotive",
+    source_type="api",
+    language="en",
+    url="https://example.com/acme",
+)
+
+OTHER_JOB = NormalizedJob(
+    id="other-1",
+    title="Frontend Engineer",
+    company="Other Corp",
+    description="Frontend role at Other",
+    skills=["javascript"],
+    location="Remote",
+    source="remotive",
+    source_type="api",
+    language="en",
+    url="https://example.com/other",
+)
+
+
+class FakeOrchestrator:
+    def list_jobs(self, criteria=None) -> list[NormalizedJob]:
+        return [ACME_JOB, OTHER_JOB]
+
+    async def run(self, filters=None) -> list[NormalizedJob]:
+        return []
+
+    def persist_scores(self, job_id, match_score, semantic_score) -> None:
+        pass
+
+    def persist_scores_batch(self, updates) -> None:
+        pass
+
+
+class FakeScanner:
+    def list_jobs(self, criteria=None) -> list[NormalizedJob]:
+        return []
+
+    def get_job_by_id(self, job_id):
+        return None
+
+    def persist_scores(self, job_id, match_score, semantic_score) -> None:
+        pass
+
+    def persist_scores_batch(self, updates) -> None:
+        pass
+
+
+class FakeContactsRepository:
+    """Fake ContactsRepositoryPort: always returns 2 connections for 'acme'."""
+
+    def count_by_companies(self, companies_normalized: list[str]) -> dict[str, int]:
+        result = {}
+        for key in companies_normalized:
+            if key == "acme":
+                result[key] = 2
+        return result
+
+    def replace_all(self, contacts):
+        return 0
+
+    def list_all(self, company=None):
+        return []
+
+    def find_by_company(self, company_normalized):
+        return []
+
+    def last_imported_at(self):
+        return None
+
+
+def _make_app_with_network() -> FastAPI:
+    """App wired with a fake contacts repository."""
+    app = FastAPI()
+    app.dependency_overrides[get_ingestion_orchestrator] = lambda: FakeOrchestrator()
+    app.dependency_overrides[get_portal_scanner] = lambda: FakeScanner()
+    app.dependency_overrides[get_profile_service] = lambda: FakeProfileService()
+    app.dependency_overrides[get_semantic_scoring] = lambda: None
+    app.dependency_overrides[get_contacts_repository] = lambda: FakeContactsRepository()
+    app.dependency_overrides[require_auth] = lambda: "test-user"
+    app.include_router(router)
+    return app
+
+
+def _make_app_without_network() -> FastAPI:
+    """Bare app — no contacts repository override (dependency returns None)."""
+    app = FastAPI()
+    app.dependency_overrides[get_ingestion_orchestrator] = lambda: FakeOrchestrator()
+    app.dependency_overrides[get_portal_scanner] = lambda: FakeScanner()
+    app.dependency_overrides[get_profile_service] = lambda: FakeProfileService()
+    app.dependency_overrides[get_semantic_scoring] = lambda: None
+    # No get_contacts_repository override — returns None via bare app.state
+    app.dependency_overrides[require_auth] = lambda: "test-user"
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_connections_badge_populated_for_matching_company() -> None:
+    """Page containing Acme Inc. and Other Corp: only Acme job gets a badge."""
+    app = _make_app_with_network()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/ingestion/jobs?tab=boards")
+
+    assert resp.status_code == 200
+    data = resp.json()
+
+    connections = data["connections_by_job"]
+    # Acme Inc. normalizes to "acme" → count 2
+    assert connections.get("acme-1") == 2
+    # Other Corp has no connections → absent from the dict
+    assert "other-1" not in connections
+
+
+@pytest.mark.asyncio
+async def test_connections_badge_empty_without_network_module() -> None:
+    """When no contacts repository is wired, connections_by_job is empty and request succeeds."""
+    app = _make_app_without_network()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        resp = await client.get("/ingestion/jobs?tab=boards")
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["connections_by_job"] == {}

--- a/backend/tests/unit/network/test_company_normalization.py
+++ b/backend/tests/unit/network/test_company_normalization.py
@@ -15,6 +15,9 @@ from hiresense.network.domain import normalize_company
         ("Thoughtworks Ltd", "thoughtworks"),
         ("Siemens GmbH", "siemens"),
         ("MixRank (YC S11)", "mixrank"),
+        ("Studio C", "studio c"),
+        ("Plan A", "plan a"),
+        ("Tesla Model S", "tesla model s"),
         ("", ""),
     ],
 )

--- a/backend/tests/unit/network/test_company_normalization.py
+++ b/backend/tests/unit/network/test_company_normalization.py
@@ -1,0 +1,22 @@
+import pytest
+
+from hiresense.network.domain import normalize_company
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Acme Inc.", "acme"),
+        ("ACME, LLC", "acme"),
+        ("Globant S.A.", "globant"),
+        ("Mercado Libre S.A. de C.V.", "mercado libre"),
+        ("Stripe", "stripe"),
+        ("  Banco   Guayaquil  ", "banco guayaquil"),
+        ("Thoughtworks Ltd", "thoughtworks"),
+        ("Siemens GmbH", "siemens"),
+        ("MixRank (YC S11)", "mixrank"),
+        ("", ""),
+    ],
+)
+def test_normalize_company(raw: str, expected: str) -> None:
+    assert normalize_company(raw) == expected

--- a/backend/tests/unit/network/test_connections_parser.py
+++ b/backend/tests/unit/network/test_connections_parser.py
@@ -53,3 +53,14 @@ def test_zip_without_connections_raises() -> None:
 def test_csv_without_header_raises() -> None:
     with pytest.raises(ConnectionsParseError, match="header"):
         parse_connections(b"not,a,connections,file\n1,2,3,4\n", filename="x.csv")
+
+
+def test_zip_member_decompression_ceiling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "hiresense.network.domain.connections_parser._MAX_MEMBER_BYTES", 64
+    )
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("Connections.csv", _HEADER + "\n" + "a,b,,,c,d,e\n" * 100)
+    with pytest.raises(ConnectionsParseError, match="decompresses beyond"):
+        parse_connections(buffer.getvalue(), filename="export.zip")

--- a/backend/tests/unit/network/test_connections_parser.py
+++ b/backend/tests/unit/network/test_connections_parser.py
@@ -1,0 +1,55 @@
+import io
+import zipfile
+
+import pytest
+
+from hiresense.network.domain import ConnectionsParseError, parse_connections
+
+_HEADER = "First Name,Last Name,URL,Email Address,Company,Position,Connected On"
+_ROWS = (
+    'Jordan,Lee,https://www.linkedin.com/in/jlee,,Acme Inc.,Engineering Manager,01 Feb 2025\n'
+    'Sam,Diaz,,sam@x.dev,Globant S.A.,Recruiter,15 Mar 2024\n'
+    ',,,,,,\n'  # fully empty row is skipped
+)
+_PREAMBLE = (
+    '"Notes:\nWhen exporting your connection data, you may notice missing emails."\n\n'
+)
+
+
+def _csv_bytes(*, preamble: bool) -> bytes:
+    return ((_PREAMBLE if preamble else "") + _HEADER + "\n" + _ROWS).encode("utf-8")
+
+
+def test_parses_plain_csv_with_preamble() -> None:
+    contacts = parse_connections(_csv_bytes(preamble=True), filename="Connections.csv")
+    assert len(contacts) == 2
+    assert contacts[0].first_name == "Jordan"
+    assert contacts[0].company_normalized == "acme"
+    assert contacts[1].email == "sam@x.dev"
+    assert contacts[1].connected_on == "15 Mar 2024"
+
+
+def test_parses_csv_without_preamble() -> None:
+    assert len(parse_connections(_csv_bytes(preamble=False), filename="x.csv")) == 2
+
+
+def test_parses_zip_export() -> None:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("Basic_LinkedInDataExport/Connections.csv", _csv_bytes(preamble=True))
+        archive.writestr("Basic_LinkedInDataExport/Skills.csv", "Name\nPython\n")
+    contacts = parse_connections(buffer.getvalue(), filename="export.zip")
+    assert len(contacts) == 2
+
+
+def test_zip_without_connections_raises() -> None:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("Skills.csv", "Name\nPython\n")
+    with pytest.raises(ConnectionsParseError, match="Connections.csv"):
+        parse_connections(buffer.getvalue(), filename="export.zip")
+
+
+def test_csv_without_header_raises() -> None:
+    with pytest.raises(ConnectionsParseError, match="header"):
+        parse_connections(b"not,a,connections,file\n1,2,3,4\n", filename="x.csv")

--- a/backend/tests/unit/network/test_contact.py
+++ b/backend/tests/unit/network/test_contact.py
@@ -1,0 +1,14 @@
+from hiresense.network.domain import Contact
+
+
+def test_contact_normalizes_company_on_construction() -> None:
+    contact = Contact(
+        first_name="Jordan", last_name="Lee", company="Acme Inc.", position="EM"
+    )
+    assert contact.company_normalized == "acme"
+    assert contact.linkedin_url is None
+    assert contact.email is None
+
+
+def test_contact_empty_company_normalizes_empty() -> None:
+    assert Contact(first_name="A", last_name="B", company="").company_normalized == ""

--- a/backend/tests/unit/network/test_contacts_repository.py
+++ b/backend/tests/unit/network/test_contacts_repository.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from hiresense.infrastructure.database import Base
+from hiresense.network.infrastructure import ContactsRepository, NetworkContactOrm  # noqa: F401 (registers table)
+
+
+@pytest.fixture
+def repo():
+    engine = create_engine(
+        "sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool
+    )
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, expire_on_commit=False)
+    yield ContactsRepository(session_factory=factory)
+    Base.metadata.drop_all(engine)
+
+
+def _contact(first: str, last: str, company: str, position: str = "Engineer"):
+    from hiresense.network.domain import Contact
+
+    return Contact(first_name=first, last_name=last, company=company, position=position)
+
+
+def test_replace_all_inserts_and_lists_roundtrip(repo) -> None:
+    contacts = [
+        _contact("Jordan", "Lee", "Acme Inc."),
+        _contact("Sam", "Diaz", "Globant S.A."),
+    ]
+    count = repo.replace_all(contacts)
+    assert count == 2
+    stored = repo.list_all()
+    assert len(stored) == 2
+    first_names = {c.first_name for c in stored}
+    assert first_names == {"Jordan", "Sam"}
+
+
+def test_replace_all_twice_keeps_only_second_snapshot(repo) -> None:
+    repo.replace_all([_contact("Jordan", "Lee", "Acme Inc.")])
+    count = repo.replace_all(
+        [
+            _contact("Sam", "Diaz", "Globant S.A."),
+            _contact("Alex", "Ruiz", "Globant S.A.", "PM"),
+        ]
+    )
+    assert count == 2
+    stored = repo.list_all()
+    assert len(stored) == 2
+    assert {c.first_name for c in stored} == {"Sam", "Alex"}
+
+
+def test_list_all_with_company_filter_matches_normalized(repo) -> None:
+    repo.replace_all(
+        [
+            _contact("Jordan", "Lee", "Acme Inc."),
+            _contact("Sam", "Diaz", "Globant S.A."),
+        ]
+    )
+    # "ACME" normalizes to "acme"; "Acme Inc." also normalizes to "acme"
+    results = repo.list_all(company="ACME")
+    assert len(results) == 1
+    assert results[0].first_name == "Jordan"
+
+
+def test_find_by_company_normalized(repo) -> None:
+    repo.replace_all(
+        [
+            _contact("Jordan", "Lee", "Acme Inc."),
+            _contact("Sam", "Diaz", "Globant S.A."),
+        ]
+    )
+    results = repo.find_by_company("acme")
+    assert len(results) == 1
+    assert results[0].first_name == "Jordan"
+
+
+def test_count_by_companies_returns_counts_and_omits_missing(repo) -> None:
+    repo.replace_all(
+        [
+            _contact("Jordan", "Lee", "Acme Inc."),
+            _contact("Sam", "Diaz", "Acme Inc."),
+            _contact("Alex", "Ruiz", "Globant S.A."),
+        ]
+    )
+    counts = repo.count_by_companies(["acme", "globant", "missing"])
+    assert counts == {"acme": 2, "globant": 1}
+
+
+def test_count_by_companies_empty_list_returns_empty_dict(repo) -> None:
+    repo.replace_all([_contact("Jordan", "Lee", "Acme Inc.")])
+    assert repo.count_by_companies([]) == {}
+
+
+def test_last_imported_at_none_then_set(repo) -> None:
+    assert repo.last_imported_at() is None
+    repo.replace_all([_contact("Jordan", "Lee", "Acme Inc.")])
+    result = repo.last_imported_at()
+    assert isinstance(result, datetime)

--- a/backend/tests/unit/network/test_import_service.py
+++ b/backend/tests/unit/network/test_import_service.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hiresense.network.domain import ConnectionsParseError, Contact, NetworkImportService
+
+_HEADER = "First Name,Last Name,URL,Email Address,Company,Position,Connected On"
+_ROWS = "Jordan,Lee,https://www.linkedin.com/in/jlee,,Acme Inc.,Engineering Manager,01 Feb 2025\n"
+_CSV_BYTES = (_HEADER + "\n" + _ROWS).encode("utf-8")
+
+
+class _FakeRepo:
+    def __init__(self, contacts: list[Contact] | None = None) -> None:
+        self._contacts: list[Contact] = contacts or []
+        self.replaced: list[Contact] | None = None
+        self._imported_at = datetime.now(timezone.utc) if contacts else None
+
+    def replace_all(self, contacts: list[Contact]) -> int:
+        self.replaced = contacts
+        self._contacts = contacts
+        self._imported_at = datetime.now(timezone.utc)
+        return len(contacts)
+
+    def list_all(self, company: str | None = None) -> list[Contact]:
+        return self._contacts
+
+    def find_by_company(self, company_normalized: str) -> list[Contact]:
+        return [c for c in self._contacts if c.company_normalized == company_normalized]
+
+    def count_by_companies(self, companies_normalized: list[str]) -> dict[str, int]:
+        return {}
+
+    def last_imported_at(self) -> datetime | None:
+        return self._imported_at
+
+
+@pytest.mark.asyncio
+async def test_import_upload_happy_path() -> None:
+    repo = _FakeRepo()
+    service = NetworkImportService(repository=repo)
+
+    count = await service.import_upload(_CSV_BYTES, filename="Connections.csv")
+
+    assert count == 1
+    assert repo.replaced is not None
+    assert len(repo.replaced) == 1
+    assert repo.replaced[0].first_name == "Jordan"
+
+
+@pytest.mark.asyncio
+async def test_import_upload_propagates_parse_error() -> None:
+    repo = _FakeRepo()
+    service = NetworkImportService(repository=repo)
+
+    with pytest.raises(ConnectionsParseError):
+        await service.import_upload(b"not,a,connections,file\n1,2,3,4\n", filename="x.csv")
+
+
+@pytest.mark.asyncio
+async def test_last_imported_at_returns_none_initially() -> None:
+    repo = _FakeRepo()
+    service = NetworkImportService(repository=repo)
+
+    result = await service.last_imported_at()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_last_imported_at_returns_value_after_import() -> None:
+    repo = _FakeRepo()
+    service = NetworkImportService(repository=repo)
+
+    await service.import_upload(_CSV_BYTES, filename="Connections.csv")
+    result = await service.last_imported_at()
+
+    assert result is not None

--- a/backend/tests/unit/network/test_routes.py
+++ b/backend/tests/unit/network/test_routes.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import io
+import types
+import zipfile
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from hiresense.identity.api.dependencies import require_auth
+from hiresense.network.api import router
+from hiresense.network.api.dependencies import get_contacts_repository, get_import_service
+from hiresense.network.domain import Contact
+
+_HEADER = "First Name,Last Name,URL,Email Address,Company,Position,Connected On"
+_VALID_CSV = (_HEADER + "\nJordan,Lee,,sam@x.dev,Acme Inc.,EM,01 Feb 2025\n").encode("utf-8")
+
+
+class _FakeRepo:
+    def __init__(self, contacts: list[Contact] | None = None) -> None:
+        self._contacts: list[Contact] = contacts or []
+        self._imported_at: datetime | None = None
+
+    def replace_all(self, contacts: list[Contact]) -> int:
+        self._contacts = contacts
+        self._imported_at = datetime.now(timezone.utc)
+        return len(contacts)
+
+    def list_all(self, company: str | None = None) -> list[Contact]:
+        if company is not None:
+            from hiresense.network.domain import normalize_company
+
+            key = normalize_company(company)
+            return [c for c in self._contacts if c.company_normalized == key]
+        return list(self._contacts)
+
+    def find_by_company(self, company_normalized: str) -> list[Contact]:
+        return [c for c in self._contacts if c.company_normalized == company_normalized]
+
+    def count_by_companies(self, companies_normalized: list[str]) -> dict[str, int]:
+        return {}
+
+    def last_imported_at(self) -> datetime | None:
+        return self._imported_at
+
+
+class _FakeImportService:
+    def __init__(self, repo: _FakeRepo) -> None:
+        self._repo = repo
+
+    async def import_upload(self, payload: bytes, *, filename: str) -> int:
+        from hiresense.network.domain import parse_connections
+
+        contacts = parse_connections(payload, filename=filename)
+        return self._repo.replace_all(contacts)
+
+    async def last_imported_at(self) -> datetime | None:
+        return self._repo.last_imported_at()
+
+
+_SETTINGS = types.SimpleNamespace(max_upload_bytes=10 * 1024 * 1024)
+
+
+def _app(service=None, repo=None) -> FastAPI:
+    app = FastAPI()
+    app.state.settings = _SETTINGS
+    app.dependency_overrides[require_auth] = lambda: "test-user"
+    app.dependency_overrides[get_import_service] = lambda: service
+    app.dependency_overrides[get_contacts_repository] = lambda: repo
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_requires_auth_without_token() -> None:
+    app = FastAPI()
+    app.include_router(router)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        assert (await client.get("/network/contacts")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_import_happy_path() -> None:
+    repo = _FakeRepo()
+    svc = _FakeImportService(repo)
+    app = _app(service=svc, repo=repo)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/network/import",
+            files={"file": ("Connections.csv", _VALID_CSV, "text/csv")},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["contacts"] == 1
+    assert body["imported_at"] is not None
+    assert len(repo._contacts) == 1
+    assert repo._contacts[0].first_name == "Jordan"
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_wrong_extension() -> None:
+    repo = _FakeRepo()
+    svc = _FakeImportService(repo)
+    app = _app(service=svc, repo=repo)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/network/import",
+            files={"file": ("connections.txt", _VALID_CSV, "text/plain")},
+        )
+
+    assert resp.status_code == 400
+    assert "Unsupported file type" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_oversized() -> None:
+    repo = _FakeRepo()
+    svc = _FakeImportService(repo)
+    app = FastAPI()
+    app.state.settings = types.SimpleNamespace(max_upload_bytes=10)  # tiny limit
+    app.dependency_overrides[require_auth] = lambda: "test-user"
+    app.dependency_overrides[get_import_service] = lambda: svc
+    app.dependency_overrides[get_contacts_repository] = lambda: repo
+    app.include_router(router)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/network/import",
+            files={"file": ("Connections.csv", _VALID_CSV, "text/csv")},
+        )
+
+    assert resp.status_code == 413
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_zip_without_pk_magic() -> None:
+    repo = _FakeRepo()
+    svc = _FakeImportService(repo)
+    app = _app(service=svc, repo=repo)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/network/import",
+            files={"file": ("export.zip", b"this is not a zip file", "application/zip")},
+        )
+
+    assert resp.status_code == 400
+    assert "does not match" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_import_503_when_service_none() -> None:
+    app = _app(service=None, repo=None)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/network/import",
+            files={"file": ("Connections.csv", _VALID_CSV, "text/csv")},
+        )
+
+    assert resp.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_import_400_on_parse_error() -> None:
+    repo = _FakeRepo()
+    svc = _FakeImportService(repo)
+    app = _app(service=svc, repo=repo)
+
+    # Valid .csv extension but no connections header
+    bad_csv = b"not,a,connections,file\n1,2,3,4\n"
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/network/import",
+            files={"file": ("Connections.csv", bad_csv, "text/csv")},
+        )
+
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_contacts_with_repo() -> None:
+    contacts = [
+        Contact(first_name="Jordan", last_name="Lee", company="Acme Inc."),
+        Contact(first_name="Sam", last_name="Diaz", company="Globant S.A."),
+    ]
+    repo = _FakeRepo(contacts)
+    app = _app(repo=repo)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/network/contacts")
+
+    assert resp.status_code == 200
+    assert len(resp.json()["contacts"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_contacts_without_repo() -> None:
+    app = _app(repo=None)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/network/contacts")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"contacts": []}
+
+
+@pytest.mark.asyncio
+async def test_contacts_filtered_by_company() -> None:
+    contacts = [
+        Contact(first_name="Jordan", last_name="Lee", company="Acme Inc."),
+        Contact(first_name="Sam", last_name="Diaz", company="Globant S.A."),
+    ]
+    repo = _FakeRepo(contacts)
+    app = _app(repo=repo)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/network/contacts", params={"company": "Acme Inc."})
+
+    assert resp.status_code == 200
+    result = resp.json()["contacts"]
+    assert len(result) == 1
+    assert result[0]["first_name"] == "Jordan"
+
+
+@pytest.mark.asyncio
+async def test_match_normalizes_company_query() -> None:
+    """Contact stored under 'ACME, LLC' should be found via 'Acme Inc.' query."""
+    contacts = [
+        Contact(first_name="Jordan", last_name="Lee", company="ACME, LLC"),
+    ]
+    repo = _FakeRepo(contacts)
+    app = _app(repo=repo)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/network/match", params={"company": "Acme Inc."})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["company_normalized"] == "acme"
+    assert len(body["contacts"]) == 1
+    assert body["contacts"][0]["first_name"] == "Jordan"
+
+
+@pytest.mark.asyncio
+async def test_match_without_repo() -> None:
+    app = _app(repo=None)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.get("/network/match", params={"company": "Stripe"})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["company_normalized"] == "stripe"
+    assert body["contacts"] == []
+
+
+@pytest.mark.asyncio
+async def test_import_valid_zip_export() -> None:
+    """A proper ZIP containing Connections.csv is accepted and parsed."""
+    repo = _FakeRepo()
+    svc = _FakeImportService(repo)
+    app = _app(service=svc, repo=repo)
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as archive:
+        archive.writestr("Basic_LinkedInDataExport/Connections.csv", _VALID_CSV)
+    zip_bytes = buf.getvalue()
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/network/import",
+            files={"file": ("export.zip", zip_bytes, "application/zip")},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["contacts"] == 1

--- a/backend/tests/unit/test_app.py
+++ b/backend/tests/unit/test_app.py
@@ -78,3 +78,4 @@ async def test_all_routers_registered(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "/profile/upload" in routes
     assert "/portfolio/sync" in routes
     assert "/portfolio/projects" in routes
+    assert "/network/import" in routes

--- a/docs/superpowers/plans/2026-06-10-network-phase4-linkedin.md
+++ b/docs/superpowers/plans/2026-06-10-network-phase4-linkedin.md
@@ -1,0 +1,378 @@
+# Phase 4 (LinkedIn Network) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Import LinkedIn's `Connections.csv` (from the data-export ZIP) into a new `network` bounded context, and surface "you know someone at this company": a connections badge on the jobs list and contact suggestions on the outreach page.
+
+**Scope decision:** Part B of the spec has two halves. This PR ships the **high-value half** (connections → network context → badges + outreach suggestions). The Positions/Skills/Education → profile merge is deferred to its own follow-up: profiles are per-language CV-derived rows with no data-lineage tagging today, and bolting LinkedIn rows onto them without an origin model would make re-imports destructive. Recorded in the spec's terms — additive, idempotent merge needs the origin field design first.
+
+**Privacy invariant (from the spec):** contacts live only in the local DB and are NEVER injected into LLM prompts. Badges and matching are deterministic lookups. The only path into a prompt is the existing user-initiated `contact_name` field, which the user fills (suggestions just pre-fill the input).
+
+**Working directory:** `C:\Users\Bryan\worktrees\hiresense-portfolio` (branch `feat/network-linkedin`, stacked on `feat/portfolio-citation`; PR base = that branch). **Quirks:** `uv run python -m pytest` only; no repo-wide `ruff format`; CI runs `npx ng lint` (run it for frontend tasks); commits end with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+**Verified facts:**
+- LinkedIn `Connections.csv` columns: `First Name,Last Name,URL,Email Address,Company,Position,Connected On`. Real exports OFTEN begin with a "Notes:" preamble paragraph before the header — the parser must scan for the header line.
+- Upload hardening precedent: `profile/api/routes.py` (`_ALLOWED_EXTENSIONS`, size cap via `settings.max_upload_bytes`, magic-byte sniffing). ZIP magic: `PK\x03\x04`.
+- Latest migration: 026 → this PR creates **027**.
+- Jobs list: `PaginatedResult` (`ingestion/domain/job_filter.py:55`) — extend with an optional per-job map rather than touching `NormalizedJob`. Frontend rows: `pages/ingestion/ingestion.component.html` `@for (job of jobs(); ...)` with a company cell.
+- Outreach frontend: free-text `contact_name` input bound to a signal (`pages/outreach/outreach.component.*`); `GenerateRequest` model.
+- Module template: `autohunt`/`portfolio` (api/provider+dependencies+routes, domain one-class-per-file, infrastructure orm+repository, bootstrap builder, registry import).
+
+---
+
+### Task 1: Network domain — Contact + company normalization
+
+**Files:** create `backend/src/hiresense/network/__init__.py` (docstring), `network/domain/contact.py`, `network/domain/company_normalization.py`, `network/domain/__init__.py`; test `backend/tests/unit/network/__init__.py` (empty) + `test_company_normalization.py` + `test_contact.py`
+
+- [ ] **Step 1: failing tests.**
+
+`tests/unit/network/test_company_normalization.py`:
+
+```python
+import pytest
+
+from hiresense.network.domain import normalize_company
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("Acme Inc.", "acme"),
+        ("ACME, LLC", "acme"),
+        ("Globant S.A.", "globant"),
+        ("Mercado Libre S.A. de C.V.", "mercado libre"),
+        ("Stripe", "stripe"),
+        ("  Banco   Guayaquil  ", "banco guayaquil"),
+        ("Thoughtworks Ltd", "thoughtworks"),
+        ("Siemens GmbH", "siemens"),
+        ("MixRank (YC S11)", "mixrank"),
+        ("", ""),
+    ],
+)
+def test_normalize_company(raw: str, expected: str) -> None:
+    assert normalize_company(raw) == expected
+```
+
+`tests/unit/network/test_contact.py`:
+
+```python
+from hiresense.network.domain import Contact
+
+
+def test_contact_normalizes_company_on_construction() -> None:
+    contact = Contact(
+        first_name="Jordan", last_name="Lee", company="Acme Inc.", position="EM"
+    )
+    assert contact.company_normalized == "acme"
+    assert contact.linkedin_url is None
+    assert contact.email is None
+
+
+def test_contact_empty_company_normalizes_empty() -> None:
+    assert Contact(first_name="A", last_name="B", company="").company_normalized == ""
+```
+
+- [ ] **Step 2:** run `uv run python -m pytest tests/unit/network -q` → FAIL.
+
+- [ ] **Step 3: implement.**
+
+`network/__init__.py`: `"""Network bounded context — contacts imported from LinkedIn exports."""`
+
+`network/domain/company_normalization.py`:
+
+```python
+from __future__ import annotations
+
+import re
+
+# Legal-suffix tokens stripped from the END of company names, repeatedly
+# ("Acme Holdings Inc." -> "acme holdings"). Lowercase, dot-free forms.
+_LEGAL_SUFFIXES = frozenset(
+    {
+        "inc", "incorporated", "llc", "llp", "ltd", "limited", "corp",
+        "corporation", "co", "company", "gmbh", "sa", "sas", "srl", "sl",
+        "bv", "ag", "plc", "sa de cv", "cv", "de",
+    }
+)
+_PARENS_RE = re.compile(r"\([^)]*\)")
+_NON_WORD_RE = re.compile(r"[^a-z0-9 ]+")
+_SPACES_RE = re.compile(r"\s+")
+
+
+def normalize_company(raw: str) -> str:
+    """Canonical company key for matching contacts to job postings.
+
+    Lowercases, drops parentheticals and punctuation, collapses whitespace,
+    and strips trailing legal suffixes (inc/llc/s.a./gmbh/...).
+    """
+    text = _PARENS_RE.sub(" ", raw.lower())
+    text = _NON_WORD_RE.sub(" ", text)
+    text = _SPACES_RE.sub(" ", text).strip()
+    words = text.split(" ") if text else []
+    while words and words[-1] in _LEGAL_SUFFIXES:
+        words.pop()
+    return " ".join(words)
+```
+
+`network/domain/contact.py`:
+
+```python
+from __future__ import annotations
+
+from pydantic import BaseModel, model_validator
+
+from hiresense.network.domain.company_normalization import normalize_company
+
+
+class Contact(BaseModel):
+    """One LinkedIn connection. company_normalized is derived, never set by hand."""
+
+    first_name: str
+    last_name: str
+    company: str = ""
+    position: str = ""
+    linkedin_url: str | None = None
+    email: str | None = None
+    connected_on: str | None = None
+    company_normalized: str = ""
+
+    @model_validator(mode="after")
+    def _derive_company_normalized(self) -> "Contact":
+        object.__setattr__(self, "company_normalized", normalize_company(self.company))
+        return self
+```
+
+`network/domain/__init__.py` re-exports `Contact`, `normalize_company` with `__all__`.
+
+- [ ] **Step 4:** tests pass; `uv run ruff check src/hiresense/network tests/unit/network` clean.
+- [ ] **Step 5: commit** — `feat(network): contact model and company normalization`.
+
+---
+
+### Task 2: Connections parser (ZIP or CSV bytes → contacts)
+
+**Files:** create `backend/src/hiresense/network/domain/connections_parser.py`; modify `network/domain/__init__.py`; test `tests/unit/network/test_connections_parser.py`
+
+- [ ] **Step 1: failing tests:**
+
+```python
+import io
+import zipfile
+
+import pytest
+
+from hiresense.network.domain import ConnectionsParseError, parse_connections
+
+_HEADER = "First Name,Last Name,URL,Email Address,Company,Position,Connected On"
+_ROWS = (
+    'Jordan,Lee,https://www.linkedin.com/in/jlee,,Acme Inc.,Engineering Manager,01 Feb 2025\n'
+    'Sam,Diaz,,sam@x.dev,Globant S.A.,Recruiter,15 Mar 2024\n'
+    ',,,,,,\n'  # fully empty row is skipped
+)
+_PREAMBLE = (
+    '"Notes:\nWhen exporting your connection data, you may notice missing emails."\n\n'
+)
+
+
+def _csv_bytes(*, preamble: bool) -> bytes:
+    return ((_PREAMBLE if preamble else "") + _HEADER + "\n" + _ROWS).encode("utf-8")
+
+
+def test_parses_plain_csv_with_preamble() -> None:
+    contacts = parse_connections(_csv_bytes(preamble=True), filename="Connections.csv")
+    assert len(contacts) == 2
+    assert contacts[0].first_name == "Jordan"
+    assert contacts[0].company_normalized == "acme"
+    assert contacts[1].email == "sam@x.dev"
+    assert contacts[1].connected_on == "15 Mar 2024"
+
+
+def test_parses_csv_without_preamble() -> None:
+    assert len(parse_connections(_csv_bytes(preamble=False), filename="x.csv")) == 2
+
+
+def test_parses_zip_export() -> None:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("Basic_LinkedInDataExport/Connections.csv", _csv_bytes(preamble=True))
+        archive.writestr("Basic_LinkedInDataExport/Skills.csv", "Name\nPython\n")
+    contacts = parse_connections(buffer.getvalue(), filename="export.zip")
+    assert len(contacts) == 2
+
+
+def test_zip_without_connections_raises() -> None:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        archive.writestr("Skills.csv", "Name\nPython\n")
+    with pytest.raises(ConnectionsParseError, match="Connections.csv"):
+        parse_connections(buffer.getvalue(), filename="export.zip")
+
+
+def test_csv_without_header_raises() -> None:
+    with pytest.raises(ConnectionsParseError, match="header"):
+        parse_connections(b"not,a,connections,file\n1,2,3,4\n", filename="x.csv")
+```
+
+- [ ] **Step 2:** FAIL. **Step 3: implement** `connections_parser.py`:
+
+```python
+from __future__ import annotations
+
+import csv
+import io
+import zipfile
+
+from hiresense.network.domain.contact import Contact
+
+_EXPECTED_COLUMNS = {"First Name", "Last Name", "Company", "Position"}
+_ZIP_MAGIC = b"PK\x03\x04"
+
+
+class ConnectionsParseError(ValueError):
+    """Raised when the upload is not a parseable LinkedIn connections export."""
+
+
+def parse_connections(payload: bytes, *, filename: str) -> list[Contact]:
+    """Parse LinkedIn `Connections.csv` content — given directly or inside the
+    data-export ZIP. Tolerates LinkedIn's "Notes:" preamble before the header."""
+    if payload.startswith(_ZIP_MAGIC):
+        payload = _extract_connections_member(payload)
+    return _parse_csv(payload)
+
+
+def _extract_connections_member(payload: bytes) -> bytes:
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        for name in archive.namelist():
+            if name.rsplit("/", 1)[-1].lower() == "connections.csv":
+                return archive.read(name)
+    raise ConnectionsParseError("ZIP does not contain a Connections.csv")
+
+
+def _parse_csv(payload: bytes) -> list[Contact]:
+    text = payload.decode("utf-8-sig", errors="replace")
+    lines = text.splitlines()
+    header_index = next(
+        (i for i, line in enumerate(lines) if line.startswith("First Name,")), None
+    )
+    if header_index is None:
+        raise ConnectionsParseError("No connections header row found")
+    reader = csv.DictReader(io.StringIO("\n".join(lines[header_index:])))
+    if not _EXPECTED_COLUMNS.issubset(set(reader.fieldnames or [])):
+        raise ConnectionsParseError("Connections header is missing expected columns")
+    contacts: list[Contact] = []
+    for row in reader:
+        first = (row.get("First Name") or "").strip()
+        last = (row.get("Last Name") or "").strip()
+        if not first and not last:
+            continue  # blank padding rows in real exports
+        contacts.append(
+            Contact(
+                first_name=first,
+                last_name=last,
+                company=(row.get("Company") or "").strip(),
+                position=(row.get("Position") or "").strip(),
+                linkedin_url=(row.get("URL") or "").strip() or None,
+                email=(row.get("Email Address") or "").strip() or None,
+                connected_on=(row.get("Connected On") or "").strip() or None,
+            )
+        )
+    return contacts
+```
+
+Re-export `parse_connections`, `ConnectionsParseError` from `domain/__init__.py`.
+
+- [ ] **Step 4:** tests + ruff. **Step 5: commit** — `feat(network): LinkedIn connections parser`.
+
+---
+
+### Task 3: Persistence — port, ORM, repository, migration 027
+
+**Files:** create `network/ports/contacts_repository.py` + `network/ports/__init__.py`, `network/infrastructure/orm.py`, `network/infrastructure/repository.py`, `network/infrastructure/__init__.py`; modify `src/hiresense/infrastructure/registry.py`; migration via autogenerate (rename to `027_add_network_contacts.py`, down_revision "026" — VERIFY it contains ONLY this table; the dev DB's known profiles JSONB drift must be stripped if autogenerate picks it up); test `tests/unit/network/test_contacts_repository.py`
+
+Port Protocol:
+
+```python
+class ContactsRepositoryPort(Protocol):
+    def replace_all(self, contacts: list[Contact]) -> int: ...
+    def list_all(self, company: str | None = None) -> list[Contact]: ...
+    def find_by_company(self, company_normalized: str) -> list[Contact]: ...
+    def count_by_companies(self, companies_normalized: list[str]) -> dict[str, int]: ...
+    def last_imported_at(self) -> datetime | None: ...
+```
+
+ORM `NetworkContactOrm` → table `network_contacts`: `id` String(64) PK (uuid assigned by repo), first/last_name String(256), company String(512), position String(512), linkedin_url/email String(2048/512) nullable, connected_on String(64) nullable, `company_normalized` String(512) indexed (`ix_network_contacts_company_normalized`), `imported_at` DateTime(tz).
+
+Repository semantics: `replace_all` = delete all + insert (one transaction, the import is a full snapshot — same model as the portfolio sync); `list_all(company=...)` filters by `company_normalized == normalize_company(company)` when given; `count_by_companies` = one GROUP BY query over the given keys returning {key: count}. Tests use the StaticPool sqlite fixture pattern (`create_engine("sqlite://", connect_args={"check_same_thread": False}, poolclass=StaticPool)`) covering: roundtrip, replace-all idempotency, find_by_company normalization, count_by_companies including absent keys (absent → missing from dict, callers default to 0), last_imported_at None→set.
+
+- [ ] TDD steps as usual; run `tests/unit/network tests/unit/test_orm_registry.py`; generate + prune migration 027 (compose db up; `uv run python -m alembic upgrade head` before and after); ruff. **Commit** — `feat(network): contacts snapshot repository and migration`.
+
+---
+
+### Task 4: API + bootstrap — import, contacts, match
+
+**Files:** create `network/api/provider.py`, `network/api/dependencies.py`, `network/api/routes.py`, `network/api/__init__.py`, `network/domain/import_service.py` (+ re-export); `bootstrap/network.py` (+ bootstrap `__init__` export); modify `main.py`; tests `tests/unit/network/test_import_service.py`, `tests/unit/network/test_routes.py`
+
+`NetworkImportService` (domain): `async import_upload(payload: bytes, filename: str) -> int` — `parse_connections` then `await asyncio.to_thread(repo.replace_all, contacts)`; raises `ConnectionsParseError` through.
+
+Routes (router-level `require_auth`, mirror portfolio's None-degrading dependencies via `app.state.network`):
+- `POST /network/import` — `UploadFile`; validation mirroring the hardened profile upload: extension whitelist `{".zip", ".csv"}`, `settings.max_upload_bytes` size cap (413), magic check (`PK\x03\x04` for .zip; for .csv must decode utf-8(-sig)) → 400 on mismatch; `ConnectionsParseError` → 400 with detail; success → `{"contacts": N, "imported_at": ...}`. 503 when module state missing (never happens — network has no external config; ALWAYS built in main.py, so dependencies can assume presence but still degrade gracefully for bare test apps).
+- `GET /network/contacts?company=` → list (company optional).
+- `GET /network/match?company=<name>` → `{company_normalized, contacts: [...]}` using `find_by_company(normalize_company(company))`.
+
+`bootstrap/network.py`: `build_network(infra) -> NetworkBuild` (always built — no config gate; repo on `infra.sync_session_factory`). `main.py`: build after portfolio, `app.state.network = network.provider`, mount router.
+
+Route tests mirror `tests/unit/portfolio/test_routes.py`: 401 unauth; import happy path (small CSV bytes), import rejects wrong extension/oversized/garbage; contacts list; match normalizes the query. App-boot determinism: network has no env config — nothing to pin.
+
+- [ ] TDD; full suite green; ruff. **Commit** — `feat(network): import and match endpoints`.
+
+---
+
+### Task 5: Jobs-list connections badge (backend)
+
+**Files:** modify `ingestion/domain/job_filter.py` (`PaginatedResult`), `ingestion/api/routes.py`; create `network/api` dependency `get_network_repository` if not already (Task 4 created it); test `tests/unit/ingestion/test_jobs_connections_badge.py`
+
+- `PaginatedResult` gains `connections_by_job: dict[str, int] = {}` (default empty — every existing constructor call stays valid; pydantic default).
+- In `list_jobs` (ingestion routes), AFTER `result = filter_and_paginate(...)` and the page-level scoring, add:
+
+```python
+    if network_repo is not None and result.jobs:
+        keys = {job.id: normalize_company(job.company) for job in result.jobs}
+        counts = await asyncio.to_thread(
+            network_repo.count_by_companies, sorted({k for k in keys.values() if k})
+        )
+        result.connections_by_job = {
+            job_id: counts[key] for job_id, key in keys.items() if counts.get(key)
+        }
+```
+
+with `network_repo: Annotated[ContactsRepositoryPort | None, Depends(get_network_repository)]` (import dependency from `hiresense.network.api.dependencies`, `normalize_company` from `hiresense.network.domain`). Page-only computation — one GROUP BY per request, no per-row queries.
+- Tests: route-level with a fake repo override → assert `connections_by_job` contains only jobs with matches; absent dependency (bare app) → field `{}` and (critical) existing list tests untouched.
+
+- [ ] TDD; FULL suite; ruff. **Commit** — `feat(network): connections count on the jobs list`.
+
+---
+
+### Task 6: Frontend — network card, jobs badge, outreach suggestions
+
+**Files:**
+- create `frontend/src/app/core/services/network.service.ts` (+spec): `import(file: File)` (FormData POST `/network/import`), `match(company: string)`, `contacts()`.
+- create `frontend/src/app/pages/profile/models/network-*.model.ts` (import result, contact).
+- create `frontend/src/app/pages/profile/components/network-card/` (+spec): mirrors `portfolio-card` — file input (accept `.zip,.csv`), import button with progress/error, "N contacts · last imported …". Mount at the end of `panel-personal` after `<app-portfolio-card />`.
+- modify `frontend/src/app/pages/ingestion/` jobs table: model `paginated-result` gains `connections_by_job?: Record<string, number>`; in the company cell render `@if (connectionsFor(job); as n) {<span class="badge connections-badge" [attr.title]="n + ' connections at this company'">{{ n }} 🤝</span>}` — read the actual component/model files first and follow their conventions (the ingestion service maps the response; check where PaginatedResult fields are read).
+- modify `frontend/src/app/pages/outreach/`: when an application is selected (there's a signal for the selected application/company — read the component), call `network.match(company)`; render suggestion chips under the contact-name input; clicking a chip sets `contactName` to "First Last". Add spec for the suggestion behavior with HttpTestingController.
+
+- [ ] TDD per component (`npm test -- --include ...`), then full `npm test` AND `npx ng lint`. **Commit** — `feat(network): import card, jobs badge, outreach suggestions`.
+
+---
+
+### Task 7: Verification + smoke + stacked PR
+
+- [ ] Backend full suite + ruff; frontend full tests + `npx ng lint`.
+- [ ] Migration 027 applied to compose DB; `-m pgvector` opt-in suite still green.
+- [ ] Live smoke: craft a small fake `Connections.csv` (2 rows, one company matching an existing tracked/job company, e.g. "MixRank (YC S11)"); `POST /network/import`; `GET /network/match?company=MixRank (YC S11)` returns the contact; `GET /ingestion/jobs?...` page containing a MixRank job shows `connections_by_job` with its id. (Use the real export later — the user can re-import their actual ZIP from the UI.)
+- [ ] Push `feat/network-linkedin`; PR base `feat/portfolio-citation`, title `feat(network): LinkedIn connections import with company-match badges (Phase 4)`. Body: scope decision (profile merge deferred + why), privacy invariant, smoke evidence, Claude Code footer.
+
+## Self-review notes (applied)
+- Spec Part B coverage: connections import ✓, badges ✓, outreach targeting ✓, privacy ✓; positions/skills merge consciously deferred (lineage design) — stated in PR + spec terms.
+- `count_by_companies` is the only hot-path query; indexed column, page-scoped.
+- No env config for the module (upload-driven) → no app-boot test pinning needed.

--- a/frontend/src/app/core/services/network.service.spec.ts
+++ b/frontend/src/app/core/services/network.service.spec.ts
@@ -1,0 +1,60 @@
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { NetworkService } from './network.service';
+import { environment } from '../../../environments/environment';
+
+describe('NetworkService', () => {
+  let service: NetworkService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [NetworkService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(NetworkService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('import POSTs multipart to /network/import', () => {
+    const file = new File(['col1,col2'], 'Connections.csv', { type: 'text/csv' });
+    service.import(file).subscribe((res) => {
+      expect(res.contacts).toBe(42);
+      expect(res.imported_at).toBe('2026-06-09T00:00:00Z');
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/network/import`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body instanceof FormData).toBe(true);
+    expect(req.request.body.get('file')).toBeTruthy();
+    req.flush({ contacts: 42, imported_at: '2026-06-09T00:00:00Z' });
+  });
+
+  it('match GETs /network/match with company param', () => {
+    service.match('Acme Corp').subscribe((res) => {
+      expect(res.company_normalized).toBe('acme corp');
+      expect(res.contacts.length).toBe(1);
+    });
+    const req = httpMock.expectOne(
+      `${environment.apiUrl}/network/match?company=Acme%20Corp`,
+    );
+    expect(req.request.method).toBe('GET');
+    expect(req.request.params.get('company')).toBe('Acme Corp');
+    req.flush({
+      company_normalized: 'acme corp',
+      contacts: [
+        {
+          first_name: 'Jane',
+          last_name: 'Doe',
+          company: 'Acme Corp',
+          position: 'Engineer',
+          linkedin_url: 'https://linkedin.com/in/janedoe',
+          email: null,
+          connected_on: '2025-01-15',
+          company_normalized: 'acme corp',
+        },
+      ],
+    });
+  });
+});

--- a/frontend/src/app/core/services/network.service.ts
+++ b/frontend/src/app/core/services/network.service.ts
@@ -1,0 +1,23 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../../environments/environment';
+import { NetworkImportResult } from '../../pages/profile/models/network-import-result.model';
+import { NetworkMatchResponse } from '../../pages/profile/models/network-match-response.model';
+
+@Injectable({ providedIn: 'root' })
+export class NetworkService {
+  private http = inject(HttpClient);
+  private base = `${environment.apiUrl}/network`;
+
+  import(file: File): Observable<NetworkImportResult> {
+    const form = new FormData();
+    form.append('file', file);
+    return this.http.post<NetworkImportResult>(`${this.base}/import`, form);
+  }
+
+  match(company: string): Observable<NetworkMatchResponse> {
+    const params = new HttpParams().set('company', company);
+    return this.http.get<NetworkMatchResponse>(`${this.base}/match`, { params });
+  }
+}

--- a/frontend/src/app/pages/ingestion/ingestion.component.html
+++ b/frontend/src/app/pages/ingestion/ingestion.component.html
@@ -192,7 +192,12 @@
                   <span class="badge badge-closed">Closed</span>
                 }
               </td>
-              <td class="cell-truncate" [title]="job.company"><app-company-link [name]="job.company" /></td>
+              <td class="cell-truncate" [title]="job.company">
+                <app-company-link [name]="job.company" />
+                @if (connectionsCount(job.id); as n) {
+                  <span class="connections-badge" [title]="n + ' LinkedIn connections at this company'">🤝 {{ n }}</span>
+                }
+              </td>
               <td class="cell-truncate" [title]="job.location">{{ job.location }}</td>
               <td class="cell-truncate salary-cell" [title]="job.salary_range">{{ job.salary_range || '—' }}</td>
               <td><span class="badge source-badge-{{ job.source }}">{{ job.source }}</span></td>

--- a/frontend/src/app/pages/ingestion/ingestion.component.scss
+++ b/frontend/src/app/pages/ingestion/ingestion.component.scss
@@ -287,3 +287,17 @@ tr.closed {
   opacity: 0.45;
   transition: opacity 0.2s;
 }
+
+/* --- LinkedIn connections badge --- */
+.connections-badge {
+  display: inline-block;
+  margin-left: 0.375rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: var(--radius-full);
+  font-size: 0.65rem;
+  font-weight: 600;
+  vertical-align: middle;
+  background: #ede9fe;
+  color: #5b21b6;
+  white-space: nowrap;
+}

--- a/frontend/src/app/pages/ingestion/ingestion.component.spec.ts
+++ b/frontend/src/app/pages/ingestion/ingestion.component.spec.ts
@@ -1,0 +1,76 @@
+import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { IngestionComponent } from './ingestion.component';
+import { environment } from '../../../environments/environment';
+
+const jobsPayload = (connectionsByJob: Record<string, number> = {}) => ({
+  jobs: [
+    {
+      id: 'job-1',
+      title: 'Engineer',
+      company: 'Acme',
+      description: 'Build things.',
+      skills: ['python'],
+      location: 'Remote',
+      salary_range: null,
+      source: 'remotive',
+      source_type: 'feed',
+      platform: null,
+      categories: [],
+      department: null,
+      url: 'https://example.com/job-1',
+      posted_date: null,
+      match_score: 0.8,
+      llm_score: 0.8,
+      verdict: 'strong',
+      reasons: [],
+      dealbreakers: [],
+      status: 'open',
+    },
+  ],
+  total: 1,
+  page: 1,
+  page_size: 20,
+  total_pages: 1,
+  connections_by_job: connectionsByJob,
+});
+
+describe('IngestionComponent — connections badge', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [IngestionComponent],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('renders the connections badge for a job present in connections_by_job', () => {
+    const fixture = TestBed.createComponent(IngestionComponent);
+    fixture.detectChanges();
+
+    // Flush portals call (order may vary)
+    httpMock.match((r) => r.url === `${environment.apiUrl}/ingestion/portals`).forEach((r) => r.flush([]));
+
+    // Flush all pending queryJobs calls (ngOnInit may issue one or two depending on route params)
+    const jobReqs = httpMock.match((r) => r.url === `${environment.apiUrl}/ingestion/jobs`);
+    expect(jobReqs.length).toBeGreaterThanOrEqual(1);
+    jobReqs.forEach((r) => r.flush(jobsPayload({ 'job-1': 3 })));
+
+    fixture.detectChanges();
+
+    const badge = (fixture.nativeElement as HTMLElement).querySelector('.connections-badge');
+    expect(badge).toBeTruthy();
+    expect(badge!.textContent?.trim()).toContain('3');
+    expect(badge!.getAttribute('title')).toContain('3 LinkedIn connections');
+  });
+});

--- a/frontend/src/app/pages/ingestion/ingestion.component.ts
+++ b/frontend/src/app/pages/ingestion/ingestion.component.ts
@@ -109,6 +109,9 @@ export class IngestionComponent implements OnInit {
     ['title', 'company', 'location', 'source'],
   );
 
+  // LinkedIn connections map (job.id → count), populated from paginated response.
+  connectionsByJob = signal<Record<string, number>>({});
+
   // Show closed jobs toggle
   includeClosed = signal(false);
   // Show low-quality / spam jobs toggle (hidden by default).
@@ -169,6 +172,7 @@ export class IngestionComponent implements OnInit {
           this.jobs.set(res.jobs);
           this.total.set(res.total);
           this.totalPages.set(res.total_pages);
+          this.connectionsByJob.set(res.connections_by_job ?? {});
           this.loading.set(false);
         },
         error: (err) => {
@@ -342,5 +346,9 @@ export class IngestionComponent implements OnInit {
 
   scoreBadgeClass(score: number): string {
     return scoreClass(score);
+  }
+
+  connectionsCount(jobId: string): number | undefined {
+    return this.connectionsByJob()[jobId];
   }
 }

--- a/frontend/src/app/pages/ingestion/models/paginated-jobs-response.model.ts
+++ b/frontend/src/app/pages/ingestion/models/paginated-jobs-response.model.ts
@@ -6,4 +6,5 @@ export interface PaginatedJobsResponse {
   page: number;
   page_size: number;
   total_pages: number;
+  connections_by_job?: Record<string, number>;
 }

--- a/frontend/src/app/pages/outreach/outreach.component.html
+++ b/frontend/src/app/pages/outreach/outreach.component.html
@@ -58,6 +58,16 @@
           (ngModelChange)="contactName.set($event)"
           placeholder="e.g. Jordan Lee"
         />
+        @if (suggestions().length > 0) {
+          <div class="contact-suggestions">
+            <span class="muted">You know:</span>
+            @for (contact of suggestions(); track contact.linkedin_url ?? contact.first_name + contact.last_name) {
+              <button type="button" class="chip" (click)="useContact(contact)">
+                {{ contact.first_name }} {{ contact.last_name }} — {{ contact.position }}
+              </button>
+            }
+          </div>
+        }
       </div>
       <div class="field">
         <label for="channel">Channel (optional)</label>

--- a/frontend/src/app/pages/outreach/outreach.component.scss
+++ b/frontend/src/app/pages/outreach/outreach.component.scss
@@ -226,3 +226,35 @@
   white-space: pre-wrap;
   color: #374151;
 }
+
+/* --- LinkedIn contact suggestions --- */
+.contact-suggestions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
+
+  .muted {
+    font-size: 0.8125rem;
+    color: #6b7280;
+  }
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid #c4b5fd;
+  background: #ede9fe;
+  color: #5b21b6;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: #ddd6fe;
+  }
+}

--- a/frontend/src/app/pages/outreach/outreach.component.spec.ts
+++ b/frontend/src/app/pages/outreach/outreach.component.spec.ts
@@ -3,6 +3,7 @@ import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
 import { OutreachComponent } from './outreach.component';
 import { OutreachService } from '../../core/services/outreach.service';
+import { NetworkService } from '../../core/services/network.service';
 import { ApplicationsService } from '../../core/services/applications.service';
 
 function makeApp(over: Partial<Record<string, unknown>> = {}) {
@@ -50,6 +51,7 @@ describe('OutreachComponent', () => {
     appId?: string | null;
     outreach?: Partial<Record<string, unknown>>;
     applications?: Partial<Record<string, unknown>>;
+    network?: Partial<Record<string, unknown>>;
   } = {}) {
     const route = {
       snapshot: {
@@ -69,6 +71,11 @@ describe('OutreachComponent', () => {
       list: vi.fn(() => of([makeApp()])),
       ...opts.applications,
     };
+    const network = {
+      match: vi.fn(() => of({ company_normalized: 'acme corp', contacts: [] })),
+      import: vi.fn(() => of({ contacts: 0, imported_at: null })),
+      ...opts.network,
+    };
 
     TestBed.configureTestingModule({
       imports: [OutreachComponent],
@@ -76,11 +83,12 @@ describe('OutreachComponent', () => {
         { provide: ActivatedRoute, useValue: route },
         { provide: OutreachService, useValue: outreach },
         { provide: ApplicationsService, useValue: applications },
+        { provide: NetworkService, useValue: network },
       ],
     });
     const fixture = TestBed.createComponent(OutreachComponent);
     fixture.detectChanges();
-    return { fixture, cmp: fixture.componentInstance, outreach, applications };
+    return { fixture, cmp: fixture.componentInstance, outreach, applications, network };
   }
 
   it('loads applications and preselects from the application_id query param', () => {
@@ -178,5 +186,77 @@ describe('OutreachComponent', () => {
     const { cmp } = mount({ outreach: { dueFollowups } });
 
     expect(cmp.nudgesError()).toBe('boom');
+  });
+
+  it('selecting an application with a company triggers network.match', () => {
+    const matchContacts = [
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+        company: 'Acme Corp',
+        position: 'Engineer',
+        linkedin_url: 'https://linkedin.com/in/janedoe',
+        email: null,
+        connected_on: null,
+        company_normalized: 'acme corp',
+      },
+    ];
+    const match = vi.fn(() => of({ company_normalized: 'acme corp', contacts: matchContacts }));
+    const { cmp, network } = mount({ network: { match } });
+
+    // No selection yet
+    cmp.selectApplication('app-1');
+
+    expect(network.match).toHaveBeenCalledWith('Acme Corp');
+    expect(cmp.suggestions()).toEqual(matchContacts);
+  });
+
+  it('clicking a contact chip fills the contactName signal', () => {
+    const matchContacts = [
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+        company: 'Acme Corp',
+        position: 'Engineer',
+        linkedin_url: null,
+        email: null,
+        connected_on: null,
+        company_normalized: 'acme corp',
+      },
+    ];
+    const match = vi.fn(() => of({ company_normalized: 'acme corp', contacts: matchContacts }));
+    const { cmp, fixture } = mount({ appId: 'app-1', network: { match } });
+
+    // Trigger suggestions render
+    fixture.detectChanges();
+
+    const chip = (fixture.nativeElement as HTMLElement).querySelector('.chip') as HTMLButtonElement | null;
+    expect(chip).toBeTruthy();
+    chip!.click();
+
+    expect(cmp.contactName()).toBe('Jane Doe');
+  });
+
+  it('clears suggestions when the selection changes', () => {
+    const matchContacts = [
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+        company: 'Acme Corp',
+        position: 'Engineer',
+        linkedin_url: null,
+        email: null,
+        connected_on: null,
+        company_normalized: 'acme corp',
+      },
+    ];
+    const match = vi.fn(() => of({ company_normalized: 'acme corp', contacts: matchContacts }));
+    const { cmp } = mount({ appId: 'app-1', network: { match } });
+
+    expect(cmp.suggestions().length).toBe(1);
+
+    cmp.selectApplication('');
+
+    expect(cmp.suggestions().length).toBe(0);
   });
 });

--- a/frontend/src/app/pages/outreach/outreach.component.ts
+++ b/frontend/src/app/pages/outreach/outreach.component.ts
@@ -3,8 +3,10 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { OutreachService } from '../../core/services/outreach.service';
+import { NetworkService } from '../../core/services/network.service';
 import { ApplicationsService } from '../../core/services/applications.service';
 import { ApplicationListItem } from '../applications/models/application-list-item.model';
+import { NetworkContact } from '../profile/models/network-contact.model';
 import { OutreachEvent } from './models/outreach-event.model';
 import { OutreachEventKind } from './models/outreach-event-kind.model';
 import { OutreachNudge } from './models/outreach-nudge.model';
@@ -21,6 +23,7 @@ import { parseSortToken } from '../../core/utils/parse-sort-token';
 })
 export class OutreachComponent implements OnInit {
   private outreach = inject(OutreachService);
+  private network = inject(NetworkService);
   private applicationsService = inject(ApplicationsService);
   private route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
@@ -57,6 +60,9 @@ export class OutreachComponent implements OnInit {
     return sortItems(rows, (e) => e.created_at, this.eventSort.dir());
   });
 
+  // LinkedIn contact suggestions for the selected application's company.
+  suggestions = signal<NetworkContact[]>([]);
+
   // Nudges
   nudges = signal<OutreachNudge[]>([]);
   nudgesError = signal('');
@@ -88,11 +94,32 @@ export class OutreachComponent implements OnInit {
     this.selectedApplicationId.set(id);
     this.composeNotice.set('');
     this.recordError.set('');
+    this.suggestions.set([]);
     if (id) {
       this.loadTimeline();
+      this.loadSuggestions(id);
     } else {
       this.events.set([]);
     }
+  }
+
+  private loadSuggestions(applicationId: string): void {
+    const app = this.applications().find((a) => a.id === applicationId);
+    const company = app?.company?.trim();
+    if (!company) return;
+    this.network
+      .match(company)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => this.suggestions.set(res.contacts.slice(0, 5)),
+        error: () => {
+          // Suggestions are best-effort; silently swallow errors.
+        },
+      });
+  }
+
+  useContact(contact: NetworkContact): void {
+    this.contactName.set(`${contact.first_name} ${contact.last_name}`);
   }
 
   onSelectChange(id: string): void {

--- a/frontend/src/app/pages/profile/components/network-card/network-card.component.html
+++ b/frontend/src/app/pages/profile/components/network-card/network-card.component.html
@@ -1,0 +1,36 @@
+<section class="card network-card">
+  <header class="card-header">
+    <h2>LinkedIn network</h2>
+  </header>
+
+  <p class="muted hint">
+    Upload LinkedIn's data-export ZIP or Connections.csv. Contacts stay local and never enter AI prompts.
+  </p>
+
+  <div class="import-row">
+    <input
+      id="network-file-input"
+      type="file"
+      accept=".zip,.csv"
+      (change)="onFileSelected($event)"
+      [disabled]="importing()"
+      hidden
+    />
+    <label for="network-file-input" class="btn" [class.disabled]="importing()">
+      {{ importing() ? 'Importing…' : 'Choose file' }}
+    </label>
+  </div>
+
+  @if (error()) {
+    <p class="error" role="alert">{{ error() }}</p>
+  }
+
+  @if (result(); as r) {
+    <p class="muted">
+      {{ r.contacts }} contacts imported
+      @if (r.imported_at) {
+        · {{ r.imported_at | date: 'medium' }}
+      }
+    </p>
+  }
+</section>

--- a/frontend/src/app/pages/profile/components/network-card/network-card.component.scss
+++ b/frontend/src/app/pages/profile/components/network-card/network-card.component.scss
@@ -1,0 +1,34 @@
+.network-card {
+  margin-top: 1rem;
+
+  .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+  }
+
+  .hint {
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+  }
+
+  .import-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .btn.disabled {
+    opacity: 0.6;
+    pointer-events: none;
+    cursor: not-allowed;
+  }
+
+  .error {
+    color: var(--color-error, #d32f2f);
+    font-size: 0.875rem;
+    margin-top: 0.5rem;
+  }
+}

--- a/frontend/src/app/pages/profile/components/network-card/network-card.component.spec.ts
+++ b/frontend/src/app/pages/profile/components/network-card/network-card.component.spec.ts
@@ -1,0 +1,70 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { NetworkCardComponent } from './network-card.component';
+import { environment } from '../../../../../environments/environment';
+
+describe('NetworkCardComponent', () => {
+  let fixture: ComponentFixture<NetworkCardComponent>;
+  let httpMock: HttpTestingController;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [NetworkCardComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NetworkCardComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => httpMock.verify());
+
+  it('renders the upload hint', () => {
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain("Upload LinkedIn's data-export ZIP or Connections.csv");
+    expect(text).toContain('never enter AI prompts');
+  });
+
+  it('shows import count and date on successful import', () => {
+    const comp = fixture.componentInstance;
+    const file = new File(['a,b'], 'Connections.csv', { type: 'text/csv' });
+
+    // Trigger import by calling onFileSelected with a fake event
+    const input = fixture.nativeElement.querySelector('input[type="file"]') as HTMLInputElement;
+    Object.defineProperty(input, 'files', {
+      value: { 0: file, length: 1, item: () => file },
+      configurable: true,
+    });
+    comp.onFileSelected({ target: input } as unknown as Event);
+
+    httpMock
+      .expectOne(`${environment.apiUrl}/network/import`)
+      .flush({ contacts: 150, imported_at: '2026-06-09T00:00:00Z' });
+
+    fixture.detectChanges();
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('150 contacts imported');
+  });
+
+  it('shows detail in the alert on failed import', () => {
+    const comp = fixture.componentInstance;
+    const file = new File(['a,b'], 'Connections.csv', { type: 'text/csv' });
+
+    const input = fixture.nativeElement.querySelector('input[type="file"]') as HTMLInputElement;
+    Object.defineProperty(input, 'files', {
+      value: { 0: file, length: 1, item: () => file },
+      configurable: true,
+    });
+    comp.onFileSelected({ target: input } as unknown as Event);
+
+    httpMock
+      .expectOne(`${environment.apiUrl}/network/import`)
+      .flush({ detail: 'File too large' }, { status: 413, statusText: 'Payload Too Large' });
+
+    fixture.detectChanges();
+    const alert = (fixture.nativeElement as HTMLElement).querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+    expect(alert!.textContent).toContain('File too large');
+  });
+});

--- a/frontend/src/app/pages/profile/components/network-card/network-card.component.ts
+++ b/frontend/src/app/pages/profile/components/network-card/network-card.component.ts
@@ -1,0 +1,47 @@
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DatePipe } from '@angular/common';
+import { NetworkService } from '../../../../core/services/network.service';
+import { NetworkImportResult } from '../../models/network-import-result.model';
+
+@Component({
+  selector: 'app-network-card',
+  imports: [DatePipe],
+  templateUrl: './network-card.component.html',
+  styleUrl: './network-card.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NetworkCardComponent {
+  private service = inject(NetworkService);
+  private destroyRef = inject(DestroyRef);
+
+  readonly importing = signal(false);
+  readonly result = signal<NetworkImportResult | null>(null);
+  readonly error = signal('');
+
+  onFileSelected(event: Event): void {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) return;
+    this.importFile(file);
+  }
+
+  private importFile(file: File): void {
+    if (this.importing()) return;
+    this.importing.set(true);
+    this.error.set('');
+    this.service
+      .import(file)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (res) => {
+          this.result.set(res);
+          this.importing.set(false);
+        },
+        error: (err) => {
+          this.error.set(err?.error?.detail ?? 'Import failed. Please try again.');
+          this.importing.set(false);
+        },
+      });
+  }
+}

--- a/frontend/src/app/pages/profile/models/network-contact.model.ts
+++ b/frontend/src/app/pages/profile/models/network-contact.model.ts
@@ -1,0 +1,10 @@
+export interface NetworkContact {
+  first_name: string;
+  last_name: string;
+  company: string;
+  position: string;
+  linkedin_url: string | null;
+  email: string | null;
+  connected_on: string | null;
+  company_normalized: string;
+}

--- a/frontend/src/app/pages/profile/models/network-import-result.model.ts
+++ b/frontend/src/app/pages/profile/models/network-import-result.model.ts
@@ -1,0 +1,4 @@
+export interface NetworkImportResult {
+  contacts: number;
+  imported_at: string | null;
+}

--- a/frontend/src/app/pages/profile/models/network-match-response.model.ts
+++ b/frontend/src/app/pages/profile/models/network-match-response.model.ts
@@ -1,0 +1,6 @@
+import { NetworkContact } from './network-contact.model';
+
+export interface NetworkMatchResponse {
+  company_normalized: string;
+  contacts: NetworkContact[];
+}

--- a/frontend/src/app/pages/profile/profile.component.html
+++ b/frontend/src/app/pages/profile/profile.component.html
@@ -418,6 +418,7 @@
       </div>
     }
     <app-portfolio-card />
+    <app-network-card />
   </section>
   }
 

--- a/frontend/src/app/pages/profile/profile.component.ts
+++ b/frontend/src/app/pages/profile/profile.component.ts
@@ -9,6 +9,7 @@ import { CoverLetterLibraryComponent } from './components/cover-letter-library/c
 import { CoverLetterTemplatesComponent } from './components/cover-letter-templates/cover-letter-templates.component';
 import { AccountComponent } from '../account/account.component';
 import { PortfolioCardComponent } from './components/portfolio-card/portfolio-card.component';
+import { NetworkCardComponent } from './components/network-card/network-card.component';
 
 type ProfilePageTab = 'cv' | 'personal' | 'cover-letters' | 'account';
 
@@ -24,6 +25,7 @@ type ProfilePageTab = 'cv' | 'personal' | 'cover-letters' | 'account';
     CoverLetterTemplatesComponent,
     AccountComponent,
     PortfolioCardComponent,
+    NetworkCardComponent,
   ],
   templateUrl: './profile.component.html',
   styleUrl: './profile.component.scss',


### PR DESCRIPTION
## Summary

Phase 4 of the external-sources integration — **stacked on #86**: a new `network` bounded context imports LinkedIn's data-export connections and surfaces "you know someone at this company" across the app.

- **Import**: `POST /network/import` accepts the LinkedIn export ZIP or `Connections.csv` directly (handles LinkedIn's "Notes:" preamble, BOM, blank padding rows). Upload hardening mirrors the profile-upload pattern (extension whitelist, size cap, magic sniffing) plus a decompression ceiling on the ZIP member (zip-bomb gate, review finding).
- **Matching foundation**: `normalize_company` (lowercase, parentheticals, punctuation, legal suffixes — with a dotted-acronym pre-pass so "S.A. de C.V." strips without mangling names like "Studio C"; that approach replaced single-letter stripping after review caught false positives like "Plan A" → "plan").
- **Jobs list**: `connections_by_job` on the list response (one GROUP BY over the visible page) → 🤝 badge in the company cell.
- **Outreach**: contact suggestions ("You know: …") under the contact-name input; clicking a chip fills the field.
- **Profile page**: "LinkedIn network" import card next to the portfolio card.
- **Privacy invariant**: contacts live only in the local DB and never enter LLM prompts — badges and matching are deterministic lookups; only the user-chosen contact name reaches the outreach prompt (existing behavior).

**Scope note**: the spec's Positions/Skills/Education → profile merge is deferred to its own follow-up — profiles have no data-lineage tagging today, and a destructive-on-reimport merge would be worse than none. Connections.csv is the high-value file and it's fully served here.

## Test plan
- [x] Backend: 994 passed, 6 skipped; `ruff check` clean. Frontend: 322 passed; `ng lint` clean.
- [x] Migration 027 applied to compose DB (autogenerate pruned of the known profiles drift)
- [x] Live smoke: imported a 2-contact CSV (with LinkedIn's real preamble format) → `{"contacts": 2}`; `GET /network/match?company=MixRank (YC S11)` returned the right contact via normalization; `GET /ingestion/jobs?keyword=mixrank` returned `connections_by_job` with both real MixRank postings at count 1
- [x] Review fixes incorporated: dotted-acronym normalization (replacing single-letter suffix stripping), zip decompression ceiling, HTTP 413 status modernization

🤖 Generated with [Claude Code](https://claude.com/claude-code)