### PR TITLE
test(auth): cover unauthorized interceptor behavior

### DIFF
--- a/frontend/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/frontend/src/app/core/interceptors/error.interceptor.spec.ts
@@ -1,0 +1,68 @@
+import { HttpClient, provideHttpClient, withInterceptors } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { environment } from '../../../environments/environment';
+import { AuthService } from '../services/auth.service';
+import { errorInterceptor } from './error.interceptor';
+
+describe('errorInterceptor', () => {
+  const logout = vi.fn();
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptors([errorInterceptor])),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: { logout } },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+    TestBed.resetTestingModule();
+    vi.clearAllMocks();
+  });
+
+  it('logs out once and rethrows a 401 from a non-auth endpoint', () => {
+    const url = `${environment.apiUrl}/applications`;
+    let capturedError: unknown;
+
+    http.get(url).subscribe({ error: (error: unknown) => (capturedError = error) });
+    httpMock.expectOne(url).flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(logout).toHaveBeenCalledTimes(1);
+    expect(capturedError).toMatchObject({ status: 401 });
+  });
+
+  it.each(['/auth/login', '/auth/me', '/auth/logout'])(
+    'skips logout and rethrows a 401 from %s',
+    (path) => {
+      const url = `${environment.apiUrl}${path}`;
+      let capturedError: unknown;
+
+      http.get(url).subscribe({ error: (error: unknown) => (capturedError = error) });
+      httpMock.expectOne(url).flush({}, { status: 401, statusText: 'Unauthorized' });
+
+      expect(logout).not.toHaveBeenCalled();
+      expect(capturedError).toMatchObject({ status: 401 });
+    },
+  );
+
+  it('skips logout and rethrows a non-401 response', () => {
+    const url = `${environment.apiUrl}/applications`;
+    let capturedError: unknown;
+
+    http.get(url).subscribe({ error: (error: unknown) => (capturedError = error) });
+    httpMock.expectOne(url).flush({}, { status: 500, statusText: 'Internal Server Error' });
+
+    expect(logout).not.toHaveBeenCalled();
+    expect(capturedError).toMatchObject({ status: 500 });
+  });
+});

--- a/frontend/src/app/core/interceptors/error.interceptor.spec.ts
+++ b/frontend/src/app/core/interceptors/error.interceptor.spec.ts
@@ -55,6 +55,15 @@ describe('errorInterceptor', () => {
     },
   );
 
+  it('does not exempt a protected endpoint whose query contains an auth path', () => {
+    const url = `${environment.apiUrl}/applications?next=/auth/login`;
+
+    http.get(url).subscribe({ error: () => undefined });
+    httpMock.expectOne(url).flush({}, { status: 401, statusText: 'Unauthorized' });
+
+    expect(logout).toHaveBeenCalledTimes(1);
+  });
+
   it('skips logout and rethrows a non-401 response', () => {
     const url = `${environment.apiUrl}/applications`;
     let capturedError: unknown;

--- a/frontend/src/app/core/interceptors/error.interceptor.ts
+++ b/frontend/src/app/core/interceptors/error.interceptor.ts
@@ -26,5 +26,6 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
 };
 
 function isAuthEndpoint(url: string): boolean {
-  return url.includes('/auth/login') || url.includes('/auth/me') || url.includes('/auth/logout');
+  const pathname = new URL(url, 'http://localhost').pathname.replace(/\/+$/, '');
+  return ['/auth/login', '/auth/me', '/auth/logout'].some((path) => pathname.endsWith(path));
 }


### PR DESCRIPTION
﻿## Problema
- El interceptor de autenticación no tenía cobertura directa para respuestas 401.
- Era necesario distinguir rutas protegidas de `/auth/login`, `/auth/me` y `/auth/logout` para evitar cierres de sesión recursivos.
- La exención usaba búsqueda por substring y podía omitir logout si una query protegida contenía el texto de una ruta de autenticación.

## Cambio
- Añade pruebas con `HttpClient` y `HttpTestingController` para el interceptor real.
- Verifica logout único en 401 protegidos, exclusión de los tres endpoints de autenticación, reenvío del error y ausencia de logout en errores no 401.
- Compara las exenciones contra el pathname normalizado e incluye una regresión de query near-miss.
- Mantiene el modelo actual de cookies `httpOnly`; no reintroduce tokens Bearer en el cliente.

## Resuelve / Impacto
La política de expiración de sesión queda protegida contra regresiones y los parámetros de una URL ya no pueden suprimir la limpieza de una sesión rechazada.

## Test plan
- [x] Suite enfocada del interceptor: 6 passed
- [x] Suite frontend completa previa al ajuste localizado: 82 archivos, 464 tests passed
- [x] `npm run lint`
- [x] `npm run build`
- [x] CI frontend

Closes #146

Generated with [Codex](https://Codex.com/Codex)
