### PR TITLE
test: harden JWT coverage and align runtime docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 HireSense — AI-assisted job hunting. Ingests postings from job boards and company ATS portals, ranks them against the user's profile (pgvector ANN semantic pre-ranking + skill overlap + tiered LLM scoring), and manages applications end to end (tracking, CV/cover-letter generation, interview prep, outreach, analytics).
 
-Monorepo: `backend/` (Python 3.13, FastAPI, SQLAlchemy + Alembic, PostgreSQL 16 + pgvector), `frontend/` (Angular 21, standalone components + signals, Vitest), `docker-compose.yml` (db, app, frontend, otel-lgtm/Grafana).
+Monorepo: `backend/` (Python 3.12+, FastAPI, SQLAlchemy + Alembic, PostgreSQL 16 + pgvector), `frontend/` (Angular 21, standalone components + signals, Vitest), `docker-compose.yml` (db, app, frontend, otel-lgtm/Grafana).
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ No NgModules: standalone components with lazy-loaded routes (`app.routes.ts`). A
 
 ### Job lifecycle (cross-cutting behavior)
 
-Jobs are upserted by stable identity (`source` + `source_id`, else `sha256(url)`); a content hash drives in-place updates. Closure detection: snapshot sources (ATS portals) close jobs missing from N consecutive complete fetches; feed sources close via a throttled URL-probe sweep (`POST /ingestion/revalidate`) driven by an **external** cron — the app never self-schedules revalidation. Closed jobs are hidden by default and excluded from semantic search.
+Jobs are upserted by stable identity (`source` + `source_id`, else `sha256(url)`); a content hash drives in-place updates. Closure detection: snapshot sources (ATS portals) close jobs missing from N consecutive complete fetches; feed sources close via a throttled URL-probe sweep run by the opt-in in-app scheduler when `SCHEDULER_ENABLED=true`. When the scheduler is disabled, operators can still trigger `POST /ingestion/revalidate` manually or from an external cron. Closed jobs are hidden by default and excluded from semantic search.
 
 ## Feature workflow
 

--- a/README.md
+++ b/README.md
@@ -110,9 +110,10 @@ content hash drives in-place updates on refetch. Closures are detected two ways:
 
 - **Snapshot sources** (company ATS portals) — a job missing from N consecutive complete
   fetches is marked `closed`.
-- **Feed / search sources** — a throttled URL-probe sweep (`POST /ingestion/revalidate`,
-  driven by an external cron) closes listings that 404 or show a "no longer available"
-  marker.
+- **Feed / search sources** — a throttled URL-probe sweep closes listings that 404 or show
+  a "no longer available" marker. The in-app scheduler runs the sweep when
+  `SCHEDULER_ENABLED=true`; when disabled, operators can trigger
+  `POST /ingestion/revalidate` manually or from an external cron.
 
 Closed jobs are hidden by default and dropped from semantic search.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ HireSense pulls postings from job boards and company ATS portals, ranks them aga
 profile with **pgvector semantic search + tiered LLM scoring**, and manages the whole
 pipeline: tracking, CV & cover-letter generation, interview prep, outreach, and analytics.
 
-[![Python 3.13](https://img.shields.io/badge/Python-3.13-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
+[![Python 3.12+](https://img.shields.io/badge/Python-3.12%2B-3776AB?style=flat-square&logo=python&logoColor=white)](https://www.python.org/)
 [![FastAPI](https://img.shields.io/badge/FastAPI-009688?style=flat-square&logo=fastapi&logoColor=white)](https://fastapi.tiangolo.com/)
 [![Angular 21](https://img.shields.io/badge/Angular-21-DD0031?style=flat-square&logo=angular&logoColor=white)](https://angular.dev/)
 [![PostgreSQL + pgvector](https://img.shields.io/badge/PostgreSQL-pgvector-4169E1?style=flat-square&logo=postgresql&logoColor=white)](https://github.com/pgvector/pgvector)
@@ -120,7 +120,7 @@ Closed jobs are hidden by default and dropped from semantic search.
 
 | Layer | Tech |
 |---|---|
-| **Backend** | Python 3.13, FastAPI, SQLAlchemy 2.0 + Alembic, Pydantic |
+| **Backend** | Python 3.12+, FastAPI, SQLAlchemy 2.0 + Alembic, Pydantic |
 | **Database** | PostgreSQL 16 + `pgvector` (ANN semantic search) |
 | **Frontend** | Angular 21 (standalone components, signals), Vitest |
 | **LLM / embeddings** | LangChain provider abstraction (Anthropic default), `all-mpnet-base-v2` embeddings |

--- a/backend/src/hiresense/config/groups/ingestion.py
+++ b/backend/src/hiresense/config/groups/ingestion.py
@@ -67,9 +67,9 @@ class IngestionSettings(BaseSettings):
     # Consecutive snapshot fetches a previously-seen job may be missing before
     # it is marked closed (guards against a transient/empty fetch).
     job_closure_miss_threshold: int = 2
-    # Advisory cadence for the URL-probe revalidation sweep. The app does NOT
-    # self-schedule — POST /ingestion/revalidate is driven by an external cron;
-    # this value documents the intended interval for that cron operator.
+    # Cadence consumed by the in-app scheduler for URL-probe revalidation when
+    # SCHEDULER_ENABLED=true. When disabled, operators can still trigger
+    # POST /ingestion/revalidate manually or from an external cron.
     job_revalidation_interval_hours: int = 24
     # Max jobs probed per sweep run (oldest-checked first) — bounds network cost.
     job_revalidation_batch: int = 100

--- a/backend/src/hiresense/config/groups/outreach.py
+++ b/backend/src/hiresense/config/groups/outreach.py
@@ -11,7 +11,8 @@ class OutreachSettings(BaseSettings):
     outreach_followup_cadence_days: int = 7
     # Soft length guard passed to the generator (chars).
     outreach_max_chars: int = 500
-    # Intended cron cadence for the follow-up nudge sweep — INFORMATIONAL ONLY.
+    # Cron cadence consumed by the in-app scheduler when SCHEDULER_ENABLED=true;
+    # when disabled, the job remains available for manual or externally driven runs.
     outreach_followup_schedule: str = "0 10 * * *"
     # SMTP for actually sending outreach email (POST /outreach/send). Leave
     # smtp_host / outreach_from_email blank to disable sending (the endpoint then

--- a/backend/src/hiresense/config/groups/scheduling.py
+++ b/backend/src/hiresense/config/groups/scheduling.py
@@ -12,7 +12,8 @@ class SchedulingSettings(BaseSettings):
     autohunt_initial_lookback_days: int = 7
     # Digests older than this are pruned at the end of each run.
     autohunt_digest_retention_days: int = 90
-    # Intended cron cadence — INFORMATIONAL ONLY; the app never self-schedules.
+    # Cron cadence consumed by the in-app scheduler when SCHEDULER_ENABLED=true;
+    # when disabled, the job remains available for manual or externally driven runs.
     autohunt_schedule: str = "0 9 * * *"
 
     # --- Autopilot pipeline (Phase 4: auto-draft applications for top matches) ---

--- a/backend/tests/unit/identity/test_auth.py
+++ b/backend/tests/unit/identity/test_auth.py
@@ -1,3 +1,4 @@
+from base64 import urlsafe_b64decode, urlsafe_b64encode
 from datetime import datetime, timezone
 
 from jose import jwt
@@ -42,6 +43,41 @@ def test_validate_invalid_token() -> None:
     service = AuthService(username="admin", password="secret", jwt_secret="key")
     payload = service.validate_token("garbage.token.here")
     assert payload is None
+
+
+def test_validate_rejects_expired_token() -> None:
+    service = AuthService(
+        username="admin",
+        password="secret",
+        jwt_secret="key",
+        expiry_hours=-1,
+    )
+    token = service.login("admin", "secret")
+    assert token is not None
+    assert service.validate_token(token) is None
+
+
+def test_validate_rejects_token_signed_with_different_secret() -> None:
+    issuer = AuthService(username="admin", password="secret", jwt_secret="secret-a")
+    validator = AuthService(username="admin", password="secret", jwt_secret="secret-b")
+    token = issuer.login("admin", "secret")
+    assert token is not None
+    assert validator.validate_token(token) is None
+
+
+def test_validate_rejects_byte_flipped_signature() -> None:
+    service = AuthService(username="admin", password="secret", jwt_secret="key")
+    token = service.login("admin", "secret")
+    assert token is not None
+
+    header, payload, encoded_signature = token.split(".")
+    padding = "=" * (-len(encoded_signature) % 4)
+    signature = bytearray(urlsafe_b64decode(encoded_signature + padding))
+    signature[0] ^= 0x01
+    tampered_signature = urlsafe_b64encode(signature).rstrip(b"=").decode("ascii")
+    tampered_token = f"{header}.{payload}.{tampered_signature}"
+
+    assert service.validate_token(tampered_token) is None
 
 
 def test_token_carries_default_admin_role() -> None:


### PR DESCRIPTION
﻿## Problema
- La validación JWT carecía de pruebas negativas específicas para expiración, firma con secreto incorrecto y manipulación de bytes.
- La documentación declaraba Python 3.13 aunque Docker, `pyproject.toml` y Ruff usan Python 3.12.
- Comentarios y documentación afirmaban que la aplicación nunca ejecutaba tareas programadas por sí misma, contradiciendo el scheduler opt-in existente.

## Cambio
- Añade tres pruebas negativas de JWT contra `AuthService.validate_token`.
- Alinea README y CLAUDE.md con Python 3.12+.
- Documenta que `SCHEDULER_ENABLED=true` activa las cadencias internas y conserva las alternativas manuales o por cron externo cuando está deshabilitado.

## Resuelve / Impacto
La seguridad JWT queda cubierta contra tres clases de tokens inválidos y la guía operativa vuelve a reflejar el runtime real.

## Test plan
- [x] Pruebas enfocadas de identidad y scheduler: 25 passed
- [x] `uv run ruff check src tests`
- [x] Búsquedas de versiones y lenguaje obsoleto sin coincidencias
- [x] `git diff --check`

Closes #155
Closes #175
Closes #176

Generated with [Codex](https://Codex.com/Codex)
