### PR TITLE
feat(portfolio): engagement readback (Phase 5) + GetOnBoard research close-out

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -269,6 +269,12 @@ PORTFOLIO_PUBLIC_URL=
 PORTFOLIO_REF_PREFIX=hiresense
 # Relevant projects cited per generated artifact.
 PORTFOLIO_RELEVANT_PROJECTS_TOP_N=2
+# Supabase service_role key for reading visitor analytics (Dashboard → Settings → API).
+# This key bypasses RLS and is required because visitor_session SELECT is restricted
+# to authenticated/service-role only (anon key cannot read it). Empty disables
+# the engagement readback entirely — the /portfolio/engagement endpoint returns
+# {"configured": false, "visits": []} when unset.
+PORTFOLIO_ANALYTICS_READ_KEY=
 
 # --- Observability (OpenTelemetry) ---
 # Master switch for the telemetry stack.

--- a/backend/src/hiresense/bootstrap/portfolio.py
+++ b/backend/src/hiresense/bootstrap/portfolio.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from hiresense.bootstrap.shared_infra import SharedInfra
-from hiresense.portfolio.adapters import GitHubPortfolioAdapter, SupabasePortfolioAdapter
+from hiresense.portfolio.adapters import (
+    GitHubPortfolioAdapter,
+    SupabaseEngagementAdapter,
+    SupabasePortfolioAdapter,
+)
 from hiresense.portfolio.api.provider import PortfolioProvider
 from hiresense.portfolio.domain import (
     PortfolioCitationService,
+    PortfolioEngagementService,
     PortfolioEnrichmentService,
     PortfolioSyncService,
     RelevantProjectSelector,
@@ -58,6 +63,17 @@ def build_portfolio(infra: SharedInfra) -> PortfolioBuild | None:
         else:
             raise ValueError(f"Unknown portfolio source: {name}")
 
+    engagement_service: PortfolioEngagementService | None = None
+    if s.portfolio_analytics_read_key and s.portfolio_supabase_url:
+        engagement_service = PortfolioEngagementService(
+            SupabaseEngagementAdapter(
+                http_client=infra.http_client,
+                base_url=s.portfolio_supabase_url,
+                read_key=s.portfolio_analytics_read_key,
+            ),
+            ref_prefix=s.portfolio_ref_prefix,
+        )
+
     repository = PortfolioProjectsRepository(session_factory=infra.sync_session_factory)
     provider = PortfolioProvider(
         sync_service=PortfolioSyncService(sources=sources, repository=repository),
@@ -75,5 +91,6 @@ def build_portfolio(infra: SharedInfra) -> PortfolioBuild | None:
             public_url=s.portfolio_public_url,
             ref_prefix=s.portfolio_ref_prefix,
         ),
+        engagement_service=engagement_service,
     )
     return PortfolioBuild(provider=provider)

--- a/backend/src/hiresense/config.py
+++ b/backend/src/hiresense/config.py
@@ -438,6 +438,9 @@ class Settings(BaseSettings):
     portfolio_ref_prefix: str = "hiresense"
     # How many relevant projects get cited per generated artifact.
     portfolio_relevant_projects_top_n: int = 2
+    # Supabase service_role key for reading visitor analytics (Dashboard →
+    # Settings → API). Empty disables engagement readback entirely.
+    portfolio_analytics_read_key: str = ""
 
     @classmethod
     def settings_customise_sources(

--- a/backend/src/hiresense/portfolio/adapters/__init__.py
+++ b/backend/src/hiresense/portfolio/adapters/__init__.py
@@ -1,4 +1,5 @@
 from hiresense.portfolio.adapters.github_portfolio import GitHubPortfolioAdapter
+from hiresense.portfolio.adapters.supabase_engagement import SupabaseEngagementAdapter
 from hiresense.portfolio.adapters.supabase_portfolio import SupabasePortfolioAdapter
 
-__all__ = ["GitHubPortfolioAdapter", "SupabasePortfolioAdapter"]
+__all__ = ["GitHubPortfolioAdapter", "SupabaseEngagementAdapter", "SupabasePortfolioAdapter"]

--- a/backend/src/hiresense/portfolio/adapters/supabase_engagement.py
+++ b/backend/src/hiresense/portfolio/adapters/supabase_engagement.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from hiresense.portfolio.domain import PortfolioVisit
+
+
+def _parse_dt(value: str) -> datetime:
+    """Parse ISO 8601 timestamp, handling the 'Z' suffix PostgREST may emit."""
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+class SupabaseEngagementAdapter:
+    """Reads aggregated portfolio visit analytics from Supabase via PostgREST.
+
+    Requires the Supabase service_role key — visitor_session SELECT is
+    restricted to authenticated/service-role only (anon key is blocked by RLS).
+    """
+
+    def __init__(self, http_client: Any, base_url: str, read_key: str) -> None:
+        self._http = http_client
+        self._base = base_url.rstrip("/")
+        self._key = read_key
+
+    async def _get(self, path: str, params: dict[str, str]) -> Any:
+        response = await self._http.get(
+            f"{self._base}{path}",
+            headers={"apikey": self._key, "Authorization": f"Bearer {self._key}"},
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    async def fetch_visits(self, ref_prefix: str) -> list[PortfolioVisit]:
+        sessions: list[dict[str, Any]] = await self._get(
+            "/rest/v1/visitor_session",
+            {
+                "select": "id,referrer_source,started_at,last_seen_at,total_page_views,country,organization",
+                "referrer_source": f"like.{ref_prefix}-*",
+            },
+        )
+
+        if not sessions:
+            return []
+
+        # Tally cv_downloads per session_id from the cv_download table.
+        session_ids = [str(s["id"]) for s in sessions]
+        downloads_raw: list[dict[str, Any]] = await self._get(
+            "/rest/v1/cv_download",
+            {
+                "select": "session_id",
+                "session_id": f"in.({','.join(session_ids)})",
+            },
+        )
+        download_count_by_session: dict[str, int] = {}
+        for row in downloads_raw:
+            sid = str(row["session_id"])
+            download_count_by_session[sid] = download_count_by_session.get(sid, 0) + 1
+
+        # Group sessions by referrer_source.
+        groups: dict[str, list[dict[str, Any]]] = {}
+        for session in sessions:
+            ref = session["referrer_source"]
+            groups.setdefault(ref, []).append(session)
+
+        visits: list[PortfolioVisit] = []
+        for ref, group in groups.items():
+            first_seen = min(_parse_dt(s["started_at"]) for s in group)
+            last_seen_values = [_parse_dt(s["last_seen_at"]) for s in group]
+            last_seen = max(last_seen_values)
+            page_views = sum(s.get("total_page_views") or 0 for s in group)
+            cv_downloads = sum(
+                download_count_by_session.get(str(s["id"]), 0) for s in group
+            )
+            # country / organization from the session with the latest last_seen_at.
+            latest_session = group[last_seen_values.index(last_seen)]
+            visits.append(
+                PortfolioVisit(
+                    ref=ref,
+                    first_seen=first_seen,
+                    last_seen=last_seen,
+                    page_views=page_views,
+                    cv_downloads=cv_downloads,
+                    country=latest_session.get("country"),
+                    organization=latest_session.get("organization"),
+                )
+            )
+
+        return visits

--- a/backend/src/hiresense/portfolio/api/dependencies.py
+++ b/backend/src/hiresense/portfolio/api/dependencies.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from fastapi import Request
 
-from hiresense.portfolio.domain import PortfolioEnrichmentService, PortfolioSyncService
+from hiresense.portfolio.domain import (
+    PortfolioEngagementService,
+    PortfolioEnrichmentService,
+    PortfolioSyncService,
+)
 from hiresense.portfolio.ports import PortfolioProjectsRepositoryPort
 
 
@@ -23,3 +27,10 @@ def get_projects_repository(request: Request) -> PortfolioProjectsRepositoryPort
 def get_portfolio_enrichment(request: Request) -> PortfolioEnrichmentService | None:
     provider = _provider(request)
     return provider.get_enrichment_service() if provider else None
+
+
+def get_engagement_service(request: Request) -> PortfolioEngagementService | None:
+    provider = _provider(request)
+    if provider is None:
+        return None
+    return provider.get_engagement_service()

--- a/backend/src/hiresense/portfolio/api/provider.py
+++ b/backend/src/hiresense/portfolio/api/provider.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from hiresense.portfolio.domain import (
     PortfolioCitationService,
+    PortfolioEngagementService,
     PortfolioEnrichmentService,
     PortfolioSyncService,
 )
@@ -15,11 +16,13 @@ class PortfolioProvider:
         repository: PortfolioProjectsRepositoryPort,
         enrichment_service: PortfolioEnrichmentService,
         citation_service: PortfolioCitationService,
+        engagement_service: PortfolioEngagementService | None = None,
     ) -> None:
         self._sync_service = sync_service
         self._repository = repository
         self._enrichment_service = enrichment_service
         self._citation_service = citation_service
+        self._engagement_service = engagement_service
 
     def get_sync_service(self) -> PortfolioSyncService:
         return self._sync_service
@@ -32,3 +35,6 @@ class PortfolioProvider:
 
     def get_citation_service(self) -> PortfolioCitationService:
         return self._citation_service
+
+    def get_engagement_service(self) -> PortfolioEngagementService | None:
+        return self._engagement_service

--- a/backend/src/hiresense/portfolio/api/routes.py
+++ b/backend/src/hiresense/portfolio/api/routes.py
@@ -8,8 +8,18 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from hiresense.identity.api.dependencies import enforce_expensive_rate_limit, require_auth
-from hiresense.portfolio.api.dependencies import get_projects_repository, get_sync_service
-from hiresense.portfolio.domain import PortfolioProject, PortfolioSyncService, SyncResult
+from hiresense.portfolio.api.dependencies import (
+    get_engagement_service,
+    get_projects_repository,
+    get_sync_service,
+)
+from hiresense.portfolio.domain import (
+    PortfolioEngagementService,
+    PortfolioProject,
+    PortfolioSyncService,
+    PortfolioVisit,
+    SyncResult,
+)
 from hiresense.portfolio.ports import PortfolioProjectsRepositoryPort
 
 router = APIRouter(prefix="/portfolio", tags=["portfolio"], dependencies=[Depends(require_auth)])
@@ -47,3 +57,17 @@ async def list_projects(
     projects = await asyncio.to_thread(repository.list_all)
     last = await asyncio.to_thread(repository.last_synced_at)
     return ProjectsResponse(projects=projects, last_synced_at=last)
+
+
+class EngagementResponse(BaseModel):
+    configured: bool
+    visits: list[PortfolioVisit]
+
+
+@router.get("/engagement", response_model=EngagementResponse)
+async def get_engagement(
+    service: Annotated[PortfolioEngagementService | None, Depends(get_engagement_service)],
+) -> EngagementResponse:
+    if service is None:
+        return EngagementResponse(configured=False, visits=[])
+    return EngagementResponse(configured=True, visits=await service.visits())

--- a/backend/src/hiresense/portfolio/domain/__init__.py
+++ b/backend/src/hiresense/portfolio/domain/__init__.py
@@ -1,6 +1,7 @@
 from hiresense.portfolio.domain.citation_service import PortfolioCitationService
 from hiresense.portfolio.domain.enrichment_service import PortfolioEnrichmentService
 from hiresense.portfolio.domain.portfolio_project import PortfolioProject
+from hiresense.portfolio.domain.portfolio_visit import PortfolioVisit
 from hiresense.portfolio.domain.profile_text import portfolio_profile_text
 from hiresense.portfolio.domain.project_text import ProjectText
 from hiresense.portfolio.domain.relevant_project_selector import RelevantProjectSelector
@@ -12,6 +13,7 @@ __all__ = [
     "PortfolioEnrichmentService",
     "PortfolioProject",
     "PortfolioSyncService",
+    "PortfolioVisit",
     "ProjectText",
     "RelevantProjectSelector",
     "SyncResult",

--- a/backend/src/hiresense/portfolio/domain/__init__.py
+++ b/backend/src/hiresense/portfolio/domain/__init__.py
@@ -1,4 +1,5 @@
 from hiresense.portfolio.domain.citation_service import PortfolioCitationService
+from hiresense.portfolio.domain.engagement_service import PortfolioEngagementService
 from hiresense.portfolio.domain.enrichment_service import PortfolioEnrichmentService
 from hiresense.portfolio.domain.portfolio_project import PortfolioProject
 from hiresense.portfolio.domain.portfolio_visit import PortfolioVisit
@@ -10,6 +11,7 @@ from hiresense.portfolio.domain.sync_service import PortfolioSyncService
 
 __all__ = [
     "PortfolioCitationService",
+    "PortfolioEngagementService",
     "PortfolioEnrichmentService",
     "PortfolioProject",
     "PortfolioSyncService",

--- a/backend/src/hiresense/portfolio/domain/engagement_service.py
+++ b/backend/src/hiresense/portfolio/domain/engagement_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from hiresense.portfolio.domain.portfolio_visit import PortfolioVisit
+
+if TYPE_CHECKING:
+    from hiresense.portfolio.ports.engagement_source import PortfolioEngagementPort
+
+logger = logging.getLogger(__name__)
+
+
+class PortfolioEngagementService:
+    """Fetches portfolio visits, derives application_id from ref prefix, sorts desc."""
+
+    def __init__(self, source: PortfolioEngagementPort | Any, *, ref_prefix: str) -> None:
+        self._source = source
+        self._prefix = ref_prefix
+
+    async def visits(self) -> list[PortfolioVisit]:
+        try:
+            raw = await self._source.fetch_visits(self._prefix)
+        except Exception:
+            logger.warning("PortfolioEngagementService: failed to fetch visits", exc_info=True)
+            return []
+
+        result: list[PortfolioVisit] = []
+        tag = f"{self._prefix}-"
+        for visit in raw:
+            application_id = visit.ref.removeprefix(tag) if visit.ref.startswith(tag) else None
+            result.append(visit.model_copy(update={"application_id": application_id}))
+
+        result.sort(key=lambda v: v.last_seen, reverse=True)
+        return result

--- a/backend/src/hiresense/portfolio/domain/portfolio_visit.py
+++ b/backend/src/hiresense/portfolio/domain/portfolio_visit.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class PortfolioVisit(BaseModel):
+    """Aggregated visit data for one tracked portfolio link (one ref)."""
+
+    ref: str
+    application_id: str | None = None
+    first_seen: datetime
+    last_seen: datetime
+    page_views: int = 0
+    cv_downloads: int = 0
+    country: str | None = None
+    organization: str | None = None

--- a/backend/src/hiresense/portfolio/ports/__init__.py
+++ b/backend/src/hiresense/portfolio/ports/__init__.py
@@ -1,4 +1,5 @@
+from hiresense.portfolio.ports.engagement_source import PortfolioEngagementPort
 from hiresense.portfolio.ports.portfolio_source import PortfolioSourcePort
 from hiresense.portfolio.ports.projects_repository import PortfolioProjectsRepositoryPort
 
-__all__ = ["PortfolioProjectsRepositoryPort", "PortfolioSourcePort"]
+__all__ = ["PortfolioEngagementPort", "PortfolioProjectsRepositoryPort", "PortfolioSourcePort"]

--- a/backend/src/hiresense/portfolio/ports/engagement_source.py
+++ b/backend/src/hiresense/portfolio/ports/engagement_source.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from hiresense.portfolio.domain import PortfolioVisit
+
+
+class PortfolioEngagementPort(Protocol):
+    """Read-only source of aggregated portfolio visit data."""
+
+    async def fetch_visits(self, ref_prefix: str) -> list[PortfolioVisit]: ...

--- a/backend/tests/unit/portfolio/test_bootstrap.py
+++ b/backend/tests/unit/portfolio/test_bootstrap.py
@@ -15,6 +15,7 @@ class _Settings:
     portfolio_public_url = ""
     portfolio_ref_prefix = "hiresense"
     portfolio_relevant_projects_top_n = 2
+    portfolio_analytics_read_key = ""
     default_language = "en"
 
 
@@ -71,3 +72,25 @@ def test_builds_provider_with_github_and_supabase() -> None:
     build = build_portfolio(_Infra(settings))
     assert build is not None
     assert build.provider.get_sync_service() is not None
+
+
+def test_engagement_service_none_when_analytics_key_unset() -> None:
+    settings = _Settings()
+    settings.portfolio_sources = ["supabase"]
+    settings.portfolio_supabase_url = "https://xyz.supabase.co"
+    settings.portfolio_supabase_anon_key = "anon"
+    # portfolio_analytics_read_key is "" by default
+    build = build_portfolio(_Infra(settings))
+    assert build is not None
+    assert build.provider.get_engagement_service() is None
+
+
+def test_engagement_service_built_when_key_and_url_set() -> None:
+    settings = _Settings()
+    settings.portfolio_sources = ["supabase"]
+    settings.portfolio_supabase_url = "https://xyz.supabase.co"
+    settings.portfolio_supabase_anon_key = "anon"
+    settings.portfolio_analytics_read_key = "service_role_key"
+    build = build_portfolio(_Infra(settings))
+    assert build is not None
+    assert build.provider.get_engagement_service() is not None

--- a/backend/tests/unit/portfolio/test_engagement_service.py
+++ b/backend/tests/unit/portfolio/test_engagement_service.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from hiresense.portfolio.domain import PortfolioVisit
+from hiresense.portfolio.domain.engagement_service import PortfolioEngagementService
+
+
+def _visit(ref: str, last_seen: datetime) -> PortfolioVisit:
+    return PortfolioVisit(
+        ref=ref,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        last_seen=last_seen,
+    )
+
+
+class _FakeSource:
+    def __init__(self, visits: list[PortfolioVisit], *, raise_on_fetch: bool = False) -> None:
+        self._visits = visits
+        self._raise = raise_on_fetch
+
+    async def fetch_visits(self, ref_prefix: str) -> list[PortfolioVisit]:
+        if self._raise:
+            raise RuntimeError("network down")
+        return self._visits
+
+
+@pytest.mark.asyncio
+async def test_prefix_parsed_into_application_id() -> None:
+    v = _visit("hiresense-abc123", datetime(2026, 6, 1, tzinfo=timezone.utc))
+    svc = PortfolioEngagementService(_FakeSource([v]), ref_prefix="hiresense")
+    visits = await svc.visits()
+    assert len(visits) == 1
+    assert visits[0].application_id == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_foreign_ref_yields_none_application_id() -> None:
+    v = _visit("other-abc123", datetime(2026, 6, 1, tzinfo=timezone.utc))
+    svc = PortfolioEngagementService(_FakeSource([v]), ref_prefix="hiresense")
+    visits = await svc.visits()
+    assert visits[0].application_id is None
+
+
+@pytest.mark.asyncio
+async def test_sorted_by_last_seen_desc() -> None:
+    v1 = _visit("hiresense-a", datetime(2026, 6, 1, tzinfo=timezone.utc))
+    v2 = _visit("hiresense-b", datetime(2026, 6, 3, tzinfo=timezone.utc))
+    v3 = _visit("hiresense-c", datetime(2026, 6, 2, tzinfo=timezone.utc))
+    svc = PortfolioEngagementService(_FakeSource([v1, v2, v3]), ref_prefix="hiresense")
+    visits = await svc.visits()
+    assert [v.ref for v in visits] == ["hiresense-b", "hiresense-c", "hiresense-a"]
+
+
+@pytest.mark.asyncio
+async def test_source_exception_returns_empty_list() -> None:
+    svc = PortfolioEngagementService(
+        _FakeSource([], raise_on_fetch=True), ref_prefix="hiresense"
+    )
+    visits = await svc.visits()
+    assert visits == []
+
+
+@pytest.mark.asyncio
+async def test_original_visit_unchanged_by_service() -> None:
+    """model_copy is used; original model instance should not be mutated."""
+    v = _visit("hiresense-xyz", datetime(2026, 6, 1, tzinfo=timezone.utc))
+    svc = PortfolioEngagementService(_FakeSource([v]), ref_prefix="hiresense")
+    await svc.visits()
+    assert v.application_id is None

--- a/backend/tests/unit/portfolio/test_routes.py
+++ b/backend/tests/unit/portfolio/test_routes.py
@@ -6,14 +6,26 @@ from httpx import ASGITransport, AsyncClient
 
 from hiresense.identity.api.dependencies import require_auth
 from hiresense.portfolio.api import router
-from hiresense.portfolio.api.dependencies import get_projects_repository, get_sync_service
-from hiresense.portfolio.domain import PortfolioProject, ProjectText, SyncResult
+from hiresense.portfolio.api.dependencies import (
+    get_engagement_service,
+    get_projects_repository,
+    get_sync_service,
+)
+from hiresense.portfolio.domain import PortfolioProject, PortfolioVisit, ProjectText, SyncResult
 
 
 def _project(key: str) -> PortfolioProject:
     return PortfolioProject(
         id=key, source="supabase", source_key=key,
         translations={"en": ProjectText(title=key)},
+    )
+
+
+def _visit(ref: str) -> PortfolioVisit:
+    return PortfolioVisit(
+        ref=ref,
+        first_seen=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        last_seen=datetime(2026, 6, 1, tzinfo=timezone.utc),
     )
 
 
@@ -36,11 +48,20 @@ class _FakeRepo:
         return self._last
 
 
-def _app(sync=None, repo=None) -> FastAPI:
+class _FakeEngagementService:
+    def __init__(self, visits: list[PortfolioVisit]) -> None:
+        self._visits = visits
+
+    async def visits(self) -> list[PortfolioVisit]:
+        return self._visits
+
+
+def _app(sync=None, repo=None, engagement=None) -> FastAPI:
     app = FastAPI()
     app.dependency_overrides[require_auth] = lambda: "test-user"
     app.dependency_overrides[get_sync_service] = lambda: sync
     app.dependency_overrides[get_projects_repository] = lambda: repo
+    app.dependency_overrides[get_engagement_service] = lambda: engagement
     app.include_router(router)
     return app
 
@@ -95,3 +116,24 @@ async def test_list_projects_with_and_without_repo() -> None:
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
         body = (await client.get("/portfolio/projects")).json()
     assert body == {"projects": [], "last_synced_at": None}
+
+
+@pytest.mark.asyncio
+async def test_engagement_unconfigured_returns_configured_false() -> None:
+    app = _app(engagement=None)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        body = (await client.get("/portfolio/engagement")).json()
+    assert body["configured"] is False
+    assert body["visits"] == []
+
+
+@pytest.mark.asyncio
+async def test_engagement_returns_visits_payload() -> None:
+    visits = [_visit("hiresense-abc"), _visit("hiresense-def")]
+    app = _app(engagement=_FakeEngagementService(visits))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        body = (await client.get("/portfolio/engagement")).json()
+    assert body["configured"] is True
+    assert len(body["visits"]) == 2
+    refs = {v["ref"] for v in body["visits"]}
+    assert refs == {"hiresense-abc", "hiresense-def"}

--- a/backend/tests/unit/portfolio/test_supabase_engagement_adapter.py
+++ b/backend/tests/unit/portfolio/test_supabase_engagement_adapter.py
@@ -1,0 +1,162 @@
+"""Tests for SupabaseEngagementAdapter.
+
+Uses a fake HTTP client with canned payloads (same pattern as
+test_supabase_adapter.py) to stay DB-free.
+"""
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttp:
+    def __init__(self, payload_by_path: dict):
+        self._payloads = payload_by_path
+        self.calls: list[tuple[str, dict, dict]] = []
+
+    async def get(self, url, headers=None, params=None):
+        self.calls.append((url, dict(headers or {}), dict(params or {})))
+        for path, payload in self._payloads.items():
+            if path in url:
+                return _FakeResponse(payload)
+        raise AssertionError(f"unexpected url {url!r}")
+
+
+# ---------------------------------------------------------------------------
+# Test (a): grouping/aggregation + cv_download attribution
+# Two sessions share "hiresense-app1", one session belongs to "hiresense-app2".
+# cv_download rows: 2 for session 1, 1 for session 3.
+# ---------------------------------------------------------------------------
+
+_SESSIONS_MULTI = [
+    {
+        "id": "s1",
+        "referrer_source": "hiresense-app1",
+        "started_at": "2026-06-01T09:00:00Z",
+        "last_seen_at": "2026-06-05T12:00:00Z",
+        "total_page_views": 3,
+        "country": "ES",
+        "organization": "Acme",
+    },
+    {
+        "id": "s2",
+        "referrer_source": "hiresense-app1",
+        "started_at": "2026-06-03T10:00:00Z",
+        "last_seen_at": "2026-06-10T08:00:00Z",
+        "total_page_views": 2,
+        "country": "DE",
+        "organization": "Beta GmbH",
+    },
+    {
+        "id": "s3",
+        "referrer_source": "hiresense-app2",
+        "started_at": "2026-06-07T14:00:00Z",
+        "last_seen_at": "2026-06-09T18:00:00Z",
+        "total_page_views": 5,
+        "country": "US",
+        "organization": None,
+    },
+]
+
+_CV_DOWNLOADS_MULTI = [
+    {"session_id": "s1"},
+    {"session_id": "s1"},  # 2 downloads for s1
+    {"session_id": "s3"},  # 1 download for s3
+]
+
+_PAYLOADS_MULTI = {
+    "/rest/v1/visitor_session": _SESSIONS_MULTI,
+    "/rest/v1/cv_download": _CV_DOWNLOADS_MULTI,
+}
+
+
+@pytest.mark.asyncio
+async def test_grouping_and_aggregation() -> None:
+    from hiresense.portfolio.adapters import SupabaseEngagementAdapter
+
+    http = _FakeHttp(_PAYLOADS_MULTI)
+    adapter = SupabaseEngagementAdapter(
+        http_client=http, base_url="https://xyz.supabase.co", read_key="svc-key"
+    )
+    visits = await adapter.fetch_visits("hiresense")
+
+    by_ref = {v.ref: v for v in visits}
+    assert set(by_ref) == {"hiresense-app1", "hiresense-app2"}
+
+    v1 = by_ref["hiresense-app1"]
+    # first_seen = min(s1.started_at, s2.started_at)
+    assert v1.first_seen.isoformat() == "2026-06-01T09:00:00+00:00"
+    # last_seen = max(s1.last_seen_at, s2.last_seen_at) → s2
+    assert v1.last_seen.isoformat() == "2026-06-10T08:00:00+00:00"
+    # page_views = 3 + 2
+    assert v1.page_views == 5
+    # cv_downloads = 2 (s1) + 0 (s2)
+    assert v1.cv_downloads == 2
+    # country/organization from the latest-last_seen session (s2)
+    assert v1.country == "DE"
+    assert v1.organization == "Beta GmbH"
+
+    v2 = by_ref["hiresense-app2"]
+    assert v2.page_views == 5
+    assert v2.cv_downloads == 1
+    assert v2.country == "US"
+    assert v2.organization is None
+
+
+# ---------------------------------------------------------------------------
+# Test (b): zero sessions → no cv_download call, empty result
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_zero_sessions_no_second_query_and_empty_result() -> None:
+    from hiresense.portfolio.adapters import SupabaseEngagementAdapter
+
+    http = _FakeHttp({"/rest/v1/visitor_session": []})
+    adapter = SupabaseEngagementAdapter(
+        http_client=http, base_url="https://xyz.supabase.co", read_key="svc-key"
+    )
+    visits = await adapter.fetch_visits("hiresense")
+
+    assert visits == []
+    # Only one HTTP call should have been made (the session query).
+    assert len(http.calls) == 1
+    assert "/rest/v1/visitor_session" in http.calls[0][0]
+
+
+# ---------------------------------------------------------------------------
+# Test (c): auth headers carry the read key on both endpoints
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_auth_headers_on_both_endpoints() -> None:
+    from hiresense.portfolio.adapters import SupabaseEngagementAdapter
+
+    captured: list[dict] = []
+
+    class _TrackedHttp(_FakeHttp):
+        async def get(self, url, headers=None, params=None):
+            captured.append(dict(headers or {}))
+            return await super().get(url, headers=headers, params=params)
+
+    http = _TrackedHttp(_PAYLOADS_MULTI)
+    adapter = SupabaseEngagementAdapter(
+        http_client=http, base_url="https://xyz.supabase.co", read_key="my-service-key"
+    )
+    await adapter.fetch_visits("hiresense")
+
+    # Both the session query and cv_download query should carry the key.
+    assert len(captured) == 2
+    for headers in captured:
+        assert headers.get("apikey") == "my-service-key"
+        assert headers.get("Authorization") == "Bearer my-service-key"

--- a/backend/tests/unit/portfolio/test_visit_model.py
+++ b/backend/tests/unit/portfolio/test_visit_model.py
@@ -1,0 +1,40 @@
+from datetime import datetime, timezone
+
+
+def test_portfolio_visit_construction_and_defaults() -> None:
+    from hiresense.portfolio.domain import PortfolioVisit
+
+    now = datetime(2026, 6, 10, 12, 0, 0, tzinfo=timezone.utc)
+    visit = PortfolioVisit(ref="hiresense-abc123", first_seen=now, last_seen=now)
+
+    assert visit.ref == "hiresense-abc123"
+    assert visit.application_id is None
+    assert visit.first_seen == now
+    assert visit.last_seen == now
+    assert visit.page_views == 0
+    assert visit.cv_downloads == 0
+    assert visit.country is None
+    assert visit.organization is None
+
+
+def test_portfolio_visit_all_fields() -> None:
+    from hiresense.portfolio.domain import PortfolioVisit
+
+    first = datetime(2026, 6, 1, 9, 0, 0, tzinfo=timezone.utc)
+    last = datetime(2026, 6, 10, 18, 30, 0, tzinfo=timezone.utc)
+    visit = PortfolioVisit(
+        ref="hiresense-xyz",
+        application_id="xyz",
+        first_seen=first,
+        last_seen=last,
+        page_views=5,
+        cv_downloads=2,
+        country="ES",
+        organization="Acme Corp",
+    )
+
+    assert visit.application_id == "xyz"
+    assert visit.page_views == 5
+    assert visit.cv_downloads == 2
+    assert visit.country == "ES"
+    assert visit.organization == "Acme Corp"

--- a/backend/tests/unit/test_config.py
+++ b/backend/tests/unit/test_config.py
@@ -125,3 +125,18 @@ def test_portfolio_citation_settings_defaults(monkeypatch: pytest.MonkeyPatch) -
     assert settings.portfolio_public_url == ""
     assert settings.portfolio_ref_prefix == "hiresense"
     assert settings.portfolio_relevant_projects_top_n == 2
+
+
+def test_portfolio_analytics_read_key_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+    monkeypatch.setenv("AUTH_USERNAME", "admin")
+    monkeypatch.setenv("AUTH_PASSWORD", "pass")
+    monkeypatch.setenv("JWT_SECRET_KEY", "secret")
+    monkeypatch.setenv("LLM_API_KEY", "sk-test")
+    # Pin against local .env value so the test is not environment-sensitive.
+    monkeypatch.setenv("PORTFOLIO_ANALYTICS_READ_KEY", "")
+
+    from hiresense.config import Settings
+
+    settings = Settings()
+    assert settings.portfolio_analytics_read_key == ""

--- a/docs/superpowers/plans/2026-06-10-portfolio-phase5-engagement.md
+++ b/docs/superpowers/plans/2026-06-10-portfolio-phase5-engagement.md
@@ -1,0 +1,131 @@
+# Portfolio Phase 5 (Engagement Readback) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Read back portfolio visits driven by Phase 3's tracked links (`?ref=hiresense-<application_id>`) and surface "Portfolio visited — N page views, last seen …" on the application detail page plus an engagement card on the analytics dashboard.
+
+**Key facts (verified against the portfolio repo's RLS):**
+- The portfolio records `?ref=` into `visitor_session.referrer_source`; sessions carry `started_at`, `last_seen_at`, `total_page_views`, `country`, `organization`.
+- `visitor_session` SELECT requires an authenticated/service role — the anon key CANNOT read it. The adapter therefore uses a dedicated `PORTFOLIO_ANALYTICS_READ_KEY` (the Supabase **service_role** key, which bypasses RLS; the user pastes it from Supabase Dashboard → Settings → API). Feature is entirely absent when unset.
+- `cv_download(session_id, ...)` is readable with the same key; counts ride along.
+- PostgREST query shapes:
+  - `GET {base}/rest/v1/visitor_session?select=id,referrer_source,started_at,last_seen_at,total_page_views,country,organization&referrer_source=like.{prefix}-*`
+  - `GET {base}/rest/v1/cv_download?select=session_id&session_id=in.(<comma ids>)`
+  - Headers: `apikey: <key>`, `Authorization: Bearer <key>`.
+
+**Working directory:** `C:\Users\Bryan\worktrees\hiresense-portfolio` (branch `feat/portfolio-engagement`, stacked on `feat/network-linkedin`; PR base = that branch). **Quirks:** `uv run python -m pytest` only; no repo-wide `ruff format`; frontend lint via `npx ng lint`; commit trailer `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+**Failure semantics:** read key unset → endpoint returns `{"configured": false, "visits": []}` and the frontend renders nothing. Adapter/network errors → log warning, return `{"configured": true, "visits": []}` ("no data", never a 5xx for a dashboard accessory).
+
+---
+
+### Task 1: Config + `PortfolioVisit` + engagement port
+
+**Files:** modify `backend/src/hiresense/config.py`, `.env.example` (+ local `.env` gets the empty key); create `portfolio/domain/portfolio_visit.py`, `portfolio/ports/engagement_source.py`; modify both `__init__.py`s; tests appended to `tests/unit/test_config.py` + new `tests/unit/portfolio/test_visit_model.py`
+
+- Config (portfolio block): `portfolio_analytics_read_key: str = ""` with comment "Supabase service_role key for reading visitor analytics (Dashboard → Settings → API). Empty disables engagement readback entirely." Config test pins it via monkeypatch and asserts default "".
+- `PortfolioVisit` (pydantic): `ref: str`, `application_id: str | None = None`, `first_seen: datetime`, `last_seen: datetime`, `page_views: int = 0`, `cv_downloads: int = 0`, `country: str | None = None`, `organization: str | None = None`.
+- `PortfolioEngagementPort(Protocol)`: `async fetch_visits(self, ref_prefix: str) -> list[PortfolioVisit]` (visits grouped per ref; `application_id` left None — the service derives it).
+- Model test: construction defaults; that's it (pure data).
+- `.env.example` line; local `.env` gets `PORTFOLIO_ANALYTICS_READ_KEY=` (empty — the user fills it later).
+- **Commit:** `feat(portfolio): engagement visit model and port`.
+
+---
+
+### Task 2: `SupabaseEngagementAdapter`
+
+**Files:** create `portfolio/adapters/supabase_engagement.py`; modify `adapters/__init__.py`; test `tests/unit/portfolio/test_supabase_engagement_adapter.py`
+
+Implementation contract (mirror `supabase_portfolio.py` style — fake http client tests with canned payloads):
+
+```python
+class SupabaseEngagementAdapter:
+    def __init__(self, http_client, base_url: str, read_key: str) -> None: ...
+    async def fetch_visits(self, ref_prefix: str) -> list[PortfolioVisit]: ...
+```
+
+- Query 1: visitor_session filtered `referrer_source=like.{ref_prefix}-*` (params dict: `{"select": "id,referrer_source,started_at,last_seen_at,total_page_views,country,organization", "referrer_source": f"like.{ref_prefix}-*"}`), raise_for_status.
+- Query 2 (only when sessions exist): cv_download with `{"select": "session_id", "session_id": f"in.({','.join(ids)})"}` → count per session_id.
+- Group sessions by `referrer_source` → one `PortfolioVisit` per ref: `first_seen=min(started_at)`, `last_seen=max(last_seen_at)`, `page_views=sum(total_page_views or 0)`, `cv_downloads=sum(counts of that ref's sessions)`, `country`/`organization` from the session with the latest `last_seen_at` (may be None). Parse timestamps with `datetime.fromisoformat` (PostgREST emits ISO 8601; handle the `Z`→`+00:00` replacement if needed).
+- Tests: (a) two sessions sharing one ref + one with another ref → grouped correctly, sums/min/max right, cv_download counts attributed; (b) zero sessions → no second query, empty list; (c) auth headers carry the read key.
+- **Commit:** `feat(portfolio): supabase engagement adapter`.
+
+---
+
+### Task 3: Engagement service + endpoint + bootstrap
+
+**Files:** create `portfolio/domain/engagement_service.py` (re-export); modify `portfolio/api/provider.py` (optional `engagement_service=None` param + getter), `portfolio/api/dependencies.py` (`get_engagement_service` None-degrading), `portfolio/api/routes.py` (new GET), `bootstrap/portfolio.py`; tests `tests/unit/portfolio/test_engagement_service.py` + extend `tests/unit/portfolio/test_routes.py` + `test_bootstrap.py`
+
+- `PortfolioEngagementService(source: PortfolioEngagementPort, *, ref_prefix: str)`: `async visits() -> list[PortfolioVisit]` — calls `source.fetch_visits(ref_prefix)`, sets `application_id = ref.removeprefix(f"{ref_prefix}-")` when the ref has that prefix (else None), sorts by `last_seen` desc. Exceptions: catch, `logger.warning`, return [] (the "no data" rule).
+- Route:
+
+```python
+class EngagementResponse(BaseModel):
+    configured: bool
+    visits: list[PortfolioVisit]
+
+
+@router.get("/engagement", response_model=EngagementResponse)
+async def engagement(
+    service: Annotated[PortfolioEngagementService | None, Depends(get_engagement_service)],
+) -> EngagementResponse:
+    if service is None:
+        return EngagementResponse(configured=False, visits=[])
+    return EngagementResponse(configured=True, visits=await service.visits())
+```
+
+- Bootstrap: build engagement only when `s.portfolio_analytics_read_key` AND `s.portfolio_supabase_url` are both non-empty:
+
+```python
+    engagement_service = None
+    if s.portfolio_analytics_read_key and s.portfolio_supabase_url:
+        engagement_service = PortfolioEngagementService(
+            source=SupabaseEngagementAdapter(
+                http_client=infra.http_client,
+                base_url=s.portfolio_supabase_url,
+                read_key=s.portfolio_analytics_read_key,
+            ),
+            ref_prefix=s.portfolio_ref_prefix,
+        )
+```
+
+  passed as `engagement_service=engagement_service` to the provider (provider param optional, default None; getter returns it). Extend `_Settings` in test_bootstrap with `portfolio_analytics_read_key = ""`; add tests: key unset → `get_engagement_service() is None`; key+url set → not None.
+- Service tests: ref parsing (prefix match / foreign ref → None), sort order, source exception → [].
+- Route tests: unconfigured → `{"configured": false, "visits": []}`; configured fake service → visits serialized.
+- **Commit:** `feat(portfolio): engagement endpoint`.
+
+---
+
+### Task 4: Frontend — application chip + analytics card
+
+**Files:** modify `frontend/src/app/core/services/portfolio.service.ts` (+spec) adding `engagement()`; create `pages/profile/models/portfolio-engagement.model.ts` (`PortfolioVisit` + `EngagementResponse` interfaces, snake_case fields matching backend); application-detail chip; analytics card. READ the existing structures first: `pages/applications/application-detail.component.{ts,html}` (where status/header info renders — put the chip near the header) and `pages/analytics/analytics.component.{ts,html}` (how cards are laid out).
+
+- `portfolio.service.ts`: `engagement(): Observable<EngagementResponse>` GET `/portfolio/engagement`. Spec test.
+- **Application detail chip**: on init (application id known), call `engagement()` once (`takeUntilDestroyed`); find the visit whose `application_id === this.applicationId` (however the component exposes it — read it); when found render near the header:
+
+```html
+@if (portfolioVisit(); as visit) {
+  <span class="portfolio-visit-chip" [title]="'First seen ' + (visit.first_seen | date: 'medium')">
+    👀 Portfolio visited — {{ visit.page_views }} page views · last {{ visit.last_seen | date: 'mediumDate' }}
+    @if (visit.cv_downloads > 0) { · {{ visit.cv_downloads }} CV downloads }
+  </span>
+}
+```
+
+  Hidden when `configured` false or no matching visit (signal stays null). Spec: flush a response containing the matching visit → chip text appears; empty response → no chip.
+- **Analytics card**: a small "Portfolio engagement" card listing up to 10 visits (most recent first): application_id short form (or full ref when application_id null), page_views, cv_downloads, last_seen, country/organization when present. Render the card ONLY when `configured && visits.length > 0`. Follow the page's existing card markup conventions. Spec: card renders rows from a flushed response; absent when unconfigured.
+- Full `npm test` + `npx ng lint` clean.
+- **Commit:** `feat(portfolio): engagement chip and analytics card`.
+
+---
+
+### Task 5: Verification + smoke + stacked PR
+
+- Backend full suite + ruff; frontend tests + lint.
+- Live smoke (key NOT configured — expected for now): `GET /portfolio/engagement` with auth → `{"configured": false, "visits": []}`; app boots clean. THEN, if `PORTFOLIO_ANALYTICS_READ_KEY` is present in `.env` at smoke time, also verify the configured path against the real Supabase (visits may legitimately be empty — assert configured: true and no 5xx).
+- Push `feat/portfolio-engagement`; PR base `feat/network-linkedin`, title `feat(portfolio): engagement readback (Phase 5)`; body: RLS rationale for the service key, activation instructions (paste key into .env), failure semantics, smoke evidence; Claude Code footer.
+
+## Self-review notes (applied)
+- Spec Part D fully covered; the "separate read key" decision is now grounded in the verified RLS (`auth.uid() IS NOT NULL` on visitor_session).
+- No migration, no new module — everything rides the portfolio context.
+- Endpoint is read-only and cheap (2 outbound queries) — not rate-limited (consistent with other GET accessories), auth-gated by the router.

--- a/docs/superpowers/specs/2026-06-10-getonboard-account-research.md
+++ b/docs/superpowers/specs/2026-06-10-getonboard-account-research.md
@@ -1,0 +1,44 @@
+# GetOnBoard Account Sync — Research Note (Phase 6: DROPPED)
+
+**Date:** 2026-06-10
+**Verdict:** NOT FEASIBLE — feature dropped per the external-sources spec's Part C gate.
+
+## Question
+
+Can HireSense auto-sync the candidate's own GetOnBoard application statuses into the
+tracking module via an authenticated API?
+
+## Findings (high confidence)
+
+- GetOnBoard's private API is **explicitly company/employer-only**: "This version is
+  exclusive for companies with an active subscription to any of our plans" (user
+  manual). API keys exist only in company dashboards.
+- The private resource set (confirmed via the official `getonbrd/getonbrd-ruby`
+  client) is entirely ATS-facing: Job, Process, Application (applications RECEIVED by
+  the employer), Professional, Phase, Message, Note, Answer, Webhook. There is **no**
+  `/me`, `/my-applications`, saved-jobs, or any candidate-scoped endpoint.
+- Webhooks: companies get 5 events (job/application lifecycle); professionals get
+  exactly ONE — "a job matches your profile" (a recommendation push). No
+  application-status event exists for candidates.
+
+Sources: getonbrd.com/user-manual/get-on-board-s-api,
+getonbrd.com/help/what-can-i-do-with-get-on-board-s-api,
+github.com/getonbrd/getonbrd-ruby,
+getonbrd.com/help/what-webhook-events-does-get-on-board-send.
+
+## What would change the verdict
+
+A candidate-scoped token + `GET /me/applications`, or a professional webhook for
+application state changes. Neither exists today. Definitive re-test: log into a
+professional account → Settings → check for an API key field.
+
+## Alternative (not pursued)
+
+GetOnBoard emails candidates on application events; parsing those (Gmail/IMAP) could
+approximate status sync without API cooperation. Fragile (format-dependent) and out of
+scope — revisit only if status sync becomes a priority.
+
+## Disposition
+
+Part C of `2026-06-09-external-sources-integration-design.md` is closed as dropped.
+Manual status tracking (the existing tracking module) remains the GetOnBoard path.

--- a/frontend/src/app/core/services/portfolio.service.spec.ts
+++ b/frontend/src/app/core/services/portfolio.service.spec.ts
@@ -43,4 +43,20 @@ describe('PortfolioService', () => {
     expect(req.request.method).toBe('POST');
     req.flush({ counts_by_source: { supabase: 3 }, errors: {}, synced_at: '2026-06-09T00:00:00Z' });
   });
+
+  it('fetches engagement data', () => {
+    const visit = {
+      ref: 'ref-1', application_id: 'app-1', first_seen: '2026-06-01T00:00:00Z',
+      last_seen: '2026-06-09T00:00:00Z', page_views: 3, cv_downloads: 1,
+      country: 'US', organization: 'Acme',
+    };
+    service.engagement().subscribe((res) => {
+      expect(res.configured).toBe(true);
+      expect(res.visits.length).toBe(1);
+      expect(res.visits[0].application_id).toBe('app-1');
+    });
+    const req = httpMock.expectOne(`${environment.apiUrl}/portfolio/engagement`);
+    expect(req.request.method).toBe('GET');
+    req.flush({ configured: true, visits: [visit] });
+  });
 });

--- a/frontend/src/app/core/services/portfolio.service.ts
+++ b/frontend/src/app/core/services/portfolio.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 import { PortfolioProjectsResponse } from '../../pages/profile/models/portfolio-projects-response.model';
 import { PortfolioSyncResult } from '../../pages/profile/models/portfolio-sync-result.model';
+import { PortfolioEngagementResponse } from '../../pages/profile/models/portfolio-engagement.model';
 
 @Injectable({ providedIn: 'root' })
 export class PortfolioService {
@@ -16,5 +17,9 @@ export class PortfolioService {
 
   sync(): Observable<PortfolioSyncResult> {
     return this.http.post<PortfolioSyncResult>(`${this.base}/sync`, {});
+  }
+
+  engagement(): Observable<PortfolioEngagementResponse> {
+    return this.http.get<PortfolioEngagementResponse>(`${this.base}/engagement`);
   }
 }

--- a/frontend/src/app/pages/analytics/analytics.component.html
+++ b/frontend/src/app/pages/analytics/analytics.component.html
@@ -57,6 +57,32 @@
       @else { <p class="section-loading">Loading…</p> }
     </section>
 
+    <!-- Portfolio engagement -->
+    @if (engagement(); as e) {
+      @if (e.configured && e.visits.length > 0) {
+        <section class="analytics-card analytics-card-wide">
+          <h2 class="card-title">Portfolio engagement</h2>
+          <ul class="engagement-list">
+            @for (visit of engagementRows(e); track visit.ref) {
+              <li class="engagement-row">
+                <span class="engagement-id" [title]="visitLabel(visit)">{{ visitLabel(visit) }}</span>
+                <span class="engagement-views">{{ visit.page_views }} views</span>
+                @if (visit.cv_downloads > 0) {
+                  <span class="engagement-cv">{{ visit.cv_downloads }} CV</span>
+                }
+                <span class="engagement-date">{{ visit.last_seen | date: 'mediumDate' }}</span>
+                @if (visit.organization) {
+                  <span class="engagement-meta">{{ visit.organization }}</span>
+                } @else if (visit.country) {
+                  <span class="engagement-meta">{{ visit.country }}</span>
+                }
+              </li>
+            }
+          </ul>
+        </section>
+      }
+    }
+
   </div>
 
   <!-- Market context (secondary) -->

--- a/frontend/src/app/pages/analytics/analytics.component.scss
+++ b/frontend/src/app/pages/analytics/analytics.component.scss
@@ -106,6 +106,48 @@
 }
 .source-rate-unit { font-family: var(--font-body); font-size: 0.72rem; font-weight: 500; color: var(--text-muted); }
 
+/* Portfolio engagement visit list. */
+.engagement-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+.engagement-row {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 0.875rem;
+
+  &:last-child { border-bottom: none; }
+}
+.engagement-id {
+  font-weight: 600;
+  color: var(--text-primary);
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: none;
+}
+.engagement-views { color: var(--text-secondary); flex: none; }
+.engagement-cv {
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: #dbeafe;
+  color: #1e40af;
+  font-size: 0.78rem;
+  font-weight: 600;
+  flex: none;
+}
+.engagement-date { color: var(--text-muted); font-size: 0.8rem; flex: none; margin-left: auto; }
+.engagement-meta { color: var(--text-muted); font-size: 0.78rem; flex: none; }
+
 /* Market context demoted into a collapsible footer. */
 .analytics-context {
   margin-top: 1.5rem;

--- a/frontend/src/app/pages/analytics/analytics.component.spec.ts
+++ b/frontend/src/app/pages/analytics/analytics.component.spec.ts
@@ -2,8 +2,10 @@ import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { AnalyticsComponent } from './analytics.component';
 import { AnalyticsService } from '../../core/services/analytics.service';
+import { PortfolioService } from '../../core/services/portfolio.service';
+import { PortfolioEngagementResponse } from '../profile/models/portfolio-engagement.model';
 
-function makeService(over: Partial<Record<string, unknown>> = {}) {
+function makeAnalyticsService(over: Partial<Record<string, unknown>> = {}) {
   return {
     funnel: () => of({ stages: [], rejected: 0, current_rejected: 0, total_applications: 0, by_source: [] }),
     market: () => of({ top_skills: [{ skill: 'python', count: 3, pct: 75 }], remote_mix: { remote: 2 },
@@ -21,11 +23,18 @@ function makeService(over: Partial<Record<string, unknown>> = {}) {
   };
 }
 
+function makePortfolioService(engagement: () => unknown = () => of({ configured: false, visits: [] } as PortfolioEngagementResponse)) {
+  return { engagement, listProjects: () => of(null), sync: () => of(null) };
+}
+
 describe('AnalyticsComponent', () => {
-  function mount(service: unknown) {
+  function mount(analyticsService: unknown = makeAnalyticsService(), portfolioService: unknown = makePortfolioService()) {
     TestBed.configureTestingModule({
       imports: [AnalyticsComponent],
-      providers: [{ provide: AnalyticsService, useValue: service }],
+      providers: [
+        { provide: AnalyticsService, useValue: analyticsService },
+        { provide: PortfolioService, useValue: portfolioService },
+      ],
     });
     const fixture = TestBed.createComponent(AnalyticsComponent);
     fixture.detectChanges();
@@ -33,19 +42,44 @@ describe('AnalyticsComponent', () => {
   }
 
   it('renders the KPI strip and the section cards on success', () => {
-    const fixture = mount(makeService());
+    const fixture = mount();
     expect(fixture.nativeElement.querySelector('app-kpi-strip')).not.toBeNull();
     // 3 main sections (Pay, Focus, Performance) + 2 in the Market-context footer.
     expect(fixture.nativeElement.querySelectorAll('.analytics-card').length).toBe(5);
   });
 
   it('renders a top skill from market (in the context section)', () => {
-    const fixture = mount(makeService());
+    const fixture = mount();
     expect(fixture.nativeElement.textContent).toContain('python');
   });
 
   it('shows a section error when an endpoint fails', () => {
-    const fixture = mount(makeService({ funnel: () => throwError(() => new Error('boom')) }));
+    const fixture = mount(makeAnalyticsService({ funnel: () => throwError(() => new Error('boom')) }));
     expect(fixture.nativeElement.querySelector('.section-error')).not.toBeNull();
+  });
+
+  it('renders the portfolio engagement card with visit rows when configured and visits present', () => {
+    const visit = {
+      ref: 'ref-1', application_id: 'app-1', first_seen: '2026-06-01T00:00:00Z',
+      last_seen: '2026-06-09T00:00:00Z', page_views: 5, cv_downloads: 2,
+      country: 'US', organization: 'Acme Corp',
+    };
+    const portfolioSvc = makePortfolioService(() => of({ configured: true, visits: [visit] } as PortfolioEngagementResponse));
+    const fixture = mount(makeAnalyticsService(), portfolioSvc);
+    fixture.detectChanges();
+    const rows = fixture.nativeElement.querySelectorAll('.engagement-row');
+    expect(rows.length).toBe(1);
+    expect(fixture.nativeElement.textContent).toContain('5 views');
+    expect(fixture.nativeElement.textContent).toContain('Acme Corp');
+  });
+
+  it('hides the portfolio engagement card when configured is false', () => {
+    const portfolioSvc = makePortfolioService(() => of({ configured: false, visits: [
+      { ref: 'ref-1', application_id: 'app-1', first_seen: '2026-06-01T00:00:00Z',
+        last_seen: '2026-06-09T00:00:00Z', page_views: 1, cv_downloads: 0, country: null, organization: null },
+    ] } as PortfolioEngagementResponse));
+    const fixture = mount(makeAnalyticsService(), portfolioSvc);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.engagement-row')).toBeNull();
   });
 });

--- a/frontend/src/app/pages/analytics/analytics.component.ts
+++ b/frontend/src/app/pages/analytics/analytics.component.ts
@@ -1,12 +1,15 @@
 import { ChangeDetectionStrategy, Component, DestroyRef, computed, inject, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { DatePipe } from '@angular/common';
 import { AnalyticsService } from '../../core/services/analytics.service';
+import { PortfolioService } from '../../core/services/portfolio.service';
 import { FunnelMetrics } from './models/funnel-metrics.model';
 import { MarketIntel } from './models/market-intel.model';
 import { SkillGap } from './models/skill-gap.model';
 import { CompBenchmark } from './models/comp-benchmark.model';
 import { SearchFocus } from './models/search-focus.model';
 import { BarRow } from './models/bar-row.model';
+import { PortfolioEngagementResponse, PortfolioVisit } from '../profile/models/portfolio-engagement.model';
 import { BarChartComponent } from './components/bar-chart/bar-chart.component';
 import { FunnelChartComponent } from './components/funnel-chart/funnel-chart.component';
 import { TrendLineComponent } from './components/trend-line/trend-line.component';
@@ -16,10 +19,13 @@ import { KpiStripComponent, KpiTile } from './components/kpi-strip/kpi-strip.com
 
 const PERCENT = 100;
 
+const ENGAGEMENT_ROW_CAP = 10;
+
 @Component({
   selector: 'app-analytics',
   standalone: true,
   imports: [
+    DatePipe,
     BarChartComponent,
     FunnelChartComponent,
     TrendLineComponent,
@@ -33,6 +39,7 @@ const PERCENT = 100;
 })
 export class AnalyticsComponent implements OnInit {
   private analytics = inject(AnalyticsService);
+  private portfolioService = inject(PortfolioService);
   private destroyRef = inject(DestroyRef);
 
   funnel = signal<FunnelMetrics | null>(null);
@@ -50,6 +57,8 @@ export class AnalyticsComponent implements OnInit {
   focus = signal<SearchFocus | null>(null);
   focusError = signal(false);
 
+  engagement = signal<PortfolioEngagementResponse | null>(null);
+
   ngOnInit(): void {
     this.analytics.funnel().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (v) => this.funnel.set(v), error: () => this.funnelError.set(true),
@@ -65,6 +74,10 @@ export class AnalyticsComponent implements OnInit {
     });
     this.analytics.focus().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
       next: (v) => this.focus.set(v), error: () => this.focusError.set(true),
+    });
+    this.portfolioService.engagement().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (v) => this.engagement.set(v),
+      error: () => { /* keep empty on error */ },
     });
   }
 
@@ -136,5 +149,13 @@ export class AnalyticsComponent implements OnInit {
 
   fmt(v: number | null): string {
     return v === null ? '—' : v.toLocaleString('en-US');
+  }
+
+  engagementRows(e: PortfolioEngagementResponse): PortfolioVisit[] {
+    return e.visits.slice(0, ENGAGEMENT_ROW_CAP);
+  }
+
+  visitLabel(visit: PortfolioVisit): string {
+    return visit.application_id ?? visit.ref;
   }
 }

--- a/frontend/src/app/pages/applications/application-detail.component.html
+++ b/frontend/src/app/pages/applications/application-detail.component.html
@@ -15,6 +15,11 @@
             <span class="applied-at">· Applied {{ agg.applied_at | date:'mediumDate' }}</span>
           }
         </p>
+        @if (portfolioVisit(); as visit) {
+          <span class="portfolio-visit-chip" [title]="'First seen ' + (visit.first_seen | date: 'medium')">
+            👀 Portfolio visited — {{ visit.page_views }} page views · last {{ visit.last_seen | date: 'mediumDate' }}@if (visit.cv_downloads > 0) {<ng-container> · {{ visit.cv_downloads }} CV downloads</ng-container>}
+          </span>
+        }
       </div>
       <div class="header-actions">
         @if (agg.url) {

--- a/frontend/src/app/pages/applications/application-detail.component.scss
+++ b/frontend/src/app/pages/applications/application-detail.component.scss
@@ -42,6 +42,19 @@
 
 .applied-at { color: #9ca3af; font-size: 0.9em; }
 
+.portfolio-visit-chip {
+  display: inline-flex;
+  align-items: center;
+  margin-top: 0.4rem;
+  padding: 3px 10px;
+  border-radius: 12px;
+  background: #ecfdf5;
+  color: #065f46;
+  border: 1px solid #a7f3d0;
+  font-size: 0.85em;
+  font-weight: 500;
+}
+
 .tabs {
   display: flex;
   gap: 4px;

--- a/frontend/src/app/pages/applications/application-detail.component.spec.ts
+++ b/frontend/src/app/pages/applications/application-detail.component.spec.ts
@@ -6,7 +6,9 @@ import { ApplicationDetailComponent } from './application-detail.component';
 import { ApplicationsService } from '../../core/services/applications.service';
 import { CvOptimizationRunnerService } from '../../core/services/cv-optimization-runner.service';
 import { CoverLetterRunnerService } from '../../core/services/cover-letter-runner.service';
+import { PortfolioService } from '../../core/services/portfolio.service';
 import { ApplicationAggregate } from './models/application-aggregate.model';
+import { PortfolioEngagementResponse } from '../profile/models/portfolio-engagement.model';
 
 function makeAggregate(over: Partial<ApplicationAggregate> = {}): ApplicationAggregate {
   return {
@@ -48,12 +50,14 @@ describe('ApplicationDetailComponent', () => {
     navigate?: ReturnType<typeof vi.fn>;
     optCompleted$?: Subject<string>;
     clCompleted$?: Subject<string>;
+    engagement?: () => unknown;
   } = {}) {
     const get = vi.fn(opts.get ?? (() => of(makeAggregate())));
     const remove = vi.fn(opts.remove ?? (() => of(undefined)));
     const navigate = opts.navigate ?? vi.fn();
     const optCompleted$ = opts.optCompleted$ ?? new Subject<string>();
     const clCompleted$ = opts.clCompleted$ ?? new Subject<string>();
+    const engagement = vi.fn(opts.engagement ?? (() => of({ configured: false, visits: [] } as PortfolioEngagementResponse)));
 
     const route = {
       snapshot: {
@@ -83,11 +87,12 @@ describe('ApplicationDetailComponent', () => {
         { provide: ApplicationsService, useValue: { get, remove } },
         { provide: CvOptimizationRunnerService, useValue: optRunner },
         { provide: CoverLetterRunnerService, useValue: clRunner },
+        { provide: PortfolioService, useValue: { engagement, listProjects: vi.fn(), sync: vi.fn() } },
       ],
     });
     const fixture = TestBed.createComponent(ApplicationDetailComponent);
     fixture.detectChanges();
-    return { fixture, get, remove, navigate, optCompleted$, clCompleted$ };
+    return { fixture, get, remove, navigate, optCompleted$, clCompleted$, engagement };
   }
 
   it('loads the aggregate on init and renders the header', () => {
@@ -192,5 +197,28 @@ describe('ApplicationDetailComponent', () => {
     fixture.componentInstance.remove();
     expect(fixture.componentInstance.error()).toBe('cannot');
     expect(fixture.componentInstance.deleting()).toBe(false);
+  });
+
+  it('shows the portfolio visit chip when a matching visit exists', () => {
+    const visit = {
+      ref: 'ref-1', application_id: 'app-1', first_seen: '2026-06-01T00:00:00Z',
+      last_seen: '2026-06-09T00:00:00Z', page_views: 3, cv_downloads: 0,
+      country: 'US', organization: 'Acme',
+    };
+    const { fixture } = mount({
+      engagement: () => of({ configured: true, visits: [visit] } as PortfolioEngagementResponse),
+    });
+    fixture.detectChanges();
+    const chip = fixture.nativeElement.querySelector('.portfolio-visit-chip');
+    expect(chip).not.toBeNull();
+    expect(chip.textContent).toContain('Portfolio visited — 3 page views');
+  });
+
+  it('hides the portfolio visit chip when visits list is empty', () => {
+    const { fixture } = mount({
+      engagement: () => of({ configured: true, visits: [] } as PortfolioEngagementResponse),
+    });
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.portfolio-visit-chip')).toBeNull();
   });
 });

--- a/frontend/src/app/pages/applications/application-detail.component.ts
+++ b/frontend/src/app/pages/applications/application-detail.component.ts
@@ -5,7 +5,9 @@ import { TitleCasePipe, DatePipe } from '@angular/common';
 import { ApplicationsService } from '../../core/services/applications.service';
 import { CoverLetterRunnerService } from '../../core/services/cover-letter-runner.service';
 import { CvOptimizationRunnerService } from '../../core/services/cv-optimization-runner.service';
+import { PortfolioService } from '../../core/services/portfolio.service';
 import { ApplicationAggregate } from './models/application-aggregate.model';
+import { PortfolioVisit } from '../profile/models/portfolio-engagement.model';
 import { JobTabComponent } from './components/job-tab.component';
 import { MatchTabComponent } from './components/match-tab.component';
 import { CvTabComponent } from './components/cv-tab.component';
@@ -37,6 +39,7 @@ export class ApplicationDetailComponent implements OnInit {
   private service = inject(ApplicationsService);
   private optimizationRunner = inject(CvOptimizationRunnerService);
   private coverLetterRunner = inject(CoverLetterRunnerService);
+  private portfolioService = inject(PortfolioService);
   private destroyRef = inject(DestroyRef);
 
   aggregate = signal<ApplicationAggregate | null>(null);
@@ -44,6 +47,7 @@ export class ApplicationDetailComponent implements OnInit {
   error = signal('');
   activeTab = signal<TabKey>('job');
   deleting = signal(false);
+  portfolioVisit = signal<PortfolioVisit | null>(null);
 
   ngOnInit(): void {
     const id = this.route.snapshot.paramMap.get('id');
@@ -56,6 +60,14 @@ export class ApplicationDetailComponent implements OnInit {
       this.activeTab.set(tab);
     }
     this.load(id);
+    this.portfolioService.engagement().pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
+      next: (res) => {
+        if (!res.configured) return;
+        const match = res.visits.find((v) => v.application_id === id) ?? null;
+        this.portfolioVisit.set(match);
+      },
+      error: () => { /* accessory — swallow silently */ },
+    });
 
     // Refetch the aggregate whenever a background CV optimization or cover
     // letter generation finishes — even if the user has switched tabs since

--- a/frontend/src/app/pages/profile/models/portfolio-engagement.model.ts
+++ b/frontend/src/app/pages/profile/models/portfolio-engagement.model.ts
@@ -1,0 +1,15 @@
+export interface PortfolioVisit {
+  ref: string;
+  application_id: string | null;
+  first_seen: string;
+  last_seen: string;
+  page_views: number;
+  cv_downloads: number;
+  country: string | null;
+  organization: string | null;
+}
+
+export interface PortfolioEngagementResponse {
+  configured: boolean;
+  visits: PortfolioVisit[];
+}


### PR DESCRIPTION
Replacement for #88 (auto-closed by stacked-base deletion). Same commits; full description, activation instructions, and smoke evidence in #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)