### PR TITLE
fix(test): stabilize Node 26 and settings defaults

### DIFF
--- a/backend/tests/unit/test_settings_autopilot.py
+++ b/backend/tests/unit/test_settings_autopilot.py
@@ -1,9 +1,12 @@
-from hiresense.config import Settings
+from hiresense.config.groups import SchedulingSettings
 
 
 def test_autopilot_pipeline_settings_defaults():
-    s = Settings()
-    assert s.autopilot_pipeline_enabled is False
-    assert s.autopilot_pipeline_top_n == 3
-    assert s.autopilot_pipeline_schedule == "0 10 * * *"
-    assert s.autopilot_draft_concurrency == 3
+    fields = SchedulingSettings.model_fields
+
+    # Read the declared defaults directly so a developer's backend/.env cannot
+    # turn this unit test into an assertion about their local configuration.
+    assert fields["autopilot_pipeline_enabled"].default is False
+    assert fields["autopilot_pipeline_top_n"].default == 3
+    assert fields["autopilot_pipeline_schedule"].default == "0 10 * * *"
+    assert fields["autopilot_draft_concurrency"].default == 3

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -81,7 +81,10 @@
           "defaultConfiguration": "development"
         },
         "test": {
-          "builder": "@angular/build:unit-test"
+          "builder": "@angular/build:unit-test",
+          "options": {
+            "setupFiles": ["src/test-setup.ts"]
+          }
         },
         "lint": {
           "builder": "@angular-eslint/builder:lint",

--- a/frontend/src/app/core/services/auth.service.spec.ts
+++ b/frontend/src/app/core/services/auth.service.spec.ts
@@ -38,7 +38,12 @@ describe('AuthService', () => {
   });
 
   it('never touches localStorage for the session', () => {
-    const spy = vi.spyOn(Storage.prototype, 'setItem');
+    const spy = vi.spyOn(localStorage, 'setItem');
+    localStorage.setItem('__hiresense_spy_probe__', 'probe');
+    expect(spy).toHaveBeenCalledOnce();
+    localStorage.removeItem('__hiresense_spy_probe__');
+    spy.mockClear();
+
     const { service, httpMock } = makeService();
     service.login('admin', 'secret').subscribe();
     httpMock.expectOne(`${environment.apiUrl}/auth/login`).flush({ access_token: 't' });

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,44 @@
+// Node 26 exposes an experimental global localStorage accessor that returns
+// undefined without --localstorage-file and shadows the browser test
+// environment. Install a deterministic browser-compatible store for tests.
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return Array.from(this.values.keys())[index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(String(key), String(value));
+  }
+}
+
+const testLocalStorage = new MemoryStorage();
+
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: testLocalStorage,
+});
+
+if (typeof window !== 'undefined' && window !== globalThis) {
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: testLocalStorage,
+  });
+}

--- a/frontend/tsconfig.spec.json
+++ b/frontend/tsconfig.spec.json
@@ -10,6 +10,7 @@
   },
   "include": [
     "src/**/*.d.ts",
+    "src/test-setup.ts",
     "src/**/*.spec.ts"
   ]
 }


### PR DESCRIPTION
﻿## Problema
- Node 26 expone un `localStorage` global experimental que devuelve `undefined` sin `--localstorage-file` y oculta el almacenamiento del entorno de pruebas Angular.
- La prueba de defaults de autopilot instanciaba `Settings()` y por tanto validaba el `.env` local en vez del valor declarado en código.

## Cambio
- Registra un setup global de Angular con una implementación determinista de `Storage` en memoria.
- Incluye el setup en el proyecto TypeScript de pruebas.
- Comprueba los defaults de autopilot directamente desde `SchedulingSettings.model_fields`.

## Resuelve / Impacto
Elimina 16 fallos dependientes de Node 26 y evita que `AUTOPILOT_PIPELINE_ENABLED` local contamine la suite backend.

## Test plan
- [x] Frontend enfocado: 2 archivos, 16 tests passed
- [x] Frontend completo: 81 archivos, 459 tests passed
- [x] Backend completo: 1523 passed, 6 skipped
- [x] `npm run lint`
- [x] `npm run build`
- [x] `uv run ruff check .`
- [x] Prettier del nuevo setup

Generated with [Codex](https://Codex.com/Codex)
