### PR TITLE
feat(core): add a shared WAI-ARIA combobox for the growing dropdowns

### DIFF
--- a/frontend/src/app/core/components/combobox/combobox-option.model.ts
+++ b/frontend/src/app/core/components/combobox/combobox-option.model.ts
@@ -1,0 +1,5 @@
+/** One choice in a {@link ComboboxComponent}. `label` is what the user types against. */
+export interface ComboboxOption {
+  readonly value: string;
+  readonly label: string;
+}

--- a/frontend/src/app/core/components/combobox/combobox.component.html
+++ b/frontend/src/app/core/components/combobox/combobox.component.html
@@ -1,0 +1,62 @@
+<div class="combobox" [class.open]="open()">
+  <input
+    #input
+    type="text"
+    class="combobox-input"
+    role="combobox"
+    autocomplete="off"
+    [id]="id"
+    [attr.aria-expanded]="open()"
+    [attr.aria-controls]="id + '-listbox'"
+    aria-autocomplete="list"
+    [attr.aria-activedescendant]="activeOptionId()"
+    [attr.aria-label]="ariaLabel() || null"
+    [attr.aria-labelledby]="labelledBy() || null"
+    [attr.placeholder]="placeholder() || null"
+    [disabled]="disabled()"
+    [value]="displayValue()"
+    (input)="onInput($event)"
+    (focus)="onFocus()"
+    (keydown)="onKeydown($event)"
+  />
+
+  <button
+    type="button"
+    class="combobox-toggle"
+    tabindex="-1"
+    [attr.aria-label]="open() ? 'Close options' : 'Open options'"
+    [attr.aria-expanded]="open()"
+    [attr.aria-controls]="id + '-listbox'"
+    [disabled]="disabled()"
+    (click)="onToggle()"
+  >
+    <span aria-hidden="true">▾</span>
+  </button>
+
+  <ul class="combobox-listbox" role="listbox" [id]="id + '-listbox'" [hidden]="!open()">
+    @for (option of filtered(); track option.value; let i = $index) {
+      <!--
+        In the ARIA combobox pattern the input keeps DOM focus and points at the
+        active row via aria-activedescendant, so options are deliberately not
+        keyboard targets — Arrow/Enter/Escape are handled on the input above.
+        The click handler is the mouse affordance for that same behaviour.
+      -->
+      <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
+      <li
+        class="combobox-option"
+        role="option"
+        tabindex="-1"
+        [id]="optionId(i)"
+        [class.active]="i === activeIndex()"
+        [class.selected]="option.value === value()"
+        [attr.aria-selected]="option.value === value()"
+        (mouseenter)="activeIndex.set(i)"
+        (click)="select(option)"
+      >
+        {{ option.label }}
+      </li>
+    } @empty {
+      <li class="combobox-empty" role="presentation">{{ emptyText() }}</li>
+    }
+  </ul>
+</div>

--- a/frontend/src/app/core/components/combobox/combobox.component.html
+++ b/frontend/src/app/core/components/combobox/combobox.component.html
@@ -33,13 +33,30 @@
     <span aria-hidden="true">▾</span>
   </button>
 
-  <ul class="combobox-listbox" role="listbox" [id]="id + '-listbox'" [hidden]="!open()">
+  <!--
+    Pressing the mouse inside the list must not move DOM focus off the input:
+    the option would take focus, then close() hides the listbox, and a focused
+    node that stops being rendered drops focus to <body>. Suppressing the
+    default mousedown keeps the input focused through a mouse pick, matching
+    the keyboard path.
+  -->
+  <ul
+    class="combobox-listbox"
+    role="listbox"
+    [id]="id + '-listbox'"
+    [hidden]="!open()"
+    (mousedown)="$event.preventDefault()"
+  >
     @for (option of filtered(); track option.value; let i = $index) {
       <!--
         In the ARIA combobox pattern the input keeps DOM focus and points at the
         active row via aria-activedescendant, so options are deliberately not
         keyboard targets — Arrow/Enter/Escape are handled on the input above.
         The click handler is the mouse affordance for that same behaviour.
+
+        aria-selected tracks the *active* row (the one aria-activedescendant
+        points at), which is what the APG pattern announces while arrowing; the
+        .selected class is the separate, visual "this is your current choice".
       -->
       <!-- eslint-disable-next-line @angular-eslint/template/click-events-have-key-events -->
       <li
@@ -49,7 +66,7 @@
         [id]="optionId(i)"
         [class.active]="i === activeIndex()"
         [class.selected]="option.value === value()"
-        [attr.aria-selected]="option.value === value()"
+        [attr.aria-selected]="i === activeIndex()"
         (mouseenter)="activeIndex.set(i)"
         (click)="select(option)"
       >

--- a/frontend/src/app/core/components/combobox/combobox.component.scss
+++ b/frontend/src/app/core/components/combobox/combobox.component.scss
@@ -1,0 +1,88 @@
+.combobox {
+  position: relative;
+  display: block;
+  width: 100%;
+}
+
+.combobox-input {
+  width: 100%;
+  padding: 0.5rem 2rem 0.5rem 0.65rem;
+  border: 1px solid var(--border, #e2e5ea);
+  border-radius: 8px;
+  background: var(--surface, #fff);
+  color: inherit;
+  font: inherit;
+  cursor: text;
+
+  &:focus-visible {
+    outline: 2px solid var(--primary, #4f46e5);
+    outline-offset: 1px;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}
+
+.combobox-toggle {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: 2rem;
+  display: grid;
+  place-items: center;
+  border: 0;
+  background: transparent;
+  color: var(--text-light, #6b7280);
+  cursor: pointer;
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+}
+
+.combobox-listbox {
+  position: absolute;
+  z-index: 20;
+  top: calc(100% + 2px);
+  left: 0;
+  right: 0;
+  max-height: 16rem;
+  overflow-y: auto;
+  margin: 0;
+  padding: 0.25rem;
+  list-style: none;
+  border: 1px solid var(--border, #e2e5ea);
+  border-radius: 8px;
+  background: var(--surface, #fff);
+  box-shadow: 0 4px 12px rgb(0 0 0 / 8%);
+
+  &[hidden] {
+    display: none;
+  }
+}
+
+.combobox-option {
+  padding: 0.45rem 0.6rem;
+  border-radius: 6px;
+  cursor: pointer;
+  // Long job titles shouldn't blow out the popup width.
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+
+  &.active {
+    background: var(--primary-light, #e0e7ff);
+  }
+
+  &.selected {
+    font-weight: 600;
+  }
+}
+
+.combobox-empty {
+  padding: 0.45rem 0.6rem;
+  color: var(--text-light, #6b7280);
+}

--- a/frontend/src/app/core/components/combobox/combobox.component.spec.ts
+++ b/frontend/src/app/core/components/combobox/combobox.component.spec.ts
@@ -29,7 +29,9 @@ describe('ComboboxComponent', () => {
     [...f.nativeElement.querySelectorAll('.combobox-option')] as HTMLElement[];
 
   function key(f: ReturnType<typeof mount>, k: string) {
-    input(f).dispatchEvent(new KeyboardEvent('keydown', { key: k, bubbles: true, cancelable: true }));
+    input(f).dispatchEvent(
+      new KeyboardEvent('keydown', { key: k, bubbles: true, cancelable: true }),
+    );
     f.detectChanges();
   }
 

--- a/frontend/src/app/core/components/combobox/combobox.component.spec.ts
+++ b/frontend/src/app/core/components/combobox/combobox.component.spec.ts
@@ -1,0 +1,181 @@
+import { TestBed } from '@angular/core/testing';
+import { ComboboxComponent } from './combobox.component';
+import { ComboboxOption } from './combobox-option.model';
+
+const OPTIONS: ComboboxOption[] = [
+  { value: 'a', label: 'Remotive' },
+  { value: 'b', label: 'Jobicy' },
+  { value: 'c', label: 'GetOnBoard' },
+];
+
+describe('ComboboxComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [ComboboxComponent] }).compileComponents();
+  });
+
+  function mount(opts: { options?: ComboboxOption[]; value?: string } = {}) {
+    const fixture = TestBed.createComponent(ComboboxComponent);
+    fixture.componentRef.setInput('options', opts.options ?? OPTIONS);
+    fixture.componentRef.setInput('value', opts.value ?? '');
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  const input = (f: ReturnType<typeof mount>) =>
+    f.nativeElement.querySelector('input.combobox-input') as HTMLInputElement;
+  const listbox = (f: ReturnType<typeof mount>) =>
+    f.nativeElement.querySelector('.combobox-listbox') as HTMLElement;
+  const optionEls = (f: ReturnType<typeof mount>) =>
+    [...f.nativeElement.querySelectorAll('.combobox-option')] as HTMLElement[];
+
+  function key(f: ReturnType<typeof mount>, k: string) {
+    input(f).dispatchEvent(new KeyboardEvent('keydown', { key: k, bubbles: true, cancelable: true }));
+    f.detectChanges();
+  }
+
+  function type(f: ReturnType<typeof mount>, text: string) {
+    input(f).value = text;
+    input(f).dispatchEvent(new Event('input'));
+    f.detectChanges();
+  }
+
+  it('exposes the ARIA combobox contract', () => {
+    const fixture = mount();
+    const el = input(fixture);
+
+    expect(el.getAttribute('role')).toBe('combobox');
+    expect(el.getAttribute('aria-expanded')).toBe('false');
+    expect(el.getAttribute('aria-autocomplete')).toBe('list');
+    expect(el.getAttribute('aria-controls')).toBe(listbox(fixture).id);
+    expect(listbox(fixture).getAttribute('role')).toBe('listbox');
+  });
+
+  it('starts closed and opens on focus', () => {
+    const fixture = mount();
+    expect(listbox(fixture).hidden).toBe(true);
+
+    input(fixture).dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+
+    expect(listbox(fixture).hidden).toBe(false);
+    expect(input(fixture).getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('shows the selected label when closed', () => {
+    const fixture = mount({ value: 'b' });
+    expect(input(fixture).value).toBe('Jobicy');
+  });
+
+  it('filters options by substring, case-insensitively', () => {
+    const fixture = mount();
+    type(fixture, 'board');
+
+    expect(optionEls(fixture).map((o) => o.textContent?.trim())).toEqual(['GetOnBoard']);
+  });
+
+  it('renders the empty text when nothing matches', () => {
+    const fixture = mount();
+    type(fixture, 'zzz');
+
+    expect(optionEls(fixture)).toHaveLength(0);
+    expect(fixture.nativeElement.querySelector('.combobox-empty')).not.toBeNull();
+  });
+
+  it('moves the active option with the arrow keys and tracks aria-activedescendant', () => {
+    const fixture = mount();
+    key(fixture, 'ArrowDown'); // opens
+    expect(input(fixture).getAttribute('aria-activedescendant')).toBe(optionEls(fixture)[0].id);
+
+    key(fixture, 'ArrowDown');
+    expect(input(fixture).getAttribute('aria-activedescendant')).toBe(optionEls(fixture)[1].id);
+
+    key(fixture, 'ArrowUp');
+    expect(input(fixture).getAttribute('aria-activedescendant')).toBe(optionEls(fixture)[0].id);
+  });
+
+  it('wraps from the first option to the last on ArrowUp', () => {
+    const fixture = mount();
+    key(fixture, 'ArrowDown');
+    key(fixture, 'ArrowUp');
+
+    expect(input(fixture).getAttribute('aria-activedescendant')).toBe(optionEls(fixture)[2].id);
+  });
+
+  it('emits the active option value on Enter and closes', () => {
+    const fixture = mount();
+    let emitted: string | null = null;
+    fixture.componentInstance.valueChange.subscribe((v) => (emitted = v));
+
+    key(fixture, 'ArrowDown');
+    key(fixture, 'ArrowDown');
+    key(fixture, 'Enter');
+
+    expect(emitted).toBe('b');
+    expect(listbox(fixture).hidden).toBe(true);
+  });
+
+  it('emits on click and marks the chosen option aria-selected', () => {
+    const fixture = mount({ value: 'c' });
+    let emitted: string | null = null;
+    fixture.componentInstance.valueChange.subscribe((v) => (emitted = v));
+
+    input(fixture).dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+    expect(optionEls(fixture)[2].getAttribute('aria-selected')).toBe('true');
+
+    optionEls(fixture)[0].click();
+    fixture.detectChanges();
+
+    expect(emitted).toBe('a');
+  });
+
+  it('closes on Escape without emitting, and restores the selected label', () => {
+    const fixture = mount({ value: 'b' });
+    let emitted = false;
+    fixture.componentInstance.valueChange.subscribe(() => (emitted = true));
+
+    type(fixture, 'remo');
+    key(fixture, 'Escape');
+
+    expect(emitted).toBe(false);
+    expect(listbox(fixture).hidden).toBe(true);
+    expect(input(fixture).value).toBe('Jobicy');
+  });
+
+  it('closes when a click lands outside the component', () => {
+    const fixture = mount();
+    input(fixture).dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+    expect(listbox(fixture).hidden).toBe(false);
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    fixture.detectChanges();
+
+    expect(listbox(fixture).hidden).toBe(true);
+  });
+
+  it('emits opened once so hosts can lazy-load their options', () => {
+    const fixture = mount();
+    let opens = 0;
+    fixture.componentInstance.opened.subscribe(() => opens++);
+
+    input(fixture).dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+    key(fixture, 'Escape');
+    input(fixture).dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+
+    expect(opens).toBe(1);
+  });
+
+  it('does not open when disabled', () => {
+    const fixture = mount();
+    fixture.componentRef.setInput('disabled', true);
+    fixture.detectChanges();
+
+    input(fixture).dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+
+    expect(listbox(fixture).hidden).toBe(true);
+  });
+});

--- a/frontend/src/app/core/components/combobox/combobox.component.spec.ts
+++ b/frontend/src/app/core/components/combobox/combobox.component.spec.ts
@@ -116,7 +116,7 @@ describe('ComboboxComponent', () => {
     expect(listbox(fixture).hidden).toBe(true);
   });
 
-  it('emits on click and marks the chosen option aria-selected', () => {
+  it('emits on click and opens with the chosen option active', () => {
     const fixture = mount({ value: 'c' });
     let emitted: string | null = null;
     fixture.componentInstance.valueChange.subscribe((v) => (emitted = v));
@@ -129,6 +129,44 @@ describe('ComboboxComponent', () => {
     fixture.detectChanges();
 
     expect(emitted).toBe('a');
+  });
+
+  it('moves aria-selected with the active option, not the committed value', () => {
+    const fixture = mount({ value: 'a' });
+
+    input(fixture).dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+    // Opens on the committed value, so active and selected coincide.
+    expect(optionEls(fixture)[0].getAttribute('aria-selected')).toBe('true');
+
+    key(fixture, 'ArrowDown');
+
+    // aria-selected follows aria-activedescendant; the old row must clear it,
+    // otherwise a screen reader never announces the row being arrowed onto.
+    const els = optionEls(fixture);
+    expect(input(fixture).getAttribute('aria-activedescendant')).toBe(els[1].id);
+    expect(els[1].getAttribute('aria-selected')).toBe('true');
+    expect(els[0].getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('keeps focus on the input when an option is picked with the mouse', () => {
+    const fixture = mount();
+    // Attached to the document so focus assertions are meaningful.
+    document.body.appendChild(fixture.nativeElement);
+
+    input(fixture).focus();
+    fixture.detectChanges();
+    expect(document.activeElement).toBe(input(fixture));
+
+    const mousedown = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    optionEls(fixture)[1].dispatchEvent(mousedown);
+    fixture.detectChanges();
+
+    // preventDefault on mousedown is what stops the option from taking focus.
+    expect(mousedown.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(input(fixture));
+
+    fixture.nativeElement.remove();
   });
 
   it('closes on Escape without emitting, and restores the selected label', () => {

--- a/frontend/src/app/core/components/combobox/combobox.component.ts
+++ b/frontend/src/app/core/components/combobox/combobox.component.ts
@@ -1,0 +1,197 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostListener,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { ComboboxOption } from './combobox-option.model';
+
+// Unique per instance so aria-activedescendant/aria-controls point at this
+// combobox's own nodes when several are on the page.
+let nextId = 0;
+
+/**
+ * Filtering single-select combobox following the WAI-ARIA 1.2 pattern
+ * (editable combobox with list autocomplete).
+ *
+ * Use this only where the option list is long or grows with the data. Short
+ * static enums (tone, language, status, sort order) should stay native
+ * `<select>` — native wins on mobile and with assistive tech.
+ */
+@Component({
+  selector: 'app-combobox',
+  standalone: true,
+  templateUrl: './combobox.component.html',
+  styleUrl: './combobox.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ComboboxComponent {
+  private host = inject(ElementRef<HTMLElement>);
+
+  options = input.required<readonly ComboboxOption[]>();
+  /** Currently selected option value; '' when nothing is chosen. */
+  value = input<string>('');
+  placeholder = input<string>('');
+  /** Labels the text input for assistive tech when there is no visible <label>. */
+  ariaLabel = input<string>('');
+  /** Id of a visible <label> element, when the host renders one. */
+  labelledBy = input<string>('');
+  emptyText = input<string>('No matches');
+  disabled = input<boolean>(false);
+
+  valueChange = output<string>();
+  /** Fires the first time the list is opened — hosts use it to lazy-load options. */
+  opened = output<void>();
+
+  readonly id = `combobox-${nextId++}`;
+
+  open = signal(false);
+  query = signal('');
+  activeIndex = signal(-1);
+
+  private hasOpened = false;
+
+  selectedLabel = computed(() => {
+    const current = this.value();
+    return this.options().find((o) => o.value === current)?.label ?? '';
+  });
+
+  filtered = computed<readonly ComboboxOption[]>(() => {
+    const q = this.query().trim().toLowerCase();
+    const all = this.options();
+    if (!q) return all;
+    return all.filter((o) => o.label.toLowerCase().includes(q));
+  });
+
+  /** Typed text while filtering, the selected label otherwise. */
+  displayValue = computed(() => (this.open() ? this.query() : this.selectedLabel()));
+
+  activeOptionId = computed(() => {
+    const i = this.activeIndex();
+    return i >= 0 && i < this.filtered().length ? this.optionId(i) : null;
+  });
+
+  optionId(index: number): string {
+    return `${this.id}-option-${index}`;
+  }
+
+  onInput(event: Event): void {
+    this.query.set((event.target as HTMLInputElement).value);
+    this.openList();
+    // Filtering changes what row 0 is, so point at the first match again.
+    this.activeIndex.set(this.filtered().length ? 0 : -1);
+  }
+
+  onFocus(): void {
+    this.openList();
+  }
+
+  onToggle(): void {
+    if (this.disabled()) return;
+    if (this.open()) {
+      this.close();
+    } else {
+      this.openList();
+    }
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        if (!this.open()) {
+          this.openList();
+          return;
+        }
+        this.move(1);
+        return;
+      case 'ArrowUp':
+        event.preventDefault();
+        if (!this.open()) {
+          this.openList();
+          return;
+        }
+        this.move(-1);
+        return;
+      case 'Home':
+        if (!this.open()) return;
+        event.preventDefault();
+        this.activeIndex.set(this.filtered().length ? 0 : -1);
+        return;
+      case 'End':
+        if (!this.open()) return;
+        event.preventDefault();
+        this.activeIndex.set(this.filtered().length - 1);
+        return;
+      case 'Enter': {
+        if (!this.open()) return;
+        const option = this.filtered()[this.activeIndex()];
+        if (option) {
+          event.preventDefault();
+          this.select(option);
+        }
+        return;
+      }
+      case 'Escape':
+        if (!this.open()) return;
+        event.preventDefault();
+        this.close();
+        return;
+      case 'Tab':
+        // Let focus move on, but never leave a half-typed filter on screen.
+        this.close();
+        return;
+    }
+  }
+
+  select(option: ComboboxOption): void {
+    this.valueChange.emit(option.value);
+    this.close();
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.open()) return;
+    if (!this.host.nativeElement.contains(event.target as Node)) {
+      this.close();
+    }
+  }
+
+  private openList(): void {
+    if (this.disabled() || this.open()) return;
+    this.open.set(true);
+    this.activeIndex.set(this.indexOfSelected());
+    if (!this.hasOpened) {
+      this.hasOpened = true;
+      this.opened.emit();
+    }
+  }
+
+  private close(): void {
+    this.open.set(false);
+    this.query.set('');
+    this.activeIndex.set(-1);
+  }
+
+  private indexOfSelected(): number {
+    const current = this.value();
+    const i = this.filtered().findIndex((o) => o.value === current);
+    return i >= 0 ? i : this.filtered().length ? 0 : -1;
+  }
+
+  private move(delta: number): void {
+    const count = this.filtered().length;
+    if (!count) {
+      this.activeIndex.set(-1);
+      return;
+    }
+    const next = this.activeIndex() + delta;
+    // Wrap, so ArrowUp from the top lands on the last option.
+    this.activeIndex.set(((next % count) + count) % count);
+  }
+}

--- a/frontend/src/app/core/components/combobox/index.ts
+++ b/frontend/src/app/core/components/combobox/index.ts
@@ -1,0 +1,2 @@
+export { ComboboxComponent } from './combobox.component';
+export type { ComboboxOption } from './combobox-option.model';

--- a/frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.html
+++ b/frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.html
@@ -1,12 +1,14 @@
 <div class="filters-bar">
   <div class="filter-item">
-    <label class="filter-label" for="filter-source">Source</label>
-    <select id="filter-source" (change)="onSourceChange($event)" class="filter-control">
-      <option value="">All sources</option>
-      @for (source of sources(); track source) {
-        <option [value]="source" [selected]="filters().source === source">{{ source }}</option>
-      }
-    </select>
+    <span class="filter-label" id="filter-source-label">Source</span>
+    <app-combobox
+      labelledBy="filter-source-label"
+      placeholder="All sources"
+      emptyText="No matching source"
+      [options]="sourceOptions()"
+      [value]="filters().source ?? ''"
+      (valueChange)="onSourceChange($event)"
+    />
   </div>
 
   <div class="filter-item">

--- a/frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.spec.ts
+++ b/frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.spec.ts
@@ -56,11 +56,27 @@ describe('JobFiltersComponent', () => {
     expect(emitted).toEqual([{ user_location: 'Chile', strict_location: true }]);
   });
 
+  // The source picker is a filtering combobox (app-combobox), not a native
+  // select — the list grows with every adapter and ATS portal ingested.
+  function openSourceCombobox(fixture: ReturnType<typeof mount>) {
+    const input = fixture.nativeElement.querySelector(
+      'app-combobox input.combobox-input',
+    ) as HTMLInputElement;
+    input.dispatchEvent(new Event('focus'));
+    fixture.detectChanges();
+    return input;
+  }
+
+  function sourceOptionEls(fixture: ReturnType<typeof mount>): HTMLElement[] {
+    return [...fixture.nativeElement.querySelectorAll('app-combobox .combobox-option')];
+  }
+
   it('renders an option per source plus the "All sources" default', () => {
     const fixture = mount({}, ['remotive', 'jobicy']);
-    const options = fixture.nativeElement.querySelectorAll('select.filter-control option');
+    openSourceCombobox(fixture);
+    const options = sourceOptionEls(fixture);
     expect(options.length).toBe(3);
-    expect((options[0] as HTMLOptionElement).textContent?.trim()).toBe('All sources');
+    expect(options[0].textContent?.trim()).toBe('All sources');
   });
 
   it('emits the source filter on select change', () => {
@@ -68,11 +84,10 @@ describe('JobFiltersComponent', () => {
     let emitted: JobFilters | null = null;
     fixture.componentInstance.filtersChange.subscribe((f) => (emitted = f));
 
-    const select = fixture.nativeElement.querySelector(
-      'select.filter-control',
-    ) as HTMLSelectElement;
-    select.value = 'remotive';
-    select.dispatchEvent(new Event('change'));
+    openSourceCombobox(fixture);
+    sourceOptionEls(fixture)
+      .find((o) => o.textContent?.trim() === 'remotive')!
+      .click();
 
     expect(emitted).toEqual({ source: 'remotive' });
   });
@@ -82,11 +97,10 @@ describe('JobFiltersComponent', () => {
     let emitted: JobFilters | null = null;
     fixture.componentInstance.filtersChange.subscribe((f) => (emitted = f));
 
-    const select = fixture.nativeElement.querySelector(
-      'select.filter-control',
-    ) as HTMLSelectElement;
-    select.value = 'remotive';
-    select.dispatchEvent(new Event('change'));
+    openSourceCombobox(fixture);
+    sourceOptionEls(fixture)
+      .find((o) => o.textContent?.trim() === 'remotive')!
+      .click();
 
     expect(emitted).toEqual({ keyword: 'python', source: 'remotive' });
   });
@@ -96,11 +110,10 @@ describe('JobFiltersComponent', () => {
     let emitted: JobFilters | null = null;
     fixture.componentInstance.filtersChange.subscribe((f) => (emitted = f));
 
-    const select = fixture.nativeElement.querySelector(
-      'select.filter-control',
-    ) as HTMLSelectElement;
-    select.value = '';
-    select.dispatchEvent(new Event('change'));
+    openSourceCombobox(fixture);
+    sourceOptionEls(fixture)
+      .find((o) => o.textContent?.trim() === 'All sources')!
+      .click();
 
     expect(emitted).toEqual({ source: undefined });
   });
@@ -112,9 +125,9 @@ describe('JobFiltersComponent', () => {
       let emitted: JobFilters | null = null;
       fixture.componentInstance.filtersChange.subscribe((f) => (emitted = f));
 
-      const input = fixture.nativeElement.querySelectorAll(
-        'input[type="text"]',
-      )[0] as HTMLInputElement;
+      const input = fixture.nativeElement.querySelector(
+        'input.filter-control[type="text"]',
+      ) as HTMLInputElement;
       input.value = '  react  ';
       input.dispatchEvent(new Event('input'));
 

--- a/frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.ts
+++ b/frontend/src/app/pages/ingestion/components/job-filters/job-filters.component.ts
@@ -1,7 +1,8 @@
-import { Component, OnInit, input, output } from '@angular/core';
+import { Component, OnInit, computed, input, output } from '@angular/core';
 import { JobFilters } from '../../models/job-filters.model';
 import { SeniorityLevel } from '../../models/seniority-level.model';
 import { detectUserLocation } from '../../../../core/utils/detect-user-location';
+import { ComboboxComponent, ComboboxOption } from '../../../../core/components/combobox';
 
 const LS_USER_LOCATION = 'hiresense.user_location';
 const LS_STRICT_LOCATION = 'hiresense.strict_location_match';
@@ -9,7 +10,7 @@ const LS_STRICT_LOCATION = 'hiresense.strict_location_match';
 @Component({
   selector: 'app-job-filters',
   standalone: true,
-  imports: [],
+  imports: [ComboboxComponent],
   templateUrl: './job-filters.component.html',
   styleUrl: './job-filters.component.scss',
 })
@@ -50,9 +51,14 @@ export class JobFiltersComponent implements OnInit {
     this.emitFilters({ user_location: detected });
   }
 
-  onSourceChange(event: Event): void {
-    const select = event.target as HTMLSelectElement;
-    const value = select.value;
+  // The source list grows with every adapter and ATS portal ingested, so this
+  // one is a filtering combobox rather than a native select.
+  sourceOptions = computed<ComboboxOption[]>(() => [
+    { value: '', label: 'All sources' },
+    ...this.sources().map((source) => ({ value: source, label: source })),
+  ]);
+
+  onSourceChange(value: string): void {
     this.emitFilters({ source: value || undefined });
   }
 

--- a/frontend/src/app/pages/matching/matching.component.html
+++ b/frontend/src/app/pages/matching/matching.component.html
@@ -43,19 +43,16 @@
       }
 
       <div class="job-selector">
-        <label for="job-select">Select a Job</label>
-        <select
-          id="job-select"
-          [ngModel]="selectedJobId()"
-          (ngModelChange)="onJobSelected($event)"
-          (focus)="ensureJobsLoaded()"
-          name="jobSelect"
-        >
-          <option value="manual">Manual entry</option>
-          @for (job of jobs(); track job.id) {
-            <option [value]="job.id">{{ job.title }} — {{ job.company }}</option>
-          }
-        </select>
+        <span id="job-select-label">Select a Job</span>
+        <app-combobox
+          labelledBy="job-select-label"
+          placeholder="Search jobs…"
+          emptyText="No matching job"
+          [options]="jobOptions()"
+          [value]="selectedJobId()"
+          (opened)="ensureJobsLoaded()"
+          (valueChange)="onJobSelected($event)"
+        />
       </div>
 
       <div class="form-row">

--- a/frontend/src/app/pages/matching/matching.component.ts
+++ b/frontend/src/app/pages/matching/matching.component.ts
@@ -14,11 +14,12 @@ import { formatScorePercent } from '../../core/utils/format-score-percent';
 import { dimensionLabel as toDimensionLabel } from '../../core/utils/dimension-label';
 import { mapLlmError } from '../../core/services/llm-error.util';
 import { LlmRunnerService } from '../../core/services/llm-runner.service';
+import { ComboboxComponent, ComboboxOption } from '../../core/components/combobox';
 
 @Component({
   selector: 'app-matching',
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, ComboboxComponent],
   templateUrl: './matching.component.html',
   styleUrl: './matching.component.scss',
 })
@@ -50,6 +51,16 @@ export class MatchingComponent implements OnInit {
   );
 
   jobs = signal<NormalizedJob[]>([]);
+
+  // Typing filters the list, so the picker no longer depends on the fetched
+  // page being small enough to scan by eye.
+  jobOptions = computed<ComboboxOption[]>(() => [
+    { value: 'manual', label: 'Manual entry' },
+    ...this.jobs().map((job) => ({
+      value: job.id,
+      label: `${job.title} — ${job.company}`,
+    })),
+  ]);
   selectedJobId = signal<string>('manual');
   profileLoaded = signal(false);
   // Gates the dropdown's job list fetch so it only fires once, the first

--- a/frontend/src/app/pages/outreach/outreach.component.html
+++ b/frontend/src/app/pages/outreach/outreach.component.html
@@ -36,17 +36,15 @@
   <section class="card">
     <h2>Compose</h2>
     <div class="field">
-      <label for="application">Application</label>
-      <select
-        id="application"
-        [ngModel]="selectedApplicationId()"
-        (ngModelChange)="onSelectChange($event)"
-      >
-        <option value="">Select an application…</option>
-        @for (app of applications(); track app.id) {
-          <option [value]="app.id">{{ app.title }} @ {{ app.company }}</option>
-        }
-      </select>
+      <span id="application-label">Application</span>
+      <app-combobox
+        labelledBy="application-label"
+        placeholder="Select an application…"
+        emptyText="No matching application"
+        [options]="applicationOptions()"
+        [value]="selectedApplicationId()"
+        (valueChange)="onSelectChange($event)"
+      />
     </div>
 
     @if (applicationsError()) {

--- a/frontend/src/app/pages/outreach/outreach.component.ts
+++ b/frontend/src/app/pages/outreach/outreach.component.ts
@@ -24,11 +24,12 @@ import { GenerateResponse } from './models/generate-response.model';
 import { createSortState } from '../../core/utils/sort-state';
 import { sortItems } from '../../core/utils/sort-items';
 import { parseSortToken } from '../../core/utils/parse-sort-token';
+import { ComboboxComponent, ComboboxOption } from '../../core/components/combobox';
 
 @Component({
   selector: 'app-outreach',
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, ComboboxComponent],
   templateUrl: './outreach.component.html',
   styleUrl: './outreach.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -43,6 +44,13 @@ export class OutreachComponent implements OnInit {
 
   // Target picker
   applications = signal<ApplicationListItem[]>([]);
+
+  applicationOptions = computed<ComboboxOption[]>(() =>
+    this.applications().map((app) => ({
+      value: app.id,
+      label: `${app.title} @ ${app.company}`,
+    })),
+  );
   applicationsError = signal('');
   selectedApplicationId = signal('');
 


### PR DESCRIPTION
Item 6 of the UI restructure. **Stacked on #227** (→ #226 → #224).

## Why these three

Exactly three pickers select from lists that grow with the data, and all three were native `<select>`s you had to scan by eye:

| Where | Problem |
|---|---|
| `job-filters` source | grows with every adapter and ATS portal ingested |
| `matching` job picker | **only fetched 25 rows**, because a longer list was unusable |
| `outreach` application picker | up to 100 entries |

The other ~30 `<select>`s stay native on purpose — short static enums (tone, language, work mode, status, sort, provider) where native wins on mobile and with assistive tech.

## The component

`core/components/combobox/`, implementing the ARIA 1.2 editable combobox with list autocomplete:

- substring filter, case-insensitive
- Arrow up/down with wraparound, Home/End, Enter to choose, Escape to cancel back to the current selection
- click-outside to dismiss
- `aria-expanded` / `aria-controls` / `aria-activedescendant` kept in sync; per-instance ids so several can coexist
- an `opened` output so hosts can lazy-load on first open — that's how matching keeps deferring its job fetch

13 specs cover the contract, keyboard model, filtering, and the disabled case.

**One lint suppression, with reasoning.** The a11y rule wants a keyboard handler on the clickable `<li role="option">`. In this pattern options are deliberately *not* focus targets — the input holds DOM focus and points at the active row via `aria-activedescendant`, and Arrow/Enter/Escape are handled there. Adding per-option key handlers would be wrong, so the rule is disabled on that line with the rationale inline. `tabindex="-1"` satisfies the focusable rule legitimately.

## Verification

**531/531** tests pass, `ng lint` clean (including the a11y step), production build succeeds, prettier clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)