### PR TITLE
fix(security): P1 backend hardening — LaTeX shell-escape, admin password hash, outreach rate limits

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,11 @@ SEMANTIC_PROFILE_CACHE_SIZE=8
 #   python -c "import secrets; print(secrets.token_urlsafe(48))"
 AUTH_USERNAME=admin
 AUTH_PASSWORD=changeme
+# Preferred over AUTH_PASSWORD: a scrypt hash so the plaintext never lives in
+# env/config. When set, it takes precedence and AUTH_PASSWORD is ignored.
+# Generate with:
+#   python -c "from hiresense.identity.domain import hash_password; print(hash_password('your-password'))"
+AUTH_PASSWORD_HASH=
 JWT_SECRET_KEY=change-this-to-a-random-secret
 # Role embedded in issued tokens. Single-user instance is admin by default;
 # set to a non-admin value to exercise the admin-only route gate.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -315,6 +315,10 @@ SMTP_USERNAME=
 SMTP_PASSWORD=
 SMTP_USE_TLS=true
 OUTREACH_FROM_EMAIL=
+# Recipient-domain allowlist for POST /outreach/send (comma/JSON list). Empty
+# allows any valid email; set to constrain sends and reduce the authenticated
+# open-relay/cost surface, e.g. ["example.com","gmail.com"].
+OUTREACH_ALLOWED_RECIPIENT_DOMAINS=[]
 
 # --- Scheduler (Autopilot Phase 1) ---
 # Self-drive the recurring pipeline in-process. Set true on EXACTLY ONE process.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "fastapi>=0.139.0",
     "uvicorn[standard]>=0.50.2",
-    "pydantic>=2.13.4",
+    "pydantic[email]>=2.13.4",
     "pydantic-settings>=2.14.2",
     "sqlalchemy[asyncio]>=2.0.51",
     "asyncpg>=0.30.0",

--- a/backend/src/hiresense/adapters/latex/compiler.py
+++ b/backend/src/hiresense/adapters/latex/compiler.py
@@ -76,11 +76,19 @@ class LatexCompiler:
             return pdf_path.read_bytes()
 
     def _run_once(self, working_dir: Path, source: Path):
+        import os
         import subprocess
 
+        # Untrusted LaTeX reaches this compiler (raw user CVs, LLM-spliced
+        # optimized CVs). Disable shell-escape entirely so `\write18{...}` can
+        # never spawn a subprocess (RCE), and set openin_any/openout_any to
+        # "paranoid" so `\input{/etc/passwd}` and friends cannot read/write
+        # files outside the compilation temp dir.
+        env = {**os.environ, "openin_any": "p", "openout_any": "p"}
         return subprocess.run(
             [
                 self._compiler,
+                "-no-shell-escape",
                 "-interaction=nonstopmode",
                 "-halt-on-error",
                 "-output-directory",
@@ -90,6 +98,7 @@ class LatexCompiler:
             cwd=working_dir,
             capture_output=True,
             timeout=self._timeout,
+            env=env,
         )
 
     @staticmethod

--- a/backend/src/hiresense/autohunt/api/routes.py
+++ b/backend/src/hiresense/autohunt/api/routes.py
@@ -4,12 +4,14 @@ from fastapi import APIRouter, Depends, Query, Response
 
 from hiresense.autohunt.api.dependencies import get_autohunt_service
 from hiresense.autohunt.domain import AutoHuntService, Digest
-from hiresense.identity.api.dependencies import require_auth
+from hiresense.identity.api.dependencies import enforce_expensive_rate_limit, require_auth
 
 router = APIRouter(prefix="/autohunt", tags=["autohunt"], dependencies=[Depends(require_auth)])
 
 
-@router.post("/run", response_model=Digest)
+@router.post(
+    "/run", response_model=Digest, dependencies=[Depends(enforce_expensive_rate_limit)]
+)
 async def run(service: AutoHuntService = Depends(get_autohunt_service)) -> Digest:
     return await service.run()
 

--- a/backend/src/hiresense/autohunt/api/routes.py
+++ b/backend/src/hiresense/autohunt/api/routes.py
@@ -9,9 +9,7 @@ from hiresense.identity.api.dependencies import enforce_expensive_rate_limit, re
 router = APIRouter(prefix="/autohunt", tags=["autohunt"], dependencies=[Depends(require_auth)])
 
 
-@router.post(
-    "/run", response_model=Digest, dependencies=[Depends(enforce_expensive_rate_limit)]
-)
+@router.post("/run", response_model=Digest, dependencies=[Depends(enforce_expensive_rate_limit)])
 async def run(service: AutoHuntService = Depends(get_autohunt_service)) -> Digest:
     return await service.run()
 

--- a/backend/src/hiresense/bootstrap/identity.py
+++ b/backend/src/hiresense/bootstrap/identity.py
@@ -10,4 +10,5 @@ def build_identity(settings: Settings) -> IdentityProvider:
         password=settings.auth_password,
         jwt_secret=settings.jwt_secret_key,
         role=settings.auth_role,
+        password_hash=settings.auth_password_hash,
     )

--- a/backend/src/hiresense/bootstrap/outreach.py
+++ b/backend/src/hiresense/bootstrap/outreach.py
@@ -45,5 +45,6 @@ def build_outreach(
         language=s.default_language,
         portfolio_citation=portfolio_citation,
         sender=sender,
+        allowed_recipient_domains=tuple(s.outreach_allowed_recipient_domains),
     )
     return OutreachBuild(provider=OutreachProvider(outreach_service=service), service=service)

--- a/backend/src/hiresense/config/groups/core.py
+++ b/backend/src/hiresense/config/groups/core.py
@@ -37,6 +37,11 @@ class CoreSettings(BaseSettings):
     # creds, see config.mode.apply_mode); required in production.
     auth_username: str = ""
     auth_password: str = ""
+    # Optional scrypt hash of the admin password (scrypt$n$r$p$salt$hash). When
+    # set it takes precedence over AUTH_PASSWORD and the plaintext is never
+    # retained by the auth service. Generate with:
+    #   python -c "from hiresense.identity.domain import hash_password; print(hash_password('pw'))"
+    auth_password_hash: str = ""
     jwt_secret_key: str = ""
 
     @field_validator("app_mode", mode="before")

--- a/backend/src/hiresense/config/groups/outreach.py
+++ b/backend/src/hiresense/config/groups/outreach.py
@@ -22,6 +22,10 @@ class OutreachSettings(BaseSettings):
     smtp_password: str = ""
     smtp_use_tls: bool = True
     outreach_from_email: str = ""
+    # Recipient-domain allowlist for POST /outreach/send. Empty (default) allows
+    # any syntactically valid address; set to constrain sends and blunt the
+    # authenticated open-relay/cost surface, e.g. ["example.com","gmail.com"].
+    outreach_allowed_recipient_domains: list[str] = []
 
     # --- Notifications (Autopilot Phase 2: digest + failure-alert email) ---
     # Recipient for scheduler digest/failure emails. BLANK disables notifications

--- a/backend/src/hiresense/identity/api/provider.py
+++ b/backend/src/hiresense/identity/api/provider.py
@@ -4,12 +4,20 @@ from hiresense.identity.domain import AuthService
 
 
 class IdentityProvider:
-    def __init__(self, username: str, password: str, jwt_secret: str, role: str = "admin") -> None:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        jwt_secret: str,
+        role: str = "admin",
+        password_hash: str = "",
+    ) -> None:
         self._auth_service = AuthService(
             username=username,
             password=password,
             jwt_secret=jwt_secret,
             role=role,
+            password_hash=password_hash,
         )
 
     def get_auth_service(self) -> AuthService:

--- a/backend/src/hiresense/identity/domain/__init__.py
+++ b/backend/src/hiresense/identity/domain/__init__.py
@@ -1,3 +1,4 @@
+from hiresense.identity.domain.password_hasher import hash_password, verify_password
 from hiresense.identity.domain.services import AuthService
 
-__all__ = ["AuthService"]
+__all__ = ["AuthService", "hash_password", "verify_password"]

--- a/backend/src/hiresense/identity/domain/password_hasher.py
+++ b/backend/src/hiresense/identity/domain/password_hasher.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+
+# scrypt cost parameters. n*r*128 bytes of memory (here 16 MiB), which stays
+# under scrypt's default 32 MiB maxmem cap while remaining expensive to brute
+# force. Encoded into the hash string so stored hashes remain verifiable even
+# if these defaults change later.
+_SCRYPT_N = 16384
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+_SALT_BYTES = 16
+_SCHEME = "scrypt"
+
+
+def _b64(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii")
+
+
+def _unb64(text: str) -> bytes:
+    return base64.urlsafe_b64decode(text.encode("ascii"))
+
+
+def hash_password(password: str, *, n: int = _SCRYPT_N, r: int = _SCRYPT_R, p: int = _SCRYPT_P) -> str:
+    """Hash a plaintext password into a self-describing scrypt string.
+
+    Format: ``scrypt$n$r$p$<salt_b64>$<hash_b64>``. Generate a value for
+    AUTH_PASSWORD_HASH with:
+
+        python -c "from hiresense.identity.domain import hash_password; print(hash_password('your-password'))"
+    """
+    salt = secrets.token_bytes(_SALT_BYTES)
+    derived = hashlib.scrypt(password.encode("utf-8"), salt=salt, n=n, r=r, p=p)
+    return f"{_SCHEME}${n}${r}${p}${_b64(salt)}${_b64(derived)}"
+
+
+def verify_password(password: str, encoded: str) -> bool:
+    """Constant-time verify a plaintext password against a scrypt hash string.
+
+    Returns False (never raises) on any malformed or unsupported hash so a
+    corrupt credential can't be distinguished by timing or exception behaviour.
+    """
+    try:
+        scheme, n_str, r_str, p_str, salt_b64, hash_b64 = encoded.split("$")
+        if scheme != _SCHEME:
+            return False
+        salt = _unb64(salt_b64)
+        expected = _unb64(hash_b64)
+        derived = hashlib.scrypt(
+            password.encode("utf-8"),
+            salt=salt,
+            n=int(n_str),
+            r=int(r_str),
+            p=int(p_str),
+        )
+    except (ValueError, TypeError):
+        return False
+    return secrets.compare_digest(derived, expected)

--- a/backend/src/hiresense/identity/domain/password_hasher.py
+++ b/backend/src/hiresense/identity/domain/password_hasher.py
@@ -23,7 +23,9 @@ def _unb64(text: str) -> bytes:
     return base64.urlsafe_b64decode(text.encode("ascii"))
 
 
-def hash_password(password: str, *, n: int = _SCRYPT_N, r: int = _SCRYPT_R, p: int = _SCRYPT_P) -> str:
+def hash_password(
+    password: str, *, n: int = _SCRYPT_N, r: int = _SCRYPT_R, p: int = _SCRYPT_P
+) -> str:
     """Hash a plaintext password into a self-describing scrypt string.
 
     Format: ``scrypt$n$r$p$<salt_b64>$<hash_b64>``. Generate a value for

--- a/backend/src/hiresense/identity/domain/services.py
+++ b/backend/src/hiresense/identity/domain/services.py
@@ -39,12 +39,14 @@ class AuthService:
         if not self._password_hash and not self._password:
             return False
         # compare_digest on both fields avoids leaking the username/password
-        # length or match position through response timing.
-        username_ok = secrets.compare_digest(username, self._username)
+        # length or match position through response timing. Compare UTF-8 bytes:
+        # compare_digest raises TypeError on non-ASCII str, which would turn a
+        # crafted non-ASCII credential into a 500 instead of a clean auth failure.
+        username_ok = secrets.compare_digest(username.encode("utf-8"), self._username.encode("utf-8"))
         if self._password_hash:
             password_ok = verify_password(password, self._password_hash)
         else:
-            password_ok = secrets.compare_digest(password, self._password)
+            password_ok = secrets.compare_digest(password.encode("utf-8"), self._password.encode("utf-8"))
         # Avoid short-circuiting so a wrong username and wrong password take the
         # same code path.
         return username_ok and password_ok

--- a/backend/src/hiresense/identity/domain/services.py
+++ b/backend/src/hiresense/identity/domain/services.py
@@ -1,22 +1,53 @@
 from __future__ import annotations
 
+import secrets
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from jose import JWTError, jwt
 
+from hiresense.identity.domain.password_hasher import verify_password
+
 
 class AuthService:
-    def __init__(self, username: str, password: str, jwt_secret: str, role: str = "admin") -> None:
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        jwt_secret: str,
+        role: str = "admin",
+        password_hash: str = "",
+    ) -> None:
         self._username = username
-        self._password = password
+        # When a hash is configured (AUTH_PASSWORD_HASH), the plaintext is never
+        # retained: verification runs against the hash only. The plaintext path
+        # exists for the local-mode ephemeral dev password (config.mode), which
+        # is generated at boot and has no hash.
+        self._password_hash = password_hash
+        self._password = "" if password_hash else password
         self._jwt_secret = jwt_secret
         self._role = role
 
     def login(self, username: str, password: str) -> str | None:
-        if username == self._username and password == self._password:
+        if self._verify(username, password):
             return self._create_token(username)
         return None
+
+    def _verify(self, username: str, password: str) -> bool:
+        # A fully unconfigured credential must never authenticate (compare_digest
+        # of two empty strings would otherwise return True).
+        if not self._password_hash and not self._password:
+            return False
+        # compare_digest on both fields avoids leaking the username/password
+        # length or match position through response timing.
+        username_ok = secrets.compare_digest(username, self._username)
+        if self._password_hash:
+            password_ok = verify_password(password, self._password_hash)
+        else:
+            password_ok = secrets.compare_digest(password, self._password)
+        # Avoid short-circuiting so a wrong username and wrong password take the
+        # same code path.
+        return username_ok and password_ok
 
     def validate_token(self, token: str) -> dict[str, Any] | None:
         try:

--- a/backend/src/hiresense/identity/domain/services.py
+++ b/backend/src/hiresense/identity/domain/services.py
@@ -42,11 +42,15 @@ class AuthService:
         # length or match position through response timing. Compare UTF-8 bytes:
         # compare_digest raises TypeError on non-ASCII str, which would turn a
         # crafted non-ASCII credential into a 500 instead of a clean auth failure.
-        username_ok = secrets.compare_digest(username.encode("utf-8"), self._username.encode("utf-8"))
+        username_ok = secrets.compare_digest(
+            username.encode("utf-8"), self._username.encode("utf-8")
+        )
         if self._password_hash:
             password_ok = verify_password(password, self._password_hash)
         else:
-            password_ok = secrets.compare_digest(password.encode("utf-8"), self._password.encode("utf-8"))
+            password_ok = secrets.compare_digest(
+                password.encode("utf-8"), self._password.encode("utf-8")
+            )
         # Avoid short-circuiting so a wrong username and wrong password take the
         # same code path.
         return username_ok and password_ok

--- a/backend/src/hiresense/outreach/api/routes.py
+++ b/backend/src/hiresense/outreach/api/routes.py
@@ -4,7 +4,7 @@ import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
 
-from hiresense.identity.api.dependencies import require_auth
+from hiresense.identity.api.dependencies import enforce_expensive_rate_limit, require_auth
 from hiresense.outreach.api.dependencies import get_outreach_service
 from hiresense.outreach.api.schemas import (
     GenerateRequest,
@@ -17,13 +17,18 @@ from hiresense.outreach.domain import (
     OutreachEvent,
     OutreachNudge,
     OutreachService,
+    RecipientNotAllowedError,
 )
 from hiresense.outreach.domain.message_generator import OutreachUnavailableError
 
 router = APIRouter(prefix="/outreach", tags=["outreach"], dependencies=[Depends(require_auth)])
 
 
-@router.post("/generate", response_model=GenerateResponse)
+@router.post(
+    "/generate",
+    response_model=GenerateResponse,
+    dependencies=[Depends(enforce_expensive_rate_limit)],
+)
 async def generate(
     body: GenerateRequest, service: OutreachService = Depends(get_outreach_service)
 ) -> GenerateResponse:
@@ -54,7 +59,12 @@ def record(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.post("/send", response_model=OutreachEvent, status_code=201)
+@router.post(
+    "/send",
+    response_model=OutreachEvent,
+    status_code=201,
+    dependencies=[Depends(enforce_expensive_rate_limit)],
+)
 async def send(
     body: SendRequest, service: OutreachService = Depends(get_outreach_service)
 ) -> OutreachEvent:
@@ -67,6 +77,9 @@ async def send(
             contact_name=body.contact_name,
             channel=body.channel,
         )
+    except RecipientNotAllowedError as exc:
+        # Subclass of ValueError, so this must precede the generic ValueError arm.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except EmailUnavailableError as exc:

--- a/backend/src/hiresense/outreach/api/schemas.py
+++ b/backend/src/hiresense/outreach/api/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 
-from pydantic import BaseModel
+from pydantic import BaseModel, EmailStr
 
 from hiresense.outreach.domain import OutreachEvent, OutreachEventKind, OutreachNudge
 
@@ -27,7 +27,7 @@ class RecordRequest(BaseModel):
 
 class SendRequest(BaseModel):
     application_id: uuid.UUID
-    to: str
+    to: EmailStr
     subject: str
     message: str
     contact_name: str | None = None

--- a/backend/src/hiresense/outreach/domain/__init__.py
+++ b/backend/src/hiresense/outreach/domain/__init__.py
@@ -8,6 +8,7 @@ from hiresense.outreach.domain.outreach_event import OutreachEvent
 from hiresense.outreach.domain.outreach_event_kind import OutreachEventKind
 from hiresense.outreach.domain.outreach_nudge import OutreachNudge
 from hiresense.outreach.domain.outreach_service import OutreachService
+from hiresense.outreach.domain.recipient_not_allowed_error import RecipientNotAllowedError
 from hiresense.outreach.domain.style_guide import DEFAULT_STYLE_GUIDE, load_style_guide
 
 __all__ = [
@@ -20,5 +21,6 @@ __all__ = [
     "OutreachNudge",
     "OutreachService",
     "OutreachUnavailableError",
+    "RecipientNotAllowedError",
     "load_style_guide",
 ]

--- a/backend/src/hiresense/outreach/domain/outreach_service.py
+++ b/backend/src/hiresense/outreach/domain/outreach_service.py
@@ -35,7 +35,9 @@ class OutreachService:
         self._sender = sender
         # Lowercased recipient-domain allowlist. Empty = no restriction (any
         # syntactically valid address, still schema-validated as EmailStr).
-        self._allowed_recipient_domains = tuple(d.strip().lower() for d in allowed_recipient_domains if d.strip())
+        self._allowed_recipient_domains = tuple(
+            d.strip().lower() for d in allowed_recipient_domains if d.strip()
+        )
         self._tracking = tracking_service
         self._profile = profile_service
         self._research = research_service

--- a/backend/src/hiresense/outreach/domain/outreach_service.py
+++ b/backend/src/hiresense/outreach/domain/outreach_service.py
@@ -9,6 +9,7 @@ from hiresense.outreach.domain.email_message import EmailMessage
 from hiresense.outreach.domain.outreach_event import OutreachEvent
 from hiresense.outreach.domain.outreach_event_kind import OutreachEventKind
 from hiresense.outreach.domain.outreach_nudge import OutreachNudge
+from hiresense.outreach.domain.recipient_not_allowed_error import RecipientNotAllowedError
 from hiresense.outreach.domain.style_guide import load_style_guide
 
 _ACTIVE_STATUSES = {"saved", "applied"}
@@ -29,8 +30,12 @@ class OutreachService:
         language: str,
         portfolio_citation: Any = None,
         sender: Any = None,
+        allowed_recipient_domains: tuple[str, ...] = (),
     ) -> None:
         self._sender = sender
+        # Lowercased recipient-domain allowlist. Empty = no restriction (any
+        # syntactically valid address, still schema-validated as EmailStr).
+        self._allowed_recipient_domains = tuple(d.strip().lower() for d in allowed_recipient_domains if d.strip())
         self._tracking = tracking_service
         self._profile = profile_service
         self._research = research_service
@@ -109,11 +114,13 @@ class OutreachService:
     ) -> OutreachEvent:
         """Send an outreach email, then record it as a SENT event.
 
-        Raises ValueError if the application is missing and EmailUnavailableError
-        (from the sender) if SMTP isn't configured — nothing is recorded when the
-        send fails.
+        Raises ValueError if the application is missing, RecipientNotAllowedError
+        if the recipient domain is outside the configured allowlist, and
+        EmailUnavailableError (from the sender) if SMTP isn't configured —
+        nothing is recorded when the send fails.
         """
         self._tracking.get(application_id)  # 404 if missing
+        self._ensure_recipient_allowed(to)
         await asyncio.to_thread(
             self._sender.send, EmailMessage(to=to, subject=subject, body=message)
         )
@@ -126,6 +133,15 @@ class OutreachService:
                 channel=channel,
             )
         )
+
+    def _ensure_recipient_allowed(self, to: str) -> None:
+        if not self._allowed_recipient_domains:
+            return
+        domain = to.rsplit("@", 1)[-1].strip().lower()
+        if domain not in self._allowed_recipient_domains:
+            raise RecipientNotAllowedError(
+                f"Recipient domain '{domain}' is not in the outreach allowlist"
+            )
 
     def list_for(self, application_id: uuid.UUID) -> list[OutreachEvent]:
         return self._repo.list_for(application_id)

--- a/backend/src/hiresense/outreach/domain/recipient_not_allowed_error.py
+++ b/backend/src/hiresense/outreach/domain/recipient_not_allowed_error.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+
+class RecipientNotAllowedError(ValueError):
+    """Raised when an outreach send targets a recipient outside the allowed set.
+
+    Subclasses ValueError so existing ``except ValueError`` handlers still catch
+    it, while the route layer can map it to a 400 distinct from the 404 used for
+    a missing application.
+    """

--- a/backend/tests/integration/test_outreach_endpoints.py
+++ b/backend/tests/integration/test_outreach_endpoints.py
@@ -10,11 +10,17 @@ from sqlalchemy.pool import StaticPool
 
 from hiresense.identity.api.dependencies import require_auth
 from hiresense.infrastructure.database import Base
+from hiresense.kernel import SlidingWindowRateLimiter
 from hiresense.outreach.api import router as outreach_router
 from hiresense.outreach.api.dependencies import get_outreach_service
 from hiresense.outreach.domain import OutreachMessageGenerator, OutreachService
 from hiresense.outreach.infrastructure import OutreachRepository
 from hiresense.outreach.infrastructure.orm import OutreachEventOrm  # noqa: F401
+
+
+class _StubSender:
+    def send(self, message) -> None:  # matches EmailSender port
+        return None
 
 
 class _FakeLLM:
@@ -63,7 +69,7 @@ def _factory():
     return sessionmaker(bind=engine, expire_on_commit=False), engine
 
 
-def _build_app(app_id, factory):
+def _build_app(app_id, factory, *, limiter=None):
     repo = OutreachRepository(session_factory=factory)
     service = OutreachService(
         tracking_service=_Tracking([_App(app_id)]),
@@ -75,8 +81,10 @@ def _build_app(app_id, factory):
         followup_cadence_days=7,
         max_chars=500,
         language="en",
+        sender=_StubSender(),
     )
     app = FastAPI()
+    app.state.rate_limiter = limiter
     app.dependency_overrides[require_auth] = lambda: "test-user"
     app.dependency_overrides[get_outreach_service] = lambda: service
     app.include_router(outreach_router)
@@ -136,3 +144,40 @@ async def test_nudge_surfaces_then_clears():
         await c.post("/outreach/record", json={"application_id": str(app_id), "kind": "replied"})
         cleared = await c.post("/outreach/nudge")
         assert cleared.json() == []
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_invalid_email_recipient():
+    factory, _ = _factory()
+    app_id = uuid_mod.uuid4()
+    app = _build_app(app_id, factory)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        resp = await c.post(
+            "/outreach/send",
+            json={
+                "application_id": str(app_id),
+                "to": "not-an-email",
+                "subject": "Hello",
+                "message": "Body",
+            },
+        )
+        assert resp.status_code == 422  # EmailStr validation rejects malformed recipient
+
+
+@pytest.mark.asyncio
+async def test_send_is_rate_limited():
+    factory, _ = _factory()
+    app_id = uuid_mod.uuid4()
+    limiter = SlidingWindowRateLimiter(max_requests=1, window_seconds=60.0)
+    app = _build_app(app_id, factory, limiter=limiter)
+    payload = {
+        "application_id": str(app_id),
+        "to": "recruiter@acme.com",
+        "subject": "Hello",
+        "message": "Body",
+    }
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        first = await c.post("/outreach/send", json=payload)
+        assert first.status_code == 201
+        second = await c.post("/outreach/send", json=payload)
+        assert second.status_code == 429

--- a/backend/tests/unit/identity/test_auth.py
+++ b/backend/tests/unit/identity/test_auth.py
@@ -1,4 +1,4 @@
-from hiresense.identity.domain import AuthService
+from hiresense.identity.domain import AuthService, hash_password
 
 
 def test_verify_valid_credentials() -> None:
@@ -45,3 +45,47 @@ def test_token_carries_configured_role() -> None:
     payload = service.validate_token(token)
     assert payload is not None
     assert payload["role"] == "member"
+
+
+def test_login_with_password_hash_accepts_correct_password() -> None:
+    service = AuthService(
+        username="admin",
+        password="",
+        jwt_secret="key",
+        password_hash=hash_password("secret"),
+    )
+    assert service.login("admin", "secret") is not None
+
+
+def test_login_with_password_hash_rejects_wrong_password() -> None:
+    service = AuthService(
+        username="admin",
+        password="",
+        jwt_secret="key",
+        password_hash=hash_password("secret"),
+    )
+    assert service.login("admin", "wrong") is None
+
+
+def test_password_hash_takes_precedence_and_plaintext_not_retained() -> None:
+    service = AuthService(
+        username="admin",
+        password="plaintext-should-be-ignored",
+        jwt_secret="key",
+        password_hash=hash_password("secret"),
+    )
+    # Plaintext arg is ignored when a hash is present, and not kept in the field.
+    assert service.login("admin", "plaintext-should-be-ignored") is None
+    assert service.login("admin", "secret") is not None
+    assert service._password == ""
+
+
+def test_login_rejects_wrong_username() -> None:
+    service = AuthService(username="admin", password="secret", jwt_secret="key")
+    assert service.login("attacker", "secret") is None
+
+
+def test_login_rejects_when_no_credential_configured() -> None:
+    # A fully-blank credential must never authenticate.
+    service = AuthService(username="", password="", jwt_secret="key")
+    assert service.login("", "") is None

--- a/backend/tests/unit/identity/test_auth.py
+++ b/backend/tests/unit/identity/test_auth.py
@@ -89,3 +89,10 @@ def test_login_rejects_when_no_credential_configured() -> None:
     # A fully-blank credential must never authenticate.
     service = AuthService(username="", password="", jwt_secret="key")
     assert service.login("", "") is None
+
+
+def test_login_handles_non_ascii_input_without_error() -> None:
+    # compare_digest raises TypeError on non-ASCII str; the service must return a
+    # clean auth failure (None), not propagate an exception (500).
+    service = AuthService(username="admin", password="secret", jwt_secret="key")
+    assert service.login("admín", "sécret") is None

--- a/backend/tests/unit/identity/test_auth.py
+++ b/backend/tests/unit/identity/test_auth.py
@@ -68,14 +68,15 @@ def test_login_with_password_hash_rejects_wrong_password() -> None:
 
 
 def test_password_hash_takes_precedence_and_plaintext_not_retained() -> None:
+    ignored_plaintext = "wrong-value"
     service = AuthService(
         username="admin",
-        password="plaintext-should-be-ignored",
+        password=ignored_plaintext,
         jwt_secret="key",
         password_hash=hash_password("secret"),
     )
     # Plaintext arg is ignored when a hash is present, and not kept in the field.
-    assert service.login("admin", "plaintext-should-be-ignored") is None
+    assert service.login("admin", ignored_plaintext) is None
     assert service.login("admin", "secret") is not None
     assert service._password == ""
 

--- a/backend/tests/unit/identity/test_password_hasher.py
+++ b/backend/tests/unit/identity/test_password_hasher.py
@@ -24,5 +24,7 @@ def test_hash_uses_random_salt() -> None:
 
 def test_verify_returns_false_on_malformed_hash() -> None:
     assert verify_password("pw", "not-a-valid-hash") is False
-    assert verify_password("pw", "bcrypt$16384$8$1$abc$def") is False
+    # Well-formed shape but an unsupported scheme name must be rejected.
+    unsupported_scheme = "$".join(["unknown", "1", "1", "1", "AAAA", "BBBB"])
+    assert verify_password("pw", unsupported_scheme) is False
     assert verify_password("pw", "") is False

--- a/backend/tests/unit/identity/test_password_hasher.py
+++ b/backend/tests/unit/identity/test_password_hasher.py
@@ -1,0 +1,28 @@
+from hiresense.identity.domain import hash_password, verify_password
+
+
+def test_hash_is_self_describing_scrypt_string() -> None:
+    encoded = hash_password("correct horse battery staple")
+    assert encoded.startswith("scrypt$")
+    assert len(encoded.split("$")) == 6
+
+
+def test_verify_accepts_correct_password() -> None:
+    encoded = hash_password("s3cret")
+    assert verify_password("s3cret", encoded) is True
+
+
+def test_verify_rejects_wrong_password() -> None:
+    encoded = hash_password("s3cret")
+    assert verify_password("nope", encoded) is False
+
+
+def test_hash_uses_random_salt() -> None:
+    # Same password hashed twice yields different strings (unique salts).
+    assert hash_password("same") != hash_password("same")
+
+
+def test_verify_returns_false_on_malformed_hash() -> None:
+    assert verify_password("pw", "not-a-valid-hash") is False
+    assert verify_password("pw", "bcrypt$16384$8$1$abc$def") is False
+    assert verify_password("pw", "") is False

--- a/backend/tests/unit/outreach/test_send.py
+++ b/backend/tests/unit/outreach/test_send.py
@@ -7,6 +7,7 @@ from hiresense.outreach.domain import (
     EmailMessage,
     EmailUnavailableError,
     OutreachEventKind,
+    RecipientNotAllowedError,
 )
 from hiresense.outreach.domain.outreach_service import OutreachService
 
@@ -52,7 +53,7 @@ class _Sender:
         self.sent.append(message)
 
 
-def _svc(tracking, repo, sender):
+def _svc(tracking, repo, sender, allowed_recipient_domains=()):
     return OutreachService(
         tracking_service=tracking,
         profile_service=None,
@@ -64,6 +65,7 @@ def _svc(tracking, repo, sender):
         max_chars=500,
         language="en",
         sender=sender,
+        allowed_recipient_domains=allowed_recipient_domains,
     )
 
 
@@ -111,3 +113,29 @@ async def test_send_propagates_unavailable_and_records_nothing():
         await svc.send(app_id, to="x@y.com", subject="s", message="m")
 
     assert repo.added == []  # failed send must not be recorded as SENT
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_recipient_outside_allowlist_and_records_nothing():
+    app_id = uuid_mod.uuid4()
+    repo = _Repo()
+    sender = _Sender()
+    svc = _svc(_Tracking([_App(app_id)]), repo, sender, allowed_recipient_domains=("acme.com",))
+
+    with pytest.raises(RecipientNotAllowedError):
+        await svc.send(app_id, to="attacker@evil.test", subject="s", message="m")
+
+    assert sender.sent == []  # blocked before dispatch
+    assert repo.added == []
+
+
+@pytest.mark.asyncio
+async def test_send_allows_recipient_in_allowlist_case_insensitively():
+    app_id = uuid_mod.uuid4()
+    repo = _Repo()
+    sender = _Sender()
+    svc = _svc(_Tracking([_App(app_id)]), repo, sender, allowed_recipient_domains=("Acme.com",))
+
+    await svc.send(app_id, to="recruiter@ACME.com", subject="s", message="m")
+
+    assert len(sender.sent) == 1

--- a/backend/tests/unit/test_latex_compiler.py
+++ b/backend/tests/unit/test_latex_compiler.py
@@ -1,4 +1,7 @@
 import logging
+import shutil
+import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -71,3 +74,48 @@ async def test_compile_failure_is_logged(
             await compiler.compile_to_pdf("plain text, not latex")
 
     assert any("LaTeX compilation failed" in record.message for record in caplog.records)
+
+
+def test_run_once_disables_shell_escape_and_file_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Untrusted LaTeX (raw user CVs and LLM-spliced optimized CVs) both flow
+    # through this single argv, so asserting the flags here covers both paths.
+    captured: dict[str, object] = {}
+
+    def _fake_run(argv: list[str], **kwargs: object):
+        captured["argv"] = argv
+        captured["env"] = kwargs.get("env")
+
+        class _Result:
+            returncode = 0
+
+        return _Result()
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    compiler = LatexCompiler()
+    compiler._run_once(Path("/tmp/work"), Path("/tmp/work/doc.tex"))
+
+    argv = captured["argv"]
+    assert "-no-shell-escape" in argv  # type: ignore[operator]
+    env = captured["env"]
+    assert isinstance(env, dict)
+    assert env["openin_any"] == "p"
+    assert env["openout_any"] == "p"
+
+
+@pytest.mark.parametrize(
+    "malicious",
+    [
+        r"\documentclass{article}\begin{document}\write18{echo pwned}\end{document}",
+        r"\documentclass{article}\begin{document}\input{/etc/passwd}\end{document}",
+    ],
+)
+@pytest.mark.skipif(shutil.which("xelatex") is None, reason="xelatex not installed")
+@pytest.mark.asyncio
+async def test_real_compile_rejects_shell_escape_and_abs_input(malicious: str) -> None:
+    # Real-compile guard: with -no-shell-escape and openin_any=p, \write18 and
+    # absolute \input must fail the compile rather than execute / read the file.
+    with pytest.raises(LatexCompileError):
+        await LatexCompiler().compile_to_pdf(malicious)

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -584,6 +584,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docstring-parser"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -602,6 +611,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -829,7 +851,7 @@ dependencies = [
     { name = "passlib", extra = ["bcrypt"] },
     { name = "pgvector" },
     { name = "psycopg2-binary" },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pymupdf" },
     { name = "python-dotenv" },
@@ -882,7 +904,7 @@ requires-dist = [
     { name = "passlib", extras = ["bcrypt"], specifier = ">=1.7.4" },
     { name = "pgvector", specifier = ">=0.3.5" },
     { name = "psycopg2-binary", specifier = ">=2.9.12" },
-    { name = "pydantic", specifier = ">=2.13.4" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.2" },
     { name = "pymupdf", specifier = ">=1.28.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
@@ -2027,6 +2049,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

P1 backend security hardening — three High-severity findings from the 2026-07-05 audit, one commit each.

### #128 — LaTeX compiled with `-no-shell-escape` + paranoid file access
`LatexCompiler._run_once` invoked `xelatex` without `-no-shell-escape`, so untrusted LaTeX (raw user CVs and LLM-spliced optimized CVs) could read arbitrary files via `\input{/etc/passwd}` (restricted shell-escape) or achieve RCE via `\write18` (full shell-escape). The fix adds `-no-shell-escape` to every invocation and sets `openin_any=p` / `openout_any=p` in the subprocess env so TeX cannot read or write files outside its temp dir. Both compile paths (original CV and optimized CV) share this single argv, so the argv-level test covers both.

Closes #128

### #129 — Admin password hashed with scrypt, compared in constant time
`AuthService.login` stored the admin password in plaintext and compared with `==` (timing side channel, no defense in depth). Added a stdlib `scrypt`-based hasher (`hiresense.identity.domain.hash_password` / `verify_password`) and a new optional `AUTH_PASSWORD_HASH` setting that takes precedence over `AUTH_PASSWORD`; when a hash is set the plaintext is never retained by the service. When only plaintext is configured (the local-mode ephemeral dev password), both username and password are now compared with `secrets.compare_digest`. A fully-blank credential can never authenticate.

Closes #129

### #130 — Rate-limited + recipient-validated `/outreach/send`
The outreach router was gated only by `require_auth` with no rate limiting, and `SendRequest.to` was a bare `str` untied to any real contact — an authenticated open email relay with unbounded LLM/SMTP cost. Fixes:
- `Depends(enforce_expensive_rate_limit)` added to `POST /outreach/send`, `POST /outreach/generate`, and `POST /autohunt/run`.
- `SendRequest.to` is now `EmailStr` (added the `pydantic[email]` extra).
- New config-driven recipient-domain allowlist `OUTREACH_ALLOWED_RECIPIENT_DOMAINS` (empty = allow any valid email). A send to a domain outside the allowlist raises `RecipientNotAllowedError` → HTTP 400, before any email dispatch.

Closes #130

## Decisions taken

- **#128 — no real-compile in CI.** `xelatex` isn't installed on the dev machine or CI, so the load-bearing regression test asserts the argv/env at the subprocess boundary (mocked `subprocess.run`). A real-compile test that feeds `\write18`/`\input{/abs}` and expects `LatexCompileError` is included but guarded with `@pytest.mark.skipif(shutil.which("xelatex") is None)`.
- **#128 — added `openin_any=p`/`openout_any=p`.** `-no-shell-escape` alone stops `\write18` (RCE) but `\input{/etc/passwd}` is a core TeX primitive, not shell-escape; the paranoid file-access env vars are what actually close the file-read surface called out in the finding.
- **#129 — stdlib scrypt, no new dependency.** Used `hashlib.scrypt` + `secrets.compare_digest` (self-describing `scrypt$n$r$p$salt$hash` format) rather than adding passlib/argon2. Cost params (n=16384, r=8, p=1 ≈ 16 MiB) stay under scrypt's default 32 MiB `maxmem` cap.
- **#129 — kept the local-mode flow intact.** `config.mode.apply_mode` still generates an ephemeral plaintext dev password when `AUTH_PASSWORD` is blank in local mode; `AUTH_PASSWORD_HASH` is optional and only takes precedence when set, so the degraded dev boot is unchanged.
- **#130 — recipient constrained via a domain allowlist, not a stored contact.** `TrackedApplication` has no contact/email field, so there is no per-application contact to validate against. The available and honest interpretation of "constrain the recipient" is (a) reject malformed addresses with `EmailStr` and (b) an optional operator-configured domain allowlist. Default (empty) preserves current behaviour.
- **#130 — reused `enforce_expensive_rate_limit`, no separate send quota.** The issue's "consider a distinct per-window send quota" was optional; the existing per-IP sliding-window limiter already bounds send/generate/run cost and satisfies the over-limit test. A separate limiter would add app.state wiring for marginal benefit — deferred.
- **#130 — `RecipientNotAllowedError` subclasses `ValueError`** so existing `except ValueError` handlers still catch it; the route catches it first and maps to 400 (distinct from the 404 used for a missing application).

## Verification

Run from the worktree `backend/` with `UV_LINK_MODE=copy`:

- `uv run ruff check .` → **All checks passed!** (repo-wide; CI runs `ruff check` only — did not run `ruff format`.)
- `uv run python -m pytest` → full suite **green** (exit code 0, DB-free SQLite run). New tests:
  - `tests/unit/test_latex_compiler.py` — argv includes `-no-shell-escape`, env has `openin_any/openout_any=p`; skipif real-compile guard.
  - `tests/unit/identity/test_password_hasher.py` + `tests/unit/identity/test_auth.py` — hash verify correct/incorrect, plaintext not retained, wrong-username and blank-credential rejection.
  - `tests/unit/outreach/test_send.py` — recipient allowlist reject/allow (case-insensitive).
  - `tests/integration/test_outreach_endpoints.py` — invalid email → 422, over-limit send → 429.

Repo traps checked:
- **`.env.example` updated** for `AUTH_PASSWORD_HASH` and `OUTREACH_ALLOWED_RECIPIENT_DOMAINS` (both with comments).
- **Config group used**, not hardcoded: `auth_password_hash` in `config/groups/core.py`, `outreach_allowed_recipient_domains` in `config/groups/outreach.py`.
- **`__init__` re-exports** added: `hash_password`/`verify_password` in `identity/domain`, `RecipientNotAllowedError` in `outreach/domain`.
- **`registry.py`** — n/a, no new ORM classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PmhxbVCx2ErqBBjibnqHY8
