### PR TITLE
docs: refresh open-source launch copy

### DIFF
--- a/docs/open-source-launch/copy-en.md
+++ b/docs/open-source-launch/copy-en.md
@@ -11,28 +11,71 @@ and is safe to share publicly.
 
 Do not publish metrics or source counts without checking them immediately before posting.
 
+## What's new (verified 2026-07-31)
+
+Fresh material for the announcements. Name features, never unverified counts.
+
+- **Opportunity Discover.** New `/opportunities` context: conferences, CFPs, and funded
+  programs from confs.tech and curated imports. Filters by topic, country, deadline, and
+  funded-only; sorting by relevance against your profile; and an attendance-cost label
+  (`Free`, `Funded`, `Paid`, `Likely paid`) inferred even when the source publishes no fee.
+- **New automated job sources:** Dice (official MCP), Y Combinator Work at a Startup
+  (public JSON), and CrunchBoard (official RSS).
+- **Opt-in, ToS-respecting imports** for Indeed, Wellfound, Glassdoor, and Monster, which
+  have no usable public job-search API. No bot-wall or login bypassing.
+- **Company portals:** adapters for Workday, Thoughtworks, and Globant, an `auto` detector
+  that picks the right ATS from a careers URL, and a generic scraper with browser rendering
+  for JavaScript-heavy sites.
+- **Source transparency:** a per-source capability registry (`GET /ingestion/sources`) and
+  per-source health with last run, counts, and errors (`GET /ingestion/sources/health`).
+  Deduplication now records which sources saw each role and ranks direct ATS above
+  aggregators.
+- **Profile-aware ranking:** single and batch evaluation now use the profile you have
+  selected instead of scoring without candidate context.
+- **Sturdier ingestion:** long fetches and job revalidation run in the background instead of
+  blocking the request.
+
+## Opening hooks
+
+A bank of first lines. Use one per post, and don't reuse the same one across networks.
+
+- How many job-board tabs do you have open right now?
+- Tired of digging through hundreds of listings to find the three that actually fit you?
+- Your next job is probably already posted. It's just on page 40.
+- Job hunting isn't an effort problem anymore. It's a noise problem.
+- Your CV, salary expectations, and application history live in six different products. Are
+  we all fine with that?
+- Applying is the easy part. Figuring out what's worth applying to is the actual work.
+
 ## Core positioning
 
 ### Primary tagline
 
 > Turn the job-board firehose into a private, ranked shortlist.
 
+### Alternatives
+
+- Hundreds of listings in. One shortlist that actually makes sense out.
+- Your entire job search in one place — and that place is yours.
+
 ### One-sentence description
 
 > HireSense is a self-hosted job-search workspace for candidates that ingests and
-> deduplicates listings, ranks the whole corpus with pgvector and cost-aware LLM scoring,
-> and manages applications end to end.
+> deduplicates listings from job boards, company ATS portals, and now conferences, CFPs, and
+> funded programs, ranks the whole corpus with pgvector and cost-aware LLM scoring, and
+> manages applications end to end.
 
 ### GitHub About description
 
 > Self-hosted job search for candidates: ingest and deduplicate listings, rank them with
-> pgvector and LLMs, and manage applications end to end.
+> pgvector and LLMs, discover conferences and CFPs, and manage applications end to end.
 
 ### Social-preview text
 
 ```text
 HireSense
-Private, ranked job search—end to end.
+Hundreds of listings in.
+One shortlist that actually fits.
 Open source · Self-hosted
 ```
 
@@ -40,46 +83,77 @@ Open source · Self-hosted
 
 ### Primary launch post
 
-> I got tired of managing a job search across five different tools, so I built one.
+> How many job-board tabs do you have open right now?
 >
-> Today I’m releasing **HireSense**, an open-source, self-hosted workspace for job
-> seekers.
+> I got to seven, plus a spreadsheet, four CV versions, and no idea what was actually
+> working. So I stopped job hunting for a while and built the tool I was missing.
+>
+> Today I'm releasing **HireSense**, an open-source, self-hosted workspace for job seekers.
 >
 > It collects roles from public job boards and company ATS portals, removes duplicates, and
-> ranks the complete job corpus against your profile using pgvector semantic search, skill
+> ranks **the entire corpus** against your profile using pgvector semantic search, skill
 > matching, and cost-aware LLM scoring.
 >
-> From there, it helps manage the rest of the process: application tracking, tailored CVs
-> and cover letters, interview preparation, outreach, and market analytics.
+> From there it handles the rest of the process: application tracking, tailored CVs and
+> cover letters, interview preparation, outreach, and market analytics.
+>
+> As of this week it also finds the things that aren't job posts: conferences, CFPs, and
+> funded programs, filtered by topic, country, and deadline, with a cost label. Sometimes
+> the thing that moves a career isn't one more application — it's a talk.
 >
 > I made it self-hosted because a CV, salary expectations, job preferences, and application
-> history are deeply personal data.
+> history are deeply personal data that should stay with you.
 >
-> The stack includes Python, FastAPI, Angular, PostgreSQL/pgvector, Docker, LangChain,
-> OpenTelemetry, and Grafana.
+> Stack: Python, FastAPI, Angular, PostgreSQL/pgvector, Docker, LangChain, OpenTelemetry,
+> and Grafana.
 >
-> This is the first public preview. I would especially value feedback on the installation
-> experience and the ranking approach.
+> This is the first public preview. I'd especially value feedback on two things: is the
+> installation clear, and does the ranking approach actually feel useful?
 >
 > Live demo (read-only, synthetic data): https://hiresense-demo.vercel.app
 >
 > Repository: https://github.com/StevSant/HireSense
 >
-> If it is useful, consider starring it or contributing to one of the beginner-friendly
-> issues.
+> If it's useful, a star or a beginner-friendly issue helps more than you'd think.
 >
 > #OpenSource #SelfHosted #Python #JobSearch
 
+### What's-new post
+
+> A job posting isn't the only door.
+>
+> I just shipped **Discover** in HireSense: alongside job listings, it now finds
+> conferences, CFPs, and funded programs, with filters by topic, country, and deadline,
+> sorting by relevance against your profile, and a cost label that tells you whether it's
+> free, funded, or paid — even when the source never publishes a fee.
+>
+> The same batch added new job sources: Dice, Y Combinator Work at a Startup, and
+> CrunchBoard running automatically, plus adapters for Workday, Thoughtworks, and Globant
+> portals and a detector that recognizes a company's ATS straight from its careers page.
+>
+> And something less flashy that I care about just as much: every source now reports its own
+> health — last run, how many roles it returned, what error it hit — and deduplication
+> records which sources saw each role, ranking the company's own ATS above aggregators.
+>
+> Still open source, still self-hosted: https://github.com/StevSant/HireSense
+>
+> Which source are you missing? It's literally one new adapter.
+>
+> #OpenSource #Python #JobSearch #DevCommunity
+
 ### Short follow-up post
 
-> One design decision in HireSense matters more than the AI label: ranking happens
-> across the full job corpus before pagination.
+> Your best match is on page 40, and you're never getting there.
 >
-> Otherwise, an excellent match can remain buried on page 40 simply because only the
-> current page was scored.
+> That's the real problem HireSense solves, and it has nothing to do with slapping "AI" on a
+> product. It's about **when** ranking happens.
 >
-> The pipeline uses pgvector for semantic pre-ranking, skill overlap for a fast structured
-> signal, and tiered LLM scoring only where the extra cost is justified.
+> If an app only scores the page you're currently looking at, a great role stays buried
+> purely because it showed up late in the feed. So the pipeline semantically pre-ranks the
+> full corpus before pagination.
+>
+> It uses pgvector for semantic pre-ranking, skill overlap as a fast structured signal, and
+> tiered LLM scoring only where the extra cost buys real signal.
 >
 > I wrote up the architecture and trade-offs here:
 > https://github.com/StevSant/HireSense/blob/main/backend/ARCHITECTURE.md
@@ -103,18 +177,25 @@ Do not publish these in several communities at the same time.
 
 **Title**
 
-> I built a self-hosted job-search workspace with pgvector ranking and an end-to-end application pipeline
+> Why should my CV and application history live on someone else's server? I built a
+> self-hosted job-search workspace with pgvector ranking
 
 **Body**
 
 > I wanted a job-search workflow where my CV, preferences, salary expectations, and
-> application history did not have to live in another SaaS product, so I built HireSense.
+> application history did not have to live in another SaaS product that also monetizes them,
+> so I built HireSense.
 >
-> It ingests roles from public job boards and company ATS portals, deduplicates them by stable
-> identity, ranks the full corpus with pgvector plus skill and optional LLM scoring, and
-> tracks applications through interview and offer stages. It also includes tailored document
-> generation, interview preparation, scheduling, analytics, and OpenTelemetry/Grafana
-> observability.
+> It ingests roles from public job boards and company ATS portals, deduplicates them by
+> stable identity, ranks the full corpus with pgvector plus skill and optional LLM scoring,
+> and tracks applications through interview and offer stages. It also includes tailored
+> document generation, interview preparation, scheduling, analytics, and
+> OpenTelemetry/Grafana observability.
+>
+> Recent additions: new sources (Dice, YC Work at a Startup, CrunchBoard), Workday /
+> Thoughtworks / Globant portal adapters with an auto-detector for unknown careers pages, a
+> per-source health endpoint so you can see which ingestion broke without opening logs, and
+> a Discover section for conferences, CFPs, and funded programs.
 >
 > The stack runs with Docker Compose: FastAPI, Angular, PostgreSQL/pgvector, and Grafana. A
 > local heuristic mode is available for trying the workflow without a paid LLM provider.
@@ -133,12 +214,16 @@ Do not publish these in several communities at the same time.
 
 **Body**
 
-> I’m preparing the first public release of HireSense, a self-hosted job-search system
-> built around FastAPI, Angular, PostgreSQL/pgvector, and a hexagonal backend architecture.
+> I'm preparing the first public release of HireSense, a self-hosted job-search system built
+> around FastAPI, Angular, PostgreSQL/pgvector, and a hexagonal backend architecture.
 >
 > The repository already includes an MIT license, security policy, contribution guide, Code
 > of Conduct, issue forms, CI, and architecture documentation. The main contribution areas
 > are source adapters, ranking quality, onboarding, accessibility, and documentation.
+>
+> Source adapters in particular are a genuinely good first contribution: each one is a port
+> implementation plus a normalizer plus a capability entry, with a documented recipe in
+> `docs/job-sources.md` and unit tests that never hit the live network.
 >
 > Repository: https://github.com/StevSant/HireSense
 >
@@ -149,13 +234,12 @@ Do not publish these in several communities at the same time.
 
 **Title**
 
-> I turned my fragmented job-search workflow into an open-source, self-hosted application
+> Applying is the easy part — I turned the hard part of job hunting into an open-source app
 
 **Body**
 
 > My job search kept expanding into separate spreadsheets, job-board tabs, CV copies,
-> interview notes, and reminders. I started HireSense to put that workflow in one
-> place.
+> interview notes, and reminders. I started HireSense to put that workflow in one place.
 >
 > The most interesting engineering problem was not generating text. It was reducing the
 > firehose: deduplicating jobs, ranking the complete corpus instead of one page, controlling
@@ -163,7 +247,8 @@ Do not publish these in several communities at the same time.
 >
 > It has grown into a FastAPI + Angular application with PostgreSQL/pgvector, Docker,
 > application tracking, tailored artifacts, interview preparation, analytics, automation,
-> and observability.
+> and observability — plus a recent Discover section for conferences, CFPs, and funded
+> programs, because not every career move is an application.
 >
 > Repository: https://github.com/StevSant/HireSense
 >
@@ -181,29 +266,33 @@ smooth local trial.
 ### Short description
 
 > HireSense is an open-source, self-hosted workspace that finds and deduplicates job
-> listings, ranks them against your profile, and supports the application process from
-> tailored documents to interview preparation and analytics.
+> listings, ranks them against your profile, surfaces relevant conferences and CFPs, and
+> supports the application process from tailored documents to interview preparation and
+> analytics.
 
 ### Maker first comment
 
-> Hi Product Hunt — I built HireSense after realizing that job hunting had become a
-> collection of disconnected tools: job boards for discovery, spreadsheets for tracking,
-> document copies for every application, separate interview notes, and no useful view of what
-> was working.
+> Hi Product Hunt — how many job-board tabs do you have open right now?
 >
-> The core idea is to reduce noise before adding more automation. HireSense ingests
-> roles from public boards and company ATS portals, deduplicates them, semantically pre-ranks
-> the complete corpus with pgvector, and uses skill matching and optional tiered LLM scoring
-> to build a shortlist.
+> I built HireSense after realizing that job hunting had become a collection of disconnected
+> tools: job boards for discovery, spreadsheets for tracking, document copies for every
+> application, separate interview notes, and no useful view of what was working.
+>
+> The core idea is to reduce noise before adding more automation. HireSense ingests roles
+> from public boards and company ATS portals, deduplicates them, semantically pre-ranks the
+> complete corpus with pgvector, and uses skill matching and optional tiered LLM scoring to
+> build a shortlist.
 >
 > It then supports the workflow around that shortlist: tracking, tailored CVs and cover
-> letters, interview preparation, outreach, automation, and market analytics.
+> letters, interview preparation, outreach, automation, and market analytics. A recent
+> addition surfaces conferences, CFPs, and funded programs with a cost label, since a talk
+> or a program can move a career as much as an application does.
 >
 > It is MIT-licensed and self-hosted because candidate data is personal. The public preview
 > source code is available at https://github.com/StevSant/HireSense.
 >
 > I would value feedback on two things: whether the first-run experience is clear, and which
-> part of the job-search workflow you would want to automate—or deliberately keep manual.
+> part of the job-search workflow you would want to automate — or deliberately keep manual.
 
 Do not ask anyone to upvote. Invite people to try it and comment.
 
@@ -214,7 +303,8 @@ submission from this file. Write the final text personally after reading the cur
 [Show HN guidelines](https://news.ycombinator.com/showhn.html) and
 [general guidelines](https://news.ycombinator.com/newsguidelines.html).
 
-An honest title should use this structure:
+Note that HN dislikes marketing hooks. Do not carry the question openers from this file into
+a Show HN post — use a plain, factual title:
 
 ```text
 Show HN: HireSense – Self-hosted job search with pgvector and tiered LLM scoring
@@ -227,7 +317,8 @@ Write a short discussion in your own words covering:
 3. Why whole-corpus ranking differs from scoring only a visible page.
 4. How pgvector, skill signals, and tiered models balance quality and cost.
 5. Why the project is self-hosted.
-6. One limitation or unfinished area you genuinely want feedback on.
+6. Which sources are genuinely automatable versus import-only, and why.
+7. One limitation or unfinished area you genuinely want feedback on.
 
 Avoid emoji, marketing adjectives, unsupported metrics, and requests for votes or comments.
 Stay available to answer technical questions after submitting.
@@ -238,11 +329,12 @@ Stay available to answer technical questions after submitting.
 
 **Title**
 
-> How I built a cost-aware job-ranking pipeline with pgvector and tiered LLM scoring
+> Your best match is on page 40: building a cost-aware job-ranking pipeline with pgvector
+> and tiered LLM scoring
 
 **Subtitle**
 
-> Why ranking the whole corpus before pagination produced a better shortlist—and how cheap
+> Why ranking the whole corpus before pagination produced a better shortlist — and how cheap
 > filters keep expensive model calls proportional to signal.
 
 **Outline**
@@ -266,6 +358,10 @@ Stay available to answer technical questions after submitting.
 ### Additional article titles
 
 - Why my job-search app ranks the entire corpus before showing page one
+- When the source won't tell you the price: inferring whether a conference is free, funded,
+  or paid
+- Seven job boards, seven ways of saying no: what you can actually integrate and what you
+  have to import by hand
 - Designing a self-hosted AI application around candidate privacy
 - Stable identity, content hashes, and the surprisingly hard problem of stale job listings
 - Using hexagonal architecture in a FastAPI application with many external adapters
@@ -275,22 +371,35 @@ Stay available to answer technical questions after submitting.
 
 ### X / Bluesky / Mastodon
 
-> I built HireSense: an open-source, self-hosted job-search workspace that deduplicates
-> listings, ranks the full corpus with pgvector + optional LLM scoring, and manages the
-> application process end to end.
+> Your next job is probably already posted. It's on page 40 and you're never getting there.
+>
+> So I built HireSense: open source, self-hosted, deduplicates listings, ranks **the whole
+> corpus** with pgvector before paginating, finds conferences and CFPs, and manages
+> applications end to end.
 >
 > Source: https://github.com/StevSant/HireSense
 >
 > Demo: https://hiresense-demo.vercel.app
 
+### Short variant (what's new)
+
+> New in HireSense: Discover for conferences, CFPs, and funded programs — filter by topic,
+> country, and deadline, with a cost label even when the source never publishes a fee.
+>
+> Plus new job sources: Dice, YC Work at a Startup, and CrunchBoard.
+>
+> https://github.com/StevSant/HireSense
+
 ### YouTube title
 
-> I built a self-hosted job-search platform with FastAPI, Angular, and pgvector
+> I built the app I wish I'd had while job hunting (FastAPI + Angular + pgvector)
 
 ### YouTube description
 
-> HireSense turns job listings into a deduplicated, ranked shortlist, then supports
+> Tired of scrolling hundreds of listings to find three that fit? HireSense turns that
+> firehose into a deduplicated shortlist ranked against your profile, then supports
 > application tracking, tailored documents, interview preparation, outreach, and analytics.
+> It also surfaces conferences, CFPs, and funded programs.
 >
 > Source code and documentation: https://github.com/StevSant/HireSense
 >
@@ -303,7 +412,15 @@ Use one call to action per post:
 - **Feedback:** What would stop you from trying or self-hosting this?
 - **Ranking:** Which matters most to you: match quality, explainability, or cost?
 - **Product:** Which part of job searching should remain manual?
+- **Sources:** Which job board are you missing? Adding one is a single new adapter.
 - **Contribution:** Is the contribution path clear enough for a first pull request?
 - **Support:** If this is useful, star the repository so you can find future releases.
 
-Do not combine all five in one post.
+Do not combine all of them in one post.
+
+## Wording guidance
+
+Hooks can be direct and have personality, but the promise underneath must stay checkable:
+describe what the tool does, not what it guarantees you'll get. Avoid "revolutionary",
+"guarantees interviews", "beats any ATS", "auto-applies to everything", "replaces
+recruiters", and any accuracy or savings claim without a verifiable measurement.

--- a/docs/open-source-launch/copy-es.md
+++ b/docs/open-source-launch/copy-es.md
@@ -11,28 +11,74 @@ sintéticos. No requiere una cuenta y se puede compartir públicamente.
 
 No publiques cifras sobre rendimiento, fuentes o pruebas sin verificarlas justo antes.
 
+## Novedades (verificadas al 2026-07-31)
+
+Material fresco para los anuncios. Nombra funciones, nunca cantidades sin comprobar.
+
+- **Discover de oportunidades.** Nuevo contexto `/opportunities`: conferencias, CFPs
+  (convocatorias de ponencias) y programas financiados, desde confs.tech e importaciones
+  curadas. Filtros por tema, país, fecha límite y “solo financiados”, orden por relevancia
+  contra tu perfil y etiquetas de costo (`Gratis`, `Financiado`, `De pago`,
+  `Probablemente de pago`) incluso cuando la fuente no publica el precio.
+- **Fuentes nuevas automatizadas:** Dice (MCP oficial), Y Combinator Work at a Startup
+  (JSON público) y CrunchBoard (RSS oficial).
+- **Importación opcional y respetuosa de ToS** para Indeed, Wellfound, Glassdoor y Monster,
+  que no tienen una API pública utilizable. Sin saltarse muros de bots ni logins.
+- **Portales de empresa:** adaptadores para Workday, Thoughtworks y Globant, un detector
+  `auto` que elige el ATS correcto desde la URL de carreras, y un scraper genérico con
+  render de navegador para sitios con mucho JavaScript.
+- **Transparencia de fuentes:** registro de capacidades por fuente
+  (`GET /ingestion/sources`) y salud por fuente con última ejecución, conteos y errores
+  (`GET /ingestion/sources/health`). La deduplicación ahora guarda qué fuentes vieron cada
+  vacante y prioriza el ATS directo sobre los agregadores.
+- **Ranking consciente del perfil:** la evaluación individual y por lotes usa el perfil que
+  tengas seleccionado, en vez de puntuar sin contexto.
+- **Ingesta más resistente:** fetches largos y revalidación de vacantes en segundo plano,
+  sin bloquear la petición.
+
+## Ganchos de apertura
+
+Banco de primeras líneas. Usa una sola por publicación y no la repitas entre redes.
+
+- ¿Cuántas pestañas de portales de empleo tienes abiertas ahora mismo?
+- ¿Te cansaste de bucear entre cientos de anuncios para encontrar las tres vacantes que de
+  verdad encajan con tu perfil?
+- Tu próximo trabajo probablemente ya está publicado. El problema es que está en la
+  página 40.
+- Buscar trabajo hoy no es un problema de esfuerzo. Es un problema de ruido.
+- Tu currículum, tu sueldo esperado y tu historial de postulaciones viven en seis
+  plataformas distintas. ¿Eso te parece normal?
+- Postularse es la parte fácil. Encontrar a qué vale la pena postularse es el trabajo real.
+
 ## Posicionamiento principal
 
 ### Frase principal
 
-> Convierte el caos de los portales de empleo en una lista privada, ordenada y relevante.
+> Convierte el ruido de los portales de empleo en una lista corta, privada y ordenada.
+
+### Alternativas
+
+- Cientos de anuncios entran. Sale una lista corta que sí tiene sentido.
+- Tu búsqueda laboral completa en un solo lugar, y ese lugar es tuyo.
 
 ### Descripción en una frase
 
-> HireSense es una plataforma autoalojable para candidatos que reúne y
-> deduplica vacantes, ordena todas las oportunidades con pgvector y evaluación eficiente con
-> LLMs, y gestiona las postulaciones de principio a fin.
+> HireSense es una plataforma autoalojable para candidatos que reúne y deduplica vacantes
+> de portales, ATS de empresas y ahora también conferencias, CFPs y programas financiados,
+> ordena todo según tu perfil con pgvector y evaluación eficiente con LLMs, y gestiona las
+> postulaciones de principio a fin.
 
 ### Descripción para GitHub
 
-> Búsqueda laboral autoalojable: reúne y deduplica vacantes, las ordena con pgvector y LLMs,
-> y gestiona tus postulaciones de principio a fin.
+> Búsqueda laboral autoalojable: reúne y deduplica vacantes, las ordena con pgvector y
+> LLMs, descubre conferencias y CFPs, y gestiona tus postulaciones de principio a fin.
 
 ### Texto para la imagen social
 
 ```text
 HireSense
-Tu búsqueda laboral, privada y ordenada.
+Cientos de anuncios entran.
+Sale una lista corta que sí encaja.
 Código abierto · Autoalojable
 ```
 
@@ -40,49 +86,81 @@ Código abierto · Autoalojable
 
 ### Publicación principal
 
-> Me cansé de gestionar una búsqueda laboral con cinco herramientas distintas, así que
-> construí una sola.
+> ¿Cuántas pestañas de portales de empleo tienes abiertas ahora mismo?
 >
-> Hoy publico **HireSense**, una plataforma de código abierto y autoalojable para
-> personas que están buscando trabajo.
+> Yo llegué a tener siete, más una hoja de cálculo, cuatro versiones del currículum y cero
+> idea de qué estaba funcionando. Así que dejé de buscar trabajo por un rato y construí la
+> herramienta que me faltaba.
 >
-> La aplicación reúne vacantes de portales públicos y sistemas de empleo de empresas,
-> elimina duplicados y ordena todas las oportunidades según su compatibilidad con tu perfil.
-> Para hacerlo combina búsqueda semántica con pgvector, coincidencia de habilidades y
-> evaluación con LLMs controlando el costo.
+> Hoy publico **HireSense**, una plataforma de código abierto y autoalojable para personas
+> que están buscando trabajo.
 >
-> Después permite gestionar todo el proceso: seguimiento de postulaciones, currículums y
-> cartas de presentación personalizadas, preparación para entrevistas, contactos
-> profesionales y análisis del mercado.
+> Reúne vacantes de portales públicos y de los sistemas de empleo de las empresas, elimina
+> duplicados y ordena **todas** las oportunidades según su compatibilidad con tu perfil,
+> combinando búsqueda semántica con pgvector, coincidencia de habilidades y evaluación con
+> LLMs controlando el costo.
 >
-> Decidí hacerla autoalojable porque tu currículum, expectativas salariales, preferencias e
-> historial de postulaciones son datos personales.
+> Después gestiona el resto del proceso: seguimiento de postulaciones, currículums y cartas
+> personalizadas, preparación para entrevistas, contactos profesionales y análisis del
+> mercado.
 >
-> Está construida con Python, FastAPI, Angular, PostgreSQL/pgvector, Docker, LangChain,
-> OpenTelemetry y Grafana.
+> Y desde esta semana también descubre lo que no es una vacante: conferencias, CFPs y
+> programas financiados, filtrados por tema, país y fecha límite, con etiqueta de costo.
+> Porque a veces lo que mueve una carrera no es una postulación más, es una charla.
 >
-> Esta es la primera versión pública. Me ayudaría especialmente recibir feedback sobre dos
-> cosas: ¿la instalación se entiende? ¿La forma de ordenar las vacantes te parece útil?
+> La hice autoalojable porque tu currículum, tus expectativas salariales y tu historial de
+> postulaciones son datos personales y deberían quedarse contigo.
+>
+> Stack: Python, FastAPI, Angular, PostgreSQL/pgvector, Docker, LangChain, OpenTelemetry y
+> Grafana.
+>
+> Es la primera versión pública y me ayudaría muchísimo feedback sobre dos cosas: ¿la
+> instalación se entiende? ¿La forma de ordenar las vacantes te parece útil?
 >
 > Demo (solo lectura, datos sintéticos): https://hiresense-demo.vercel.app
 >
 > Repositorio: https://github.com/StevSant/HireSense
 >
-> Si te resulta útil, puedes guardar el repositorio con una estrella o contribuir en alguno
-> de los issues para principiantes.
+> Si te resulta útil, una estrella en el repo o un issue para principiantes ayudan más de lo
+> que parece.
 >
-> #CodigoAbierto #OpenSource #Python #BusquedaLaboral
+> #CodigoAbierto #OpenSource #Python #BusquedaLaboral #Careers
 
-### Publicación de seguimiento
+### Publicación de novedades
 
-> Una de las decisiones más importantes de HireSense no tiene que ver con
-> “ponerle IA” al producto.
+> Una vacante no es la única puerta que existe.
 >
-> Tiene que ver con **cuándo** se ordenan las vacantes.
+> Acabo de agregar **Discover** a HireSense: además de vacantes, ahora encuentra
+> conferencias, CFPs (convocatorias de ponencias) y programas financiados, con filtros por
+> tema, país y fecha límite, orden por relevancia contra tu perfil, y una etiqueta de costo
+> que te dice si es gratis, financiado o de pago, incluso cuando la fuente no publica el
+> precio.
+>
+> En la misma tanda entraron fuentes nuevas de empleo: Dice, Y Combinator Work at a Startup
+> y CrunchBoard de forma automática, más adaptadores para portales Workday, Thoughtworks y
+> Globant y un detector que reconoce solo el ATS de una empresa desde su página de carreras.
+>
+> Y algo menos vistoso pero que me importa igual: cada fuente ahora reporta su propia salud
+> (última ejecución, cuántas vacantes trajo, qué error dio) y la deduplicación guarda qué
+> fuentes vieron cada vacante, priorizando el ATS de la empresa sobre los agregadores.
+>
+> Todo sigue siendo código abierto y autoalojable:
+> https://github.com/StevSant/HireSense
+>
+> ¿Qué fuente te falta a ti? Es literalmente un adaptador nuevo.
+>
+> #OpenSource #Python #BusquedaLaboral #DevCommunity
+
+### Publicación de seguimiento (técnica)
+
+> Tu mejor oportunidad está en la página 40 y nunca vas a llegar ahí.
+>
+> Ese es el problema real que resuelve HireSense, y no tiene que ver con “ponerle IA” al
+> producto. Tiene que ver con **cuándo** se ordenan las vacantes.
 >
 > Si una aplicación evalúa únicamente la página que estás viendo, una oportunidad excelente
-> puede quedar escondida en la página 40. Por eso el sistema hace una preselección semántica
-> sobre todo el conjunto antes de paginar.
+> queda enterrada por el simple hecho de haber llegado tarde al feed. Por eso el sistema hace
+> una preselección semántica sobre todo el conjunto antes de paginar.
 >
 > El flujo combina pgvector, coincidencia de habilidades y evaluación escalonada con LLMs
 > solo cuando el costo adicional aporta una señal útil.
@@ -109,21 +187,31 @@ mismo anuncio en varias comunidades al mismo tiempo.
 
 **Título**
 
-> Construí una plataforma open source y autoalojable para organizar la búsqueda laboral
+> Me cansé de buscar trabajo entre 7 pestañas y una hoja de cálculo, así que construí una
+> plataforma open source y autoalojable
 
 **Texto**
 
 > Mi búsqueda laboral terminó repartida entre portales, hojas de cálculo, distintas versiones
-> del currículum, notas de entrevistas y recordatorios. Empecé HireSense para
-> reunir ese proceso en una sola aplicación.
+> del currículum, notas de entrevistas y recordatorios. Empecé HireSense para reunir ese
+> proceso en una sola aplicación.
 >
-> El sistema obtiene vacantes de fuentes públicas y portales ATS de empresas, elimina
-> duplicados, ordena todo el conjunto con pgvector, habilidades y evaluación opcional con
+> El problema interesante no era generar texto con un LLM. Era reducir el ruido: deduplicar
+> vacantes con identidad estable, ordenar el conjunto completo en lugar de una sola página,
+> controlar el costo de los modelos y detectar cuándo un anuncio ya está muerto.
+>
+> El sistema obtiene vacantes de fuentes públicas y portales ATS de empresas (Greenhouse,
+> Lever, Ashby, Workable, SmartRecruiters, Recruitee, Workday, más un detector automático y
+> un scraper genérico para los que no exponen API), elimina duplicados guardando de qué
+> fuentes vino cada rol, ordena todo con pgvector + habilidades + evaluación opcional con
 > LLMs, y permite seguir las postulaciones hasta entrevista u oferta.
 >
-> El stack es FastAPI, Angular, PostgreSQL/pgvector y Docker. También incluye generación de
-> documentos, preparación para entrevistas, analítica y observabilidad con OpenTelemetry y
-> Grafana.
+> Lo más reciente: un módulo de oportunidades que no son vacantes (conferencias, CFPs,
+> programas financiados) con filtros y etiquetas de costo, y salud por fuente para saber
+> cuál se rompió y por qué.
+>
+> Stack: FastAPI, Angular, PostgreSQL/pgvector y Docker, con observabilidad vía
+> OpenTelemetry y Grafana.
 >
 > Repositorio: https://github.com/StevSant/HireSense
 >
@@ -134,17 +222,23 @@ mismo anuncio en varias comunidades al mismo tiempo.
 
 **Título**
 
-> Una alternativa autoalojable para mantener privados los datos de tu búsqueda laboral
+> ¿Por qué tu currículum y tu historial de postulaciones tienen que vivir en el servidor de
+> otro? Alternativa autoalojable para la búsqueda laboral
 
 **Texto**
 
-> Construí HireSense porque el currículum, las expectativas salariales, las
-> preferencias y el historial de postulaciones son demasiado personales para repartirlos
-> entre varias plataformas.
+> Construí HireSense porque el currículum, las expectativas salariales, las preferencias y el
+> historial de postulaciones son demasiado personales para repartirlos entre varias
+> plataformas que además te los monetizan.
 >
 > La aplicación corre con Docker y mantiene el flujo completo bajo tu control: ingesta y
-> deduplicación de vacantes, ranking con pgvector, seguimiento, documentos, entrevistas y
-> analítica. El uso de proveedores LLM es opcional para probar el flujo local.
+> deduplicación de vacantes, ranking con pgvector, descubrimiento de conferencias y CFPs,
+> seguimiento, documentos, entrevistas y analítica. El uso de proveedores LLM es opcional:
+> hay un modo heurístico local para probar el flujo sin pagar nada.
+>
+> Novedades recientes: fuentes nuevas (Dice, YC, CrunchBoard), adaptadores de portales
+> Workday/Thoughtworks/Globant, y un panel de salud por fuente para ver qué ingesta está
+> fallando sin abrir los logs.
 >
 > Código: https://github.com/StevSant/HireSense
 >
@@ -160,28 +254,28 @@ principal y este texto para comunicarlo después a tu red hispanohablante.
 
 ### Frase corta
 
-> De cientos de vacantes a una lista privada y ordenada
+> De cientos de anuncios a una lista corta, privada y ordenada
 
 ### Descripción
 
-> HireSense es una plataforma de código abierto y autoalojable que encuentra y
-> deduplica vacantes, las ordena según tu perfil y acompaña el proceso desde los documentos
-> personalizados hasta la preparación para entrevistas y la analítica.
+> HireSense es una plataforma de código abierto y autoalojable que encuentra y deduplica
+> vacantes, las ordena según tu perfil, descubre conferencias y CFPs relevantes, y acompaña
+> el proceso desde los documentos personalizados hasta la preparación para entrevistas y la
+> analítica.
 
 ### Anuncio para la comunidad hispanohablante
 
-> Hoy lancé HireSense en Product Hunt.
+> ¿Cuánto de tu búsqueda laboral es buscar, y cuánto es solo administrar pestañas?
 >
-> Es una plataforma open source y autoalojable que convierte cientos de anuncios laborales
-> en una lista priorizada y después ayuda a gestionar todo el proceso de postulación.
+> Hoy lancé HireSense en Product Hunt: una plataforma open source y autoalojable que
+> convierte cientos de anuncios en una lista priorizada y después ayuda a gestionar todo el
+> proceso de postulación. Y ahora también encuentra conferencias, CFPs y programas
+> financiados relacionados con tu perfil.
 >
-> Si quieres revisar el proyecto y contarme qué funciona o qué falta, aquí está el repositorio:
-> https://github.com/StevSant/HireSense
+> Repositorio: https://github.com/StevSant/HireSense
 >
-> El código está disponible en: https://github.com/StevSant/HireSense
->
-> No necesito que votes por compromiso. Me sirve mucho más que la pruebes y dejes una opinión
-> honesta sobre la instalación o la utilidad del ranking.
+> No necesito que votes por compromiso. Me sirve mucho más que la pruebes y dejes una
+> opinión honesta sobre la instalación o la utilidad del ranking.
 
 ## DEV Community / Hashnode
 
@@ -189,7 +283,8 @@ principal y este texto para comunicarlo después a tu red hispanohablante.
 
 **Título**
 
-> Cómo construí un sistema eficiente de ranking laboral con pgvector y LLMs escalonados
+> Tu mejor vacante está en la página 40: cómo construí un ranking laboral eficiente con
+> pgvector y LLMs escalonados
 
 **Subtítulo**
 
@@ -217,6 +312,10 @@ principal y este texto para comunicarlo después a tu red hispanohablante.
 ### Otros títulos
 
 - Por qué mi aplicación laboral ordena todas las vacantes antes de mostrar la primera página
+- Cuando la fuente no dice el precio: cómo inferir si una conferencia es gratis, financiada
+  o de pago
+- Siete portales de empleo, siete formas de decir “no”: qué se puede integrar de verdad y
+  qué toca importar a mano
 - Cómo diseñar una aplicación de IA autoalojable alrededor de la privacidad del candidato
 - Identidad estable, hashes de contenido y el problema de las vacantes obsoletas
 - Arquitectura hexagonal en FastAPI con múltiples adaptadores externos
@@ -226,21 +325,35 @@ principal y este texto para comunicarlo después a tu red hispanohablante.
 
 ### X / Bluesky / Mastodon
 
-> Construí HireSense: una plataforma open source y autoalojable que deduplica
-> vacantes, ordena todo el conjunto con pgvector y evaluación opcional con LLMs, y gestiona
-> las postulaciones de principio a fin.
+> Tu próximo trabajo ya está publicado. Está en la página 40 y nunca vas a llegar ahí.
+>
+> Por eso construí HireSense: open source y autoalojable, deduplica vacantes, ordena **todo**
+> el conjunto con pgvector antes de paginar, encuentra conferencias y CFPs, y gestiona tus
+> postulaciones de principio a fin.
 >
 > Código: https://github.com/StevSant/HireSense
 
+### Variante corta (novedades)
+
+> Nuevo en HireSense: Discover para conferencias, CFPs y programas financiados, con filtros
+> por tema, país y deadline, y etiqueta de costo aunque la fuente no publique el precio.
+>
+> Más fuentes de empleo: Dice, YC y CrunchBoard.
+>
+> https://github.com/StevSant/HireSense
+
 ### Título para YouTube
 
-> Construí una plataforma de búsqueda laboral con FastAPI, Angular y pgvector
+> Construí la app que me hubiera gustado tener buscando trabajo (FastAPI + Angular +
+> pgvector)
 
 ### Descripción para YouTube
 
-> HireSense transforma cientos de vacantes en una lista deduplicada y ordenada,
-> y después ayuda con el seguimiento, los documentos personalizados, la preparación para
-> entrevistas, los contactos profesionales y la analítica.
+> ¿Te cansaste de revisar cientos de anuncios para encontrar tres que encajen? HireSense
+> transforma esa avalancha en una lista deduplicada y ordenada según tu perfil, y después
+> ayuda con el seguimiento, los documentos personalizados, la preparación para entrevistas,
+> los contactos profesionales y la analítica. También descubre conferencias, CFPs y
+> programas financiados.
 >
 > Código y documentación: https://github.com/StevSant/HireSense
 >
@@ -253,11 +366,12 @@ Usa solo una por publicación:
 - **Feedback:** ¿Qué te impediría probar o autoalojar esta aplicación?
 - **Ranking:** ¿Qué te importa más: calidad, explicación o costo?
 - **Producto:** ¿Qué parte de la búsqueda laboral debería seguir siendo manual?
+- **Fuentes:** ¿Qué portal de empleo te falta? Agregarlo es un adaptador nuevo.
 - **Contribución:** ¿La guía permite hacer un primer pull request sin ayuda adicional?
 - **Apoyo:** Si te resulta útil, guarda el repositorio con una estrella para encontrar las
   próximas versiones.
 
-No combines las cinco preguntas en la misma publicación.
+No combines todas las preguntas en la misma publicación.
 
 ## Vocabulario recomendado
 
@@ -267,3 +381,6 @@ laboral`, `lista priorizada`, `compatibilidad`, `control de datos` y `asistido p
 Evita `revolucionario`, `garantiza entrevistas`, `vence cualquier ATS`, `postula
 automáticamente a todo`, `reemplaza a los reclutadores` y cualquier afirmación de precisión
 o ahorro que no tenga una medición verificable.
+
+Los ganchos pueden ser directos y con personalidad, pero la promesa debe seguir siendo
+comprobable: describe lo que la herramienta hace, no lo que garantiza que vas a conseguir.


### PR DESCRIPTION
Refreshes the English and Spanish open-source launch copy with verified feature updates, new opening hooks, launch posts, and source-specific messaging. Documentation-only change.