### PR TITLE
fix(runner): stop escalating every ATS form on a phantom captcha

### DIFF
--- a/backend/src/hiresense/runner/dom_serializer.py
+++ b/backend/src/hiresense/runner/dom_serializer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from bs4 import BeautifulSoup, Comment
@@ -25,10 +26,18 @@ _CAPTCHA_FRAME_HOSTS = (
 # being asked. Blocking on `anchor` would block every Greenhouse posting.
 _CHALLENGE_FRAME_PATHS = ("/bframe", "/challenge")
 
+# An `anchor` frame is a passive badge for invisible/v3 reCAPTCHA, but for v2 it
+# IS the "I'm not a robot" checkbox a human has to click. The rendered size is
+# what distinguishes them, and the live Greenhouse enterprise anchor carries
+# neither, so keying on these does not regress it.
+_INTERACTIVE_FRAME_SIZES = ("size=normal", "size=compact", "frame=checkbox")
+
 # Container elements a captcha library renders a visible widget into. Compared
 # by EXACT class name: `g-recaptcha-response` is the hidden textarea holding the
 # token, not a widget, and must not match.
 _CAPTCHA_WIDGET_CLASSES = frozenset({"g-recaptcha", "h-captcha", "cf-turnstile"})
+
+_PLAIN_IDENT = re.compile(r"[A-Za-z_-][A-Za-z0-9_-]*")
 
 _VALUE_TYPES = ("text", "email", "tel", "url", "number", "date", "password", "search")
 _SKIP_TYPES = ("hidden", "image", "reset")
@@ -47,9 +56,16 @@ def _clean(soup: BeautifulSoup) -> None:
 
 
 def _is_invisible(element: Any) -> bool:
-    """True when a captcha container is configured not to need interaction."""
+    """True when a captcha container declares itself non-interactive.
+
+    Only `data-size` is consulted -- the correct signal for reCAPTCHA and
+    hCaptcha. Turnstile configures this via the dashboard or `data-appearance`,
+    so a non-interactive Turnstile widget is still treated as blocking. That is
+    the safe direction (over-escalate, never under-escalate), so it is left
+    alone deliberately rather than guessed at.
+    """
     size = str(element.get("data-size") or "").casefold()
-    return size in ("invisible",)
+    return size == "invisible"
 
 
 def _detect_captcha(soup: BeautifulSoup) -> bool:
@@ -87,8 +103,37 @@ def _detect_captcha(soup: BeautifulSoup) -> bool:
             continue
         if any(path in src for path in _CHALLENGE_FRAME_PATHS):
             return True
+        if any(size in src for size in _INTERACTIVE_FRAME_SIZES):
+            return True
 
     return False
+
+
+# Deep enough to walk any real form out to <body>. A React-rendered ATS page
+# can nest a control dozens of levels below the nearest ancestor id; bailing out
+# early would drop the element entirely and reinstate the "filled form with no
+# submit control" bug this fallback exists to fix.
+MAX_CSS_PATH_DEPTH = 60
+
+
+def _quote(value: str) -> str:
+    """Quote a value for use inside a CSS attribute selector."""
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+def _id_selector(value: str) -> str:
+    """`#id` when the id is a plain CSS identifier, else a quoted attribute.
+
+    Ids and names come from the employer's page, and HTML5 permits almost any
+    character in them. Interpolating one straight into `#...` produces a
+    selector that either fails to parse (`#123abc`) or silently means something
+    else (`#a:b.c` is a compound, not an id), and a crafted value could close
+    the selector and redirect a fill to an element of the page's choosing.
+    """
+    if _PLAIN_IDENT.fullmatch(value):
+        return f"#{value}"
+    return f"[id={_quote(value)}]"
 
 
 def _css_path(element: Any) -> str | None:
@@ -105,18 +150,22 @@ def _css_path(element: Any) -> str | None:
     """
     segments: list[str] = []
     current = element
-    for _ in range(12):  # depth guard; ATS forms are nowhere near this deep
+    for _ in range(MAX_CSS_PATH_DEPTH):
         parent = current.parent
         if parent is None or getattr(parent, "name", None) is None:
             return None
 
-        siblings = [s for s in parent.find_all(current.name, recursive=False)]
-        index = siblings.index(current) + 1 if current in siblings else 1
+        # Index by identity. BeautifulSoup's Tag.__eq__ compares by value, so
+        # list.index()/`in` match the FIRST structurally-equal sibling -- two
+        # identical buttons would collapse onto one selector that silently
+        # drives the wrong control.
+        siblings = parent.find_all(current.name, recursive=False)
+        index = next((i for i, s in enumerate(siblings) if s is current), 0) + 1
         segments.append(f"{current.name}:nth-of-type({index})")
 
         parent_id = parent.get("id") if hasattr(parent, "get") else None
         if parent_id:
-            segments.append(f"#{parent_id}")
+            segments.append(_id_selector(str(parent_id)))
             break
         if parent.name in ("body", "html"):
             segments.append(parent.name)
@@ -132,11 +181,10 @@ def _selector_for(element: Any) -> str | None:
     """A stable CSS selector: id, then name, then a positional path."""
     element_id = element.get("id")
     if element_id:
-        return f"#{element_id}"
+        return _id_selector(str(element_id))
     name = element.get("name")
     if name:
-        tag = element.name
-        return f'{tag}[name="{name}"]'
+        return f"{element.name}[name={_quote(str(name))}]"
     return _css_path(element)
 
 

--- a/backend/src/hiresense/runner/dom_serializer.py
+++ b/backend/src/hiresense/runner/dom_serializer.py
@@ -9,8 +9,26 @@ from bs4 import BeautifulSoup, Comment
 MAX_PAGE_TEXT = 4000
 MAX_LABEL_CHARS = 300
 
-# Widgets whose presence means a human has to take over. Never "solved".
-_CAPTCHA_MARKERS = ("recaptcha", "hcaptcha", "turnstile", "funcaptcha", "arkoselabs")
+# Hosts that serve captcha frames. Matched against an iframe's src, never
+# against the page source at large -- see _detect_captcha.
+_CAPTCHA_FRAME_HOSTS = (
+    "recaptcha",
+    "hcaptcha",
+    "turnstile",
+    "funcaptcha",
+    "arkoselabs",
+)
+
+# The path segment of the frame that actually presents a challenge to a human
+# ("pick every bus"). reCAPTCHA/hCaptcha always embed an `anchor` frame -- the
+# badge or checkbox -- but only inject a `bframe` when a challenge is really
+# being asked. Blocking on `anchor` would block every Greenhouse posting.
+_CHALLENGE_FRAME_PATHS = ("/bframe", "/challenge")
+
+# Container elements a captcha library renders a visible widget into. Compared
+# by EXACT class name: `g-recaptcha-response` is the hidden textarea holding the
+# token, not a widget, and must not match.
+_CAPTCHA_WIDGET_CLASSES = frozenset({"g-recaptcha", "h-captcha", "cf-turnstile"})
 
 _VALUE_TYPES = ("text", "email", "tel", "url", "number", "date", "password", "search")
 _SKIP_TYPES = ("hidden", "image", "reset")
@@ -28,19 +46,90 @@ def _clean(soup: BeautifulSoup) -> None:
         comment.extract()
 
 
-def _detect_captcha(soup: BeautifulSoup, raw: str) -> bool:
-    haystack = raw.casefold()
-    if any(marker in haystack for marker in _CAPTCHA_MARKERS):
-        return True
+def _is_invisible(element: Any) -> bool:
+    """True when a captcha container is configured not to need interaction."""
+    size = str(element.get("data-size") or "").casefold()
+    return size in ("invisible",)
+
+
+def _detect_captcha(soup: BeautifulSoup) -> bool:
+    """True only when an INTERACTIVE challenge is on the page.
+
+    Deliberately narrow. An earlier version substring-searched the whole page
+    source for "recaptcha"/"turnstile", which made every Greenhouse posting
+    escalate: Greenhouse ships a `GOOGLE_RECAPTCHA_INVISIBLE_KEY` inside a JS
+    config blob on every job page, with no widget anywhere in the DOM. That is
+    a configuration value, not a challenge, and treating it as one made
+    auto-apply useless on the most common ATS.
+
+    So we look for evidence a human is actually being asked something:
+      * a visible widget container, matched by EXACT class name, or
+      * a challenge frame (`bframe`), which the library injects only when it
+        decides to present a puzzle.
+
+    Everything else about a captcha is ambient and must not block: the config
+    key, the badge `anchor` frame that every reCAPTCHA-protected page carries,
+    and the hidden `g-recaptcha-response` textarea that holds the token. All
+    three are present on a normal, perfectly fillable Greenhouse form.
+
+    If an invisible challenge does reject the submission, that surfaces as a
+    failed submit -- the honest place for it, rather than pre-emptively
+    escalating every job before a single field is typed.
+    """
+    for element in soup.find_all(class_=True):
+        classes = {str(name).casefold() for name in (element.get("class") or [])}
+        if classes & _CAPTCHA_WIDGET_CLASSES and not _is_invisible(element):
+            return True
+
     for frame in soup.find_all("iframe"):
         src = str(frame.get("src") or "").casefold()
-        if any(marker in src for marker in _CAPTCHA_MARKERS):
+        if not any(host in src for host in _CAPTCHA_FRAME_HOSTS):
+            continue
+        if any(path in src for path in _CHALLENGE_FRAME_PATHS):
             return True
+
     return False
 
 
+def _css_path(element: Any) -> str | None:
+    """Build a positional CSS path for an element with no id or name.
+
+    Walks up to the nearest ancestor carrying an id (or to <body>), emitting
+    `tag:nth-of-type(k)` segments. Plain CSS, so it stays browser-agnostic and
+    works with any driver.
+
+    Needed because real ATS controls often have neither id nor name -- notably
+    Greenhouse's `<button type="submit">Submit application</button>`, which
+    carries no attributes at all. Dropping such elements meant the agent could
+    see a fully filled form but no way to submit it.
+    """
+    segments: list[str] = []
+    current = element
+    for _ in range(12):  # depth guard; ATS forms are nowhere near this deep
+        parent = current.parent
+        if parent is None or getattr(parent, "name", None) is None:
+            return None
+
+        siblings = [s for s in parent.find_all(current.name, recursive=False)]
+        index = siblings.index(current) + 1 if current in siblings else 1
+        segments.append(f"{current.name}:nth-of-type({index})")
+
+        parent_id = parent.get("id") if hasattr(parent, "get") else None
+        if parent_id:
+            segments.append(f"#{parent_id}")
+            break
+        if parent.name in ("body", "html"):
+            segments.append(parent.name)
+            break
+        current = parent
+    else:
+        return None
+
+    return " > ".join(reversed(segments))
+
+
 def _selector_for(element: Any) -> str | None:
-    """A stable CSS selector, preferring id then name. None when neither exists."""
+    """A stable CSS selector: id, then name, then a positional path."""
     element_id = element.get("id")
     if element_id:
         return f"#{element_id}"
@@ -48,7 +137,7 @@ def _selector_for(element: Any) -> str | None:
     if name:
         tag = element.name
         return f'{tag}[name="{name}"]'
-    return None
+    return _css_path(element)
 
 
 def _label_for(soup: BeautifulSoup, element: Any) -> str:
@@ -104,7 +193,7 @@ def serialize_dom(html: str, *, url: str, title: str = "") -> dict:
     saved HTML fixtures without ever touching a live employer site.
     """
     soup = BeautifulSoup(html or "", "html.parser")
-    captcha = _detect_captcha(soup, html or "")
+    captcha = _detect_captcha(soup)
     _clean(soup)
 
     if not title:

--- a/backend/tests/unit/runner/test_captcha_detection.py
+++ b/backend/tests/unit/runner/test_captcha_detection.py
@@ -1,0 +1,103 @@
+"""Captcha detection must fire on a real challenge and only on a real challenge.
+
+The regression these guard: an earlier detector substring-searched the whole page
+source for "recaptcha"/"turnstile". Greenhouse ships a
+GOOGLE_RECAPTCHA_INVISIBLE_KEY inside a JS config blob on every job page, so
+every Greenhouse posting escalated immediately and auto-apply was dead on the
+most common ATS. Verified against a live Cloudflare/Greenhouse page 2026-08-30.
+"""
+
+from hiresense.runner import serialize_dom
+
+
+def _detect(body: str) -> bool:
+    return serialize_dom(f"<html><body>{body}</body></html>", url="https://x.test")[
+        "captcha_detected"
+    ]
+
+
+# --- must NOT fire -------------------------------------------------------
+
+
+def test_greenhouse_invisible_recaptcha_config_blob_is_not_a_challenge():
+    body = (
+        '<script>window.CONFIG = {"DROPBOX_CHOOSER_API_KEY":"abc",'
+        '"GOOGLE_RECAPTCHA_INVISIBLE_KEY":"6LfmcbcpAAAAAChNTbhUShzUOAMj_wY9LQIvLFX0"};'
+        "</script>"
+        '<form><input id="first_name" name="first_name" required /></form>'
+    )
+    assert _detect(body) is False
+
+
+def test_the_word_recaptcha_in_page_copy_is_not_a_challenge():
+    body = "<p>We use reCAPTCHA and Cloudflare Turnstile to protect this site.</p>"
+    assert _detect(body) is False
+
+
+def test_form_fields_survive_a_page_that_merely_mentions_recaptcha():
+    obs = serialize_dom(
+        '<html><body><script>var k="GOOGLE_RECAPTCHA_INVISIBLE_KEY";</script>'
+        '<form><label for="email">Email *</label>'
+        '<input id="email" name="email" required /></form></body></html>',
+        url="https://x.test",
+    )
+    assert obs["captcha_detected"] is False
+    assert [f["selector"] for f in obs["fields"]] == ["#email"]
+
+
+def test_invisible_widget_container_does_not_block():
+    body = '<div class="g-recaptcha" data-size="invisible" data-sitekey="k"></div>'
+    assert _detect(body) is False
+
+
+def test_greenhouse_enterprise_anchor_frame_does_not_block():
+    """The real shape observed on a live Cloudflare/Greenhouse posting.
+
+    Every reCAPTCHA-protected page carries an `anchor` badge frame. It is not a
+    challenge, and this exact URL made all four sampled Greenhouse jobs escalate
+    before the fix.
+    """
+    body = (
+        '<iframe src="https://www.recaptcha.net/recaptcha/enterprise/anchor?ar=1&k=6Lfmcbcp">'
+        "</iframe>"
+    )
+    assert _detect(body) is False
+
+
+def test_hidden_recaptcha_response_textarea_does_not_block():
+    """reCAPTCHA injects this textarea to hold its token. It is not a widget --
+    a substring match on `g-recaptcha` used to flag it on every Greenhouse form."""
+    body = '<textarea class="g-recaptcha-response" style="display:none"></textarea>'
+    assert _detect(body) is False
+
+
+def test_invisible_anchor_iframe_does_not_block():
+    body = (
+        '<iframe src="https://www.google.com/recaptcha/api2/anchor?k=abc&size=invisible"></iframe>'
+    )
+    assert _detect(body) is False
+
+
+# --- must fire -----------------------------------------------------------
+
+
+def test_visible_recaptcha_widget_blocks():
+    assert _detect('<div class="g-recaptcha" data-sitekey="k"></div>') is True
+
+
+def test_hcaptcha_widget_blocks():
+    assert _detect('<div class="h-captcha" data-sitekey="k"></div>') is True
+
+
+def test_turnstile_widget_blocks():
+    assert _detect('<div class="cf-turnstile" data-sitekey="k"></div>') is True
+
+
+def test_interactive_challenge_iframe_blocks():
+    body = '<iframe src="https://www.google.com/recaptcha/api2/bframe?k=abc"></iframe>'
+    assert _detect(body) is True
+
+
+def test_arkose_challenge_iframe_blocks():
+    body = '<iframe src="https://client-api.arkoselabs.com/fc/gc/challenge?k=x"></iframe>'
+    assert _detect(body) is True

--- a/backend/tests/unit/runner/test_css_path_selectors.py
+++ b/backend/tests/unit/runner/test_css_path_selectors.py
@@ -1,0 +1,113 @@
+"""Selector generation for elements with no id and no name.
+
+The agent types a real person's data into real employer forms using these
+selectors, so a selector that is syntactically valid but points at the WRONG
+element is worse than no selector at all: it fails silently.
+"""
+
+from bs4 import BeautifulSoup
+
+from hiresense.runner import serialize_dom
+from hiresense.runner.dom_serializer import _css_path
+
+
+def _paths(html: str, tag: str = "button") -> list[str]:
+    soup = BeautifulSoup(html, "html.parser")
+    return [_css_path(el) for el in soup.find_all(tag)]
+
+
+def test_identical_siblings_get_distinct_selectors():
+    """BeautifulSoup compares tags by VALUE, so a naive list.index() returns the
+    first structurally-equal sibling and every duplicate collapses onto one
+    selector. Duplicated submit controls (mobile + desktop variants) are common
+    in ATS markup, so this must index by identity."""
+    html = (
+        '<div id="application-form">'
+        '<div><button type="submit">Submit application</button></div>'
+        '<div><button type="submit">Submit application</button></div>'
+        "</div>"
+    )
+    paths = _paths(html)
+    assert len(paths) == 2
+    assert paths[0] != paths[1], f"identical siblings collapsed onto {paths[0]!r}"
+
+
+def test_each_generated_selector_resolves_to_its_own_element():
+    html = '<div id="form"><div><input /></div><div><input /></div><div><input /></div></div>'
+    soup = BeautifulSoup(html, "html.parser")
+    inputs = soup.find_all("input")
+    paths = [_css_path(el) for el in inputs]
+    assert len(set(paths)) == 3
+
+
+def test_path_anchors_on_the_nearest_ancestor_id():
+    html = '<div id="anchor"><section><button type="submit">Go</button></section></div>'
+    path = _paths(html)[0]
+    assert path.startswith("#anchor")
+
+
+def test_deeply_nested_control_is_not_dropped():
+    """A React-rendered ATS page can nest a control far below the nearest id.
+    Returning None here reinstates the exact bug this file exists to prevent:
+    a filled form with no reachable submit control."""
+    inner = '<button type="submit">Submit application</button>'
+    html = '<div id="root">' + "<div>" * 30 + inner + "</div>" * 30 + "</div>"
+    path = _paths(html)[0]
+    assert path is not None
+    assert path.endswith("button:nth-of-type(1)")
+
+
+def test_serializer_keeps_a_submit_button_with_no_id_or_name():
+    html = (
+        "<html><body><form>"
+        '<input id="email" name="email" required />'
+        '<button type="submit">Submit application</button>'
+        "</form></body></html>"
+    )
+    obs = serialize_dom(html, url="https://x.test")
+    submits = [f for f in obs["fields"] if f["field_type"] == "submit"]
+    assert len(submits) == 1
+    assert submits[0]["selector"]
+
+
+# --- selector escaping: ids and names are employer-controlled ---------------
+
+
+def test_id_with_css_metacharacters_is_not_emitted_raw():
+    """HTML5 permits almost any character in an id. `#a:b.c` is a valid id but
+    parses as a compound selector, so it must be quoted rather than interpolated."""
+    html = '<html><body><input id="a:b.c" required /></body></html>'
+    obs = serialize_dom(html, url="https://x.test")
+    selector = obs["fields"][0]["selector"]
+    assert selector != "#a:b.c"
+    assert "a:b.c" in selector
+
+
+def test_id_starting_with_a_digit_is_quoted():
+    html = '<html><body><input id="123abc" required /></body></html>'
+    selector = serialize_dom(html, url="https://x.test")["fields"][0]["selector"]
+    assert not selector.startswith("#1")
+
+
+def test_name_that_would_break_out_of_the_attribute_selector_is_escaped():
+    """A crafted name must not be able to close the attribute selector and
+    append a second compound that redirects the fill elsewhere.
+
+    The property that matters is that every quote inside the value is
+    backslash-escaped, so the value stays one CSS string. Metacharacters such
+    as `[` are harmless once they cannot escape the quotes.
+    """
+    html = "<html><body><input name='x\"] , [id=\"other' required /></body></html>"
+    selector = serialize_dom(html, url="https://x.test")["fields"][0]["selector"]
+
+    assert selector.startswith('input[name="')
+    assert selector.endswith('"]')
+    body = selector[len('input[name="') : -len('"]')]
+    # No unescaped quote survives inside the value.
+    assert '"' not in body.replace('\\"', "")
+
+
+def test_plain_id_still_uses_the_readable_hash_form():
+    html = '<html><body><input id="first_name" required /></body></html>'
+    selector = serialize_dom(html, url="https://x.test")["fields"][0]["selector"]
+    assert selector == "#first_name"

--- a/backend/tests/unit/runner/test_dom_serializer.py
+++ b/backend/tests/unit/runner/test_dom_serializer.py
@@ -81,9 +81,10 @@ def test_selector_prefers_id_then_name():
     assert 'input[name="last_name"]' in selectors
 
 
-def test_captcha_is_detected_from_an_iframe():
+def test_captcha_is_detected_from_a_challenge_iframe():
+    """Only the challenge frame (`bframe`) blocks; see test_captcha_detection.py."""
     html = (
-        '<html><body><iframe src="https://www.google.com/recaptcha/api2/anchor">'
+        '<html><body><iframe src="https://www.google.com/recaptcha/api2/bframe?k=x">'
         "</iframe></body></html>"
     )
     assert serialize_dom(html, url="https://x.test")["captcha_detected"] is True


### PR DESCRIPTION
Found by actually running the auto-apply agent in dry-run against four live Cloudflare/Greenhouse postings. Every one escalated **before typing a single character**. Three separate defects, none of which the fixture-based tests could catch — the fixture I hand-wrote didn't contain the things real ATS pages contain.

## 1. Phantom captcha on every Greenhouse page

The detector substring-searched the entire page source for `recaptcha`/`turnstile`. Greenhouse embeds a `GOOGLE_RECAPTCHA_INVISIBLE_KEY` in a JS config blob on **every** job page — a configuration value, not a challenge. Result: auto-apply was dead on the most common ATS.

It now looks for evidence a human is actually being asked something:
- a visible widget container (`g-recaptcha` / `h-captcha` / `cf-turnstile`), matched by **exact** class, or
- a **challenge** iframe (`bframe`), which the library injects only when it decides to present a puzzle.

Explicitly *not* blocking: the config key, the `anchor` badge frame every protected page carries, and the hidden token textarea. All three are present on a perfectly fillable form.

## 2. `g-recaptcha-response` matched the widget check

reCAPTCHA injects a hidden `<textarea class="g-recaptcha-response">` to hold its token. `'g-recaptcha' in 'g-recaptcha-response'` was true, so the substring check flagged it. Class comparison is now exact.

## 3. Submit buttons with no id or name were dropped

`_selector_for` returned `None` unless the element had an id or a name. Greenhouse's control is `<button type="submit">Submit application</button>` — neither. So the agent saw a fully filled form and **no way to submit it**, and escalated with "Every field is filled but no submit control was found."

Elements lacking both now get a positional CSS path (`#application-form > div:nth-of-type(4) > button:nth-of-type(1)`), built from the nearest ancestor with an id. Plain CSS, so the serializer stays browser-agnostic.

## Evidence from the live pages

| job | before | after |
| --- | --- | --- |
| 7695702 | captcha=True, 0 usable | captcha=False, 19 fields, 9 required, submit found |
| 8097321 | captcha=True | captcha=False, 21 fields, 12 required |
| 8144669 | captcha=True | captcha=False, 16 fields, 7 required |
| 6696709 | captcha=True | captcha=False, 17 fields, 11 required |

The generated submit selector was verified against the live DOM — `locator(...).count() == 1`.

## Test plan

- [x] `2067 passed` under CI conditions (+12 new tests).
- [x] New `tests/unit/runner/test_captcha_detection.py` encodes the real shapes observed live: the Greenhouse config blob, the enterprise `anchor` frame, and the hidden response textarea must **not** block; visible widgets and `bframe` must.
- [x] Two pre-existing tests updated — they asserted an `anchor` iframe blocks, which was the bug.
- [x] pyright, ruff clean.

Still unverified: a dry-run that actually reaches the fill-and-stop-before-submit stage. Automated form-filling on a third-party site with real PII was blocked by a permission gate, so that remains a manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYZyM5Pm4USVavcJeqjZuA