### PR TITLE
feat(profile): show personal details edit form only via an Edit button (#93)

### DIFF
--- a/frontend/src/app/pages/profile/components/manual-fields-form/manual-fields-form.component.html
+++ b/frontend/src/app/pages/profile/components/manual-fields-form/manual-fields-form.component.html
@@ -102,10 +102,10 @@
     <button
       type="button"
       class="btn-ghost"
-      (click)="reset()"
-      [disabled]="!isDirty() || saving()"
+      (click)="cancel()"
+      [disabled]="saving()"
     >
-      Discard changes
+      Cancel
     </button>
     <button
       type="submit"

--- a/frontend/src/app/pages/profile/components/manual-fields-form/manual-fields-form.component.spec.ts
+++ b/frontend/src/app/pages/profile/components/manual-fields-form/manual-fields-form.component.spec.ts
@@ -1,0 +1,73 @@
+import { TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { ManualFieldsFormComponent } from './manual-fields-form.component';
+import { ProfileService } from '../../../../core/services/profile.service';
+
+function makeProfile(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'p1',
+    name: 'Ada',
+    email: null,
+    phone: null,
+    location: null,
+    sections: [],
+    raw_tex: '',
+    language: 'en',
+    skills: [],
+    linkedin_url: null,
+    github_url: null,
+    portfolio_url: null,
+    ...over,
+  };
+}
+
+describe('ManualFieldsFormComponent', () => {
+  function mount(
+    updateManualFields = vi.fn(() => of(makeProfile({ name: 'Ada Lovelace' }))),
+  ) {
+    TestBed.configureTestingModule({
+      imports: [ManualFieldsFormComponent],
+      providers: [{ provide: ProfileService, useValue: { updateManualFields } }],
+    });
+    const fixture = TestBed.createComponent(ManualFieldsFormComponent);
+    fixture.componentRef.setInput('profile', makeProfile());
+    fixture.detectChanges();
+    return { fixture, cmp: fixture.componentInstance, updateManualFields };
+  }
+
+  it('save emits saved, refreshes the baseline, and flashes', () => {
+    const { cmp, updateManualFields } = mount();
+    const saved = vi.fn();
+    cmp.saved.subscribe(saved);
+
+    cmp.set('name', 'Grace Hopper');
+    expect(cmp.isDirty()).toBe(true);
+    cmp.save();
+
+    expect(updateManualFields).toHaveBeenCalled();
+    expect(saved).toHaveBeenCalledTimes(1);
+    expect(cmp.savedFlash()).toBe(true);
+    expect(cmp.isDirty()).toBe(false); // baseline updated to the saved profile
+  });
+
+  it('cancel resets the form and emits cancelled', () => {
+    const { cmp } = mount();
+    const cancelled = vi.fn();
+    cmp.cancelled.subscribe(cancelled);
+
+    cmp.set('name', 'Changed');
+    expect(cmp.isDirty()).toBe(true);
+    cmp.cancel();
+
+    expect(cmp.isDirty()).toBe(false);
+    expect(cancelled).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables Save while the form is pristine (dirty-guard)', () => {
+    const { fixture } = mount();
+    const saveBtn = (fixture.nativeElement as HTMLElement).querySelector(
+      'button[type="submit"]',
+    ) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+  });
+});

--- a/frontend/src/app/pages/profile/components/manual-fields-form/manual-fields-form.component.ts
+++ b/frontend/src/app/pages/profile/components/manual-fields-form/manual-fields-form.component.ts
@@ -5,6 +5,7 @@ import {
   effect,
   inject,
   input,
+  output,
   signal,
 } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -49,6 +50,8 @@ export class ManualFieldsFormComponent {
   private readonly destroyRef = inject(DestroyRef);
 
   profile = input.required<CandidateProfile>();
+  readonly saved = output<void>();
+  readonly cancelled = output<void>();
 
   form = signal<ManualFieldsFormState>({
     name: '',
@@ -87,6 +90,11 @@ export class ManualFieldsFormComponent {
     this.error.set('');
   }
 
+  cancel(): void {
+    this.reset();
+    this.cancelled.emit();
+  }
+
   save(): void {
     if (!this.isDirty() || this.saving()) return;
     const current = this.form();
@@ -107,6 +115,7 @@ export class ManualFieldsFormComponent {
         this.baseline.set(snap);
         this.savedFlash.set(true);
         setTimeout(() => this.savedFlash.set(false), 2200);
+        this.saved.emit();
       },
       error: (err) => {
         this.saving.set(false);

--- a/frontend/src/app/pages/profile/profile.component.html
+++ b/frontend/src/app/pages/profile/profile.component.html
@@ -354,7 +354,12 @@
   @if (pageTab() === 'personal') {
   <section class="tab-panel" id="panel-personal" role="tabpanel" aria-labelledby="tab-personal">
     @if (profile(); as p) {
+      @if (!editingPersonal()) {
       <div class="details-card">
+        <div class="details-card-header">
+          <h3 class="details-card-title">Personal details</h3>
+          <button type="button" class="btn-secondary" (click)="editingPersonal.set(true)">Edit</button>
+        </div>
         <div class="details-grid">
           <div class="details-item">
             <span class="details-label">Name</span>
@@ -401,14 +406,17 @@
             }
           </div>
         </div>
-        <p class="details-source-note">
-          Parsed from your uploaded CV. Edit them in the form below.
-        </p>
+        <p class="details-source-note">Parsed from your uploaded CV.</p>
       </div>
-
+      } @else {
       <div class="details-card">
-        <app-manual-fields-form [profile]="p" />
+        <app-manual-fields-form
+          [profile]="p"
+          (saved)="editingPersonal.set(false)"
+          (cancelled)="editingPersonal.set(false)"
+        />
       </div>
+      }
     } @else {
       <div class="empty-state">
         <p class="empty-state-title">No profile yet</p>

--- a/frontend/src/app/pages/profile/profile.component.scss
+++ b/frontend/src/app/pages/profile/profile.component.scss
@@ -694,6 +694,20 @@ $transition: 0.2s ease;
   margin-bottom: 1.25rem;
 }
 
+.details-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.details-card-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
 .details-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/frontend/src/app/pages/profile/profile.component.spec.ts
+++ b/frontend/src/app/pages/profile/profile.component.spec.ts
@@ -145,6 +145,33 @@ describe('ProfileComponent', () => {
     expect(cmp.selectedFile()).toBeNull();
   });
 
+  it('hides the personal-details form until Edit is clicked, then swaps back on save/cancel', () => {
+    const { fixture } = mount({ profiles: { en: makeProfile() } });
+    const cmp = fixture.componentInstance;
+    cmp.pageTab.set('personal');
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+
+    // read-only card visible, form hidden by default
+    expect(cmp.editingPersonal()).toBe(false);
+    expect(el.querySelector('.details-grid')).not.toBeNull();
+    expect(el.querySelector('app-manual-fields-form')).toBeNull();
+
+    // clicking Edit reveals the form and hides the read-only grid
+    const editBtn = [...el.querySelectorAll('button')].find((b) => b.textContent?.trim() === 'Edit')!;
+    editBtn.click();
+    fixture.detectChanges();
+    expect(cmp.editingPersonal()).toBe(true);
+    expect(el.querySelector('app-manual-fields-form')).not.toBeNull();
+    expect(el.querySelector('.details-grid')).toBeNull();
+
+    // saved/cancelled return to the read-only view
+    cmp.editingPersonal.set(false);
+    fixture.detectChanges();
+    expect(el.querySelector('app-manual-fields-form')).toBeNull();
+    expect(el.querySelector('.details-grid')).not.toBeNull();
+  });
+
   it('addAnotherLanguage marks the intent as add', () => {
     const { fixture } = mount({ profiles: { en: makeProfile() } });
     const cmp = fixture.componentInstance;

--- a/frontend/src/app/pages/profile/profile.component.ts
+++ b/frontend/src/app/pages/profile/profile.component.ts
@@ -54,6 +54,7 @@ export class ProfileComponent implements OnInit {
   error = signal('');
   showUploadForm = signal(false);
   uploadIntent = signal<'add' | 'replace'>('add');
+  editingPersonal = signal(false);
 
   profile = this.profileService.profile;
   profiles = this.profileService.profiles;


### PR DESCRIPTION
## Summary
On Profile → **Personal details**, the editable form was always rendered below the read-only card. This adds an explicit **inline edit toggle**.

- Read-only details card now has a header-row **Edit** button; the input form is **not** shown by default.
- Clicking **Edit** swaps the form in place (read-only grid hidden). **Save** or **Cancel** returns to the read-only view.
- `manual-fields-form` gains `saved` + `cancelled` outputs; the former "Discard changes" button becomes **Cancel** (resets + emits `cancelled`, always available to exit edit mode). Save emits `saved` after persisting.
- Removed the now-obsolete "Edit them in the form below" note. Dirty-guard, "Saved" flash, and OnPush preserved.

## Test plan
- [x] `profile.component.spec.ts`: form hidden by default; Edit reveals form + hides read-only grid; save/cancel returns to read-only.
- [x] New `manual-fields-form.component.spec.ts`: save emits `saved` + refreshes baseline + flash; cancel resets + emits `cancelled`; Save disabled when pristine.
- [x] 11 specs pass; `ng lint` clean.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)