### PR TITLE
feat(portfolio): per-project toggle to include/exclude from matching (#95)

### DIFF
--- a/backend/alembic/versions/029_add_portfolio_projects_include_in_matching.py
+++ b/backend/alembic/versions/029_add_portfolio_projects_include_in_matching.py
@@ -1,0 +1,32 @@
+"""add include_in_matching column to portfolio_projects
+
+Revision ID: 029
+Revises: 028
+Create Date: 2026-06-13
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "029"
+down_revision: Union[str, None] = "028"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "portfolio_projects",
+        sa.Column(
+            "include_in_matching",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.true(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("portfolio_projects", "include_in_matching")

--- a/backend/src/hiresense/portfolio/api/routes.py
+++ b/backend/src/hiresense/portfolio/api/routes.py
@@ -75,6 +75,28 @@ async def list_projects(
     return ProjectsResponse(projects=projects, total=total, last_synced_at=last)
 
 
+class MatchingUpdate(BaseModel):
+    include_in_matching: bool
+
+
+@router.patch("/projects/{project_id}/matching", status_code=200)
+async def set_project_matching(
+    project_id: str,
+    body: MatchingUpdate,
+    repository: Annotated[
+        PortfolioProjectsRepositoryPort | None, Depends(get_projects_repository)
+    ],
+) -> dict[str, bool]:
+    if repository is None:
+        raise HTTPException(status_code=404, detail="Portfolio not configured")
+    updated = await asyncio.to_thread(
+        repository.set_include_in_matching, project_id, body.include_in_matching
+    )
+    if not updated:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return {"include_in_matching": body.include_in_matching}
+
+
 class EngagementResponse(BaseModel):
     configured: bool
     visits: list[PortfolioVisit]

--- a/backend/src/hiresense/portfolio/domain/enrichment_service.py
+++ b/backend/src/hiresense/portfolio/domain/enrichment_service.py
@@ -25,7 +25,7 @@ class PortfolioEnrichmentService:
         self._char_cap = char_cap
 
     async def enrichment(self) -> tuple[list[str], str]:
-        projects = await asyncio.to_thread(self._repository.list_all)
+        projects = await asyncio.to_thread(self._repository.list_for_matching)
         if not projects:
             return [], ""
         skills = sorted({tech for project in projects for tech in project.tech})

--- a/backend/src/hiresense/portfolio/domain/portfolio_project.py
+++ b/backend/src/hiresense/portfolio/domain/portfolio_project.py
@@ -15,6 +15,9 @@ class PortfolioProject(BaseModel):
     demo_url: str | None = None
     pinned: bool = False
     position: int | None = None
+    # When False, this project's tech tags + summary are excluded from
+    # skill-matching enrichment (does not affect job-specific citations).
+    include_in_matching: bool = True
     tech: list[str] = Field(default_factory=list)
     translations: dict[str, ProjectText] = Field(default_factory=dict)
 

--- a/backend/src/hiresense/portfolio/infrastructure/orm.py
+++ b/backend/src/hiresense/portfolio/infrastructure/orm.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, Index, Integer, String, UniqueConstraint
+from sqlalchemy import Boolean, DateTime, Index, Integer, String, UniqueConstraint, true
 from sqlalchemy.orm import Mapped, mapped_column
 
 from hiresense.infrastructure import JSONB_OR_JSON
@@ -25,6 +25,9 @@ class PortfolioProjectOrm(Base):
     demo_url: Mapped[str | None] = mapped_column(String(2048), nullable=True)
     pinned: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     position: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    include_in_matching: Mapped[bool] = mapped_column(
+        Boolean, default=True, server_default=true(), nullable=False
+    )
     tech: Mapped[list] = mapped_column(JSONB_OR_JSON, default=list)
     translations: Mapped[dict] = mapped_column(JSONB_OR_JSON, default=dict)
     synced_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/backend/src/hiresense/portfolio/infrastructure/repository.py
+++ b/backend/src/hiresense/portfolio/infrastructure/repository.py
@@ -18,6 +18,7 @@ def _to_orm(project: PortfolioProject, synced_at: datetime) -> PortfolioProjectO
         demo_url=project.demo_url,
         pinned=project.pinned,
         position=project.position,
+        include_in_matching=project.include_in_matching,
         tech=list(project.tech),
         translations={k: v.model_dump() for k, v in project.translations.items()},
         synced_at=synced_at,
@@ -33,6 +34,7 @@ def _to_domain(row: PortfolioProjectOrm) -> PortfolioProject:
         demo_url=row.demo_url,
         pinned=row.pinned,
         position=row.position,
+        include_in_matching=row.include_in_matching,
         tech=list(row.tech or []),
         translations={k: ProjectText(**v) for k, v in (row.translations or {}).items()},
     )
@@ -44,16 +46,44 @@ class PortfolioProjectsRepository(SqlRepository):
     def replace_source(self, source: str, projects: list[PortfolioProject]) -> int:
         now = datetime.now(timezone.utc)
         with self._session_factory() as session:
+            # Preserve the user's include_in_matching choice across re-sync: the
+            # DELETE+re-INSERT below would otherwise reset every project to the
+            # default. New projects (unseen source_key) keep their incoming default.
+            kept_flag = {
+                row.source_key: row.include_in_matching
+                for row in session.scalars(
+                    select(PortfolioProjectOrm).where(PortfolioProjectOrm.source == source)
+                ).all()
+            }
             session.execute(
                 delete(PortfolioProjectOrm).where(PortfolioProjectOrm.source == source)
             )
             for project in projects:
-                session.add(_to_orm(project, now))
+                orm = _to_orm(project, now)
+                if project.source_key in kept_flag:
+                    orm.include_in_matching = kept_flag[project.source_key]
+                session.add(orm)
             session.commit()
         return len(projects)
 
     def list_all(self) -> list[PortfolioProject]:
         return self._select_all(select(PortfolioProjectOrm), _to_domain)
+
+    def list_for_matching(self) -> list[PortfolioProject]:
+        return self._select_all(
+            select(PortfolioProjectOrm).where(
+                PortfolioProjectOrm.include_in_matching.is_(True)
+            ),
+            _to_domain,
+        )
+
+    def set_include_in_matching(self, id: str, value: bool) -> bool:
+        return (
+            self._update_by_pk(
+                PortfolioProjectOrm, id, {"include_in_matching": value}, _to_domain
+            )
+            is not None
+        )
 
     def list_page(self, limit: int, offset: int) -> tuple[list[PortfolioProject], int]:
         stmt = (

--- a/backend/src/hiresense/portfolio/ports/projects_repository.py
+++ b/backend/src/hiresense/portfolio/ports/projects_repository.py
@@ -15,6 +15,14 @@ class PortfolioProjectsRepositoryPort(Protocol):
 
     def list_all(self) -> list[PortfolioProject]: ...
 
+    def list_for_matching(self) -> list[PortfolioProject]:
+        """Projects flagged to contribute to skill-matching enrichment."""
+        ...
+
+    def set_include_in_matching(self, id: str, value: bool) -> bool:
+        """Set a project's matching flag; returns False if no row matched `id`."""
+        ...
+
     def list_page(self, limit: int, offset: int) -> tuple[list[PortfolioProject], int]:
         """Return one page (pinned-first, then position, then source_key) and the total count."""
         ...

--- a/backend/tests/unit/portfolio/test_enrichment_service.py
+++ b/backend/tests/unit/portfolio/test_enrichment_service.py
@@ -11,13 +11,14 @@ class _FakeRepo:
     def __init__(self, projects):
         self._projects = projects
 
-    def list_all(self):
-        return self._projects
+    def list_for_matching(self):
+        return [p for p in self._projects if p.include_in_matching]
 
 
-def _project(key: str, tech: list[str]) -> PortfolioProject:
+def _project(key: str, tech: list[str], include_in_matching: bool = True) -> PortfolioProject:
     return PortfolioProject(
         id=key, source="supabase", source_key=key, tech=tech,
+        include_in_matching=include_in_matching,
         translations={"en": ProjectText(title=key.title(), description="d")},
     )
 
@@ -39,3 +40,20 @@ async def test_enrichment_unions_tech_and_builds_text() -> None:
 async def test_enrichment_empty_snapshot() -> None:
     service = PortfolioEnrichmentService(repository=_FakeRepo([]), language="en", char_cap=500)
     assert await service.enrichment() == ([], "")
+
+
+@pytest.mark.asyncio
+async def test_enrichment_excludes_projects_opted_out_of_matching() -> None:
+    service = PortfolioEnrichmentService(
+        repository=_FakeRepo(
+            [
+                _project("a", ["python"]),
+                _project("b", ["rust"], include_in_matching=False),
+            ]
+        ),
+        language="en",
+        char_cap=500,
+    )
+    skills, text = await service.enrichment()
+    assert skills == ["python"]  # rust from the opted-out project is absent
+    assert "B " not in text and "rust" not in text

--- a/backend/tests/unit/portfolio/test_repository.py
+++ b/backend/tests/unit/portfolio/test_repository.py
@@ -86,6 +86,26 @@ def test_list_page_slices_with_limit_and_offset(repo) -> None:
     assert [p.source_key for p in rows] == ["c", "d"]
 
 
+def test_list_for_matching_filters_out_excluded(repo) -> None:
+    repo.replace_source("supabase", [_project("a"), _project("b")])
+    assert repo.set_include_in_matching("id-supabase-b", False) is True
+    keys = {p.source_key for p in repo.list_for_matching()}
+    assert keys == {"a"}
+
+
+def test_set_include_in_matching_unknown_id_returns_false(repo) -> None:
+    assert repo.set_include_in_matching("nope", False) is False
+
+
+def test_include_in_matching_flag_survives_resync(repo) -> None:
+    repo.replace_source("supabase", [_project("a"), _project("b")])
+    repo.set_include_in_matching("id-supabase-b", False)
+    # Re-sync the same source with b still present plus a new project c.
+    repo.replace_source("supabase", [_project("a"), _project("b"), _project("c")])
+    flags = {p.source_key: p.include_in_matching for p in repo.list_all()}
+    assert flags == {"a": True, "b": False, "c": True}  # b stays off, c defaults on
+
+
 def test_last_synced_at_none_then_set(repo) -> None:
     assert repo.last_synced_at() is None
     repo.replace_source("supabase", [_project("a")])

--- a/backend/tests/unit/portfolio/test_routes.py
+++ b/backend/tests/unit/portfolio/test_routes.py
@@ -47,6 +47,12 @@ class _FakeRepo:
     def list_page(self, limit, offset):
         return self._projects[offset : offset + limit], len(self._projects)
 
+    def list_for_matching(self):
+        return [p for p in self._projects if p.include_in_matching]
+
+    def set_include_in_matching(self, id, value):
+        return any(p.id == id for p in self._projects)
+
     def last_synced_at(self):
         return self._last
 
@@ -130,6 +136,27 @@ async def test_list_projects_paginates_with_limit_and_offset() -> None:
         body = (await client.get("/portfolio/projects?limit=2&offset=2")).json()
     assert [p["source_key"] for p in body["projects"]] == ["c", "d"]
     assert body["total"] == 5
+
+
+@pytest.mark.asyncio
+async def test_set_matching_200_on_success() -> None:
+    app = _app(repo=_FakeRepo([_project("a")], None))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.patch(
+            "/portfolio/projects/a/matching", json={"include_in_matching": False}
+        )
+    assert resp.status_code == 200
+    assert resp.json() == {"include_in_matching": False}
+
+
+@pytest.mark.asyncio
+async def test_set_matching_404_for_unknown_id() -> None:
+    app = _app(repo=_FakeRepo([_project("a")], None))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.patch(
+            "/portfolio/projects/zzz/matching", json={"include_in_matching": True}
+        )
+    assert resp.status_code == 404
 
 
 @pytest.mark.asyncio

--- a/frontend/src/app/core/services/portfolio.service.ts
+++ b/frontend/src/app/core/services/portfolio.service.ts
@@ -22,6 +22,13 @@ export class PortfolioService {
     return this.http.post<PortfolioSyncResult>(`${this.base}/sync`, {});
   }
 
+  setMatching(id: string, include_in_matching: boolean): Observable<{ include_in_matching: boolean }> {
+    return this.http.patch<{ include_in_matching: boolean }>(
+      `${this.base}/projects/${id}/matching`,
+      { include_in_matching },
+    );
+  }
+
   engagement(): Observable<PortfolioEngagementResponse> {
     return this.http.get<PortfolioEngagementResponse>(`${this.base}/engagement`);
   }

--- a/frontend/src/app/pages/profile/components/portfolio-card/portfolio-card.component.html
+++ b/frontend/src/app/pages/profile/components/portfolio-card/portfolio-card.component.html
@@ -17,6 +17,9 @@
   @if (total() === 0) {
     <p class="muted">No portfolio projects synced yet.</p>
   } @else {
+    <p class="muted hint">
+      Turn off any project you don't want influencing your job-matching skills.
+    </p>
     <div class="project-grid">
       @for (project of projects(); track project.id) {
         <article class="project-card">
@@ -52,6 +55,15 @@
               }
             </div>
           }
+
+          <label class="matching-toggle">
+            <input
+              type="checkbox"
+              [checked]="project.include_in_matching"
+              (change)="toggleMatching(project, $event)"
+            />
+            <span>Counts toward matching</span>
+          </label>
         </article>
       }
     </div>

--- a/frontend/src/app/pages/profile/components/portfolio-card/portfolio-card.component.scss
+++ b/frontend/src/app/pages/profile/components/portfolio-card/portfolio-card.component.scss
@@ -143,6 +143,28 @@ $shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
   padding-top: 0.25rem;
 }
 
+.matching-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px solid $border;
+  font-size: 0.75rem;
+  color: $text-light;
+  cursor: pointer;
+  user-select: none;
+
+  input {
+    width: auto;
+    cursor: pointer;
+  }
+}
+
+.hint {
+  font-style: italic;
+}
+
 .pagination {
   display: flex;
   align-items: center;

--- a/frontend/src/app/pages/profile/components/portfolio-card/portfolio-card.component.spec.ts
+++ b/frontend/src/app/pages/profile/components/portfolio-card/portfolio-card.component.spec.ts
@@ -29,7 +29,7 @@ describe('PortfolioCardComponent', () => {
   function project(over: Record<string, unknown> = {}) {
     return {
       id: 'p1', source: 'supabase', source_key: 'x', url: null, demo_url: null,
-      pinned: false, position: null, tech: [],
+      pinned: false, position: null, include_in_matching: true, tech: [],
       translations: { en: { title: 'X', description: null } },
       ...over,
     };
@@ -94,6 +94,19 @@ describe('PortfolioCardComponent', () => {
     expect(el.querySelector('.project-grid')).toBeTruthy();
     expect(el.textContent ?? '').toContain('AI job hunting');
     expect(el.textContent ?? '').toContain('+2 more');
+  });
+
+  it('toggling "Counts toward matching" patches the project', () => {
+    fixture.detectChanges();
+    flushProjects([project({ id: 'p1', source_key: 'x', include_in_matching: true })], null);
+    const el = fixture.nativeElement as HTMLElement;
+    const checkbox = el.querySelector('.matching-toggle input') as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    checkbox.click(); // unchecks and fires the change handler
+    const req = httpMock.expectOne(`${environment.apiUrl}/portfolio/projects/p1/matching`);
+    expect(req.request.method).toBe('PATCH');
+    expect(req.request.body).toEqual({ include_in_matching: false });
+    req.flush({ include_in_matching: false });
   });
 
   it('paginates with Prev/Next and shows the X–Y of N indicator', () => {

--- a/frontend/src/app/pages/profile/components/portfolio-card/portfolio-card.component.ts
+++ b/frontend/src/app/pages/profile/components/portfolio-card/portfolio-card.component.ts
@@ -62,6 +62,26 @@ export class PortfolioCardComponent implements OnInit {
     return Math.max(0, project.tech.length - MAX_VISIBLE_TECH);
   }
 
+  toggleMatching(project: PortfolioProject, event: Event): void {
+    const value = (event.target as HTMLInputElement).checked;
+    this.setMatchingFlag(project.id, value); // optimistic
+    this.service
+      .setMatching(project.id, value)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        error: () => {
+          this.setMatchingFlag(project.id, !value); // revert
+          this.error.set('Could not update the matching setting');
+        },
+      });
+  }
+
+  private setMatchingFlag(id: string, value: boolean): void {
+    this.projects.update((list) =>
+      list.map((p) => (p.id === id ? { ...p, include_in_matching: value } : p)),
+    );
+  }
+
   prev(): void {
     if (!this.canPrev()) return;
     this.offset.set(Math.max(0, this.offset() - this.pageSize));

--- a/frontend/src/app/pages/profile/models/portfolio-project.model.ts
+++ b/frontend/src/app/pages/profile/models/portfolio-project.model.ts
@@ -11,6 +11,7 @@ export interface PortfolioProject {
   demo_url: string | null;
   pinned: boolean;
   position: number | null;
+  include_in_matching: boolean;
   tech: string[];
   translations: Record<string, PortfolioProjectText>;
 }


### PR DESCRIPTION
## Summary
Adds a per-project **"Counts toward matching"** toggle so noisy repos (e.g. `html`, `dockerfile`) no longer silently inflate the matched skill set. Matching-only scope — job-specific citations are unaffected.

> **Stacked on #96 (feat/94).** Base is `feat/94-portfolio-card-grid`; review/merge after #96. The toggle UI lives on #94's card.

### Backend
- New `include_in_matching` column (NOT NULL, default true) on domain + ORM; **Alembic migration 029**.
- Flag **preserved across re-sync**: `replace_source` reads existing `source_key → flag` before its DELETE+re-INSERT and re-applies it; new projects default to included.
- `list_for_matching()` / `set_include_in_matching(id, value)` repo methods; enrichment switched `list_all` → `list_for_matching`.
- `PATCH /portfolio/projects/{id}/matching` → 200 / 404.

### Frontend
- `PortfolioProject.include_in_matching`; `portfolio.setMatching()`.
- Per-card switch with optimistic update + revert-on-error, plus a one-line hint.

## Test plan
- [x] Backend: `pytest tests/unit/portfolio` (59 passed) — incl. enrichment exclusion, `list_for_matching` filter, flag-survives-resync, PATCH 200/404.
- [x] Migration: single head 029, chains 028 → 029.
- [x] Frontend: `portfolio-card.component.spec.ts` (6 passed) — toggle fires PATCH.
- [x] `ruff check` + `ng lint` clean.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)